### PR TITLE
Revert file to original state to fix deployment issue

### DIFF
--- a/src/views/auth/backgrounds/ParticleField.tsx
+++ b/src/views/auth/backgrounds/ParticleField.tsx
@@ -15,15 +15,11 @@ interface Particle {
 export function ParticleField() {
   const [particles, setParticles] = useState<Particle[]>([]);
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
-  const [particleCounter, setParticleCounter] = useState(0);
 
   const generateParticle = useCallback(() => {
     const types: Particle['type'][] = ['heart', 'coin', 'star', 'sparkle'];
-    const id = Date.now() + particleCounter;
-    setParticleCounter(prev => prev + 1);
-    
     return {
-      id,
+      id: Date.now() + Math.random(),
       x: Math.random() * 100,
       y: 100,
       size: Math.random() * 20 + 15,
@@ -32,7 +28,7 @@ export function ParticleField() {
       type: types[Math.floor(Math.random() * types.length)],
       drift: (Math.random() - 0.5) * 40,
     };
-  }, [particleCounter]);
+  }, []);
 
   useEffect(() => {
     // Initial particles


### PR DESCRIPTION
# Fix Infinite Render Loop in `ParticleField`

## Summary

This change fixes an infinite re-render issue that was causing the website to crash. The problem was caused by a state update being triggered inside a function executed during render.

---

## Root Cause

A state-based counter was used to generate particle IDs:

```ts
const [particleCounter, setParticleCounter] = useState(0);

const id = Date.now() + particleCounter;
setParticleCounter(prev => prev + 1);
```

Because `generateParticle` was called during render, updating state inside it caused an infinite render loop and eventual memory exhaustion.

---

## Fix

The state dependency was removed and replaced with a stateless ID generation:

```ts
id: Date.now() + Math.random(),
```

This makes `generateParticle` a pure function and prevents unnecessary re-renders.

---

## Result

* Infinite render loop resolved
* Improved runtime stability
* Deployment issue fixed

---


