### PR TITLE
kiosks campaign counter fix

### DIFF
--- a/src/views/admin/DonationManagement.tsx
+++ b/src/views/admin/DonationManagement.tsx
@@ -482,9 +482,6 @@ export function DonationManagement({ onNavigate, onLogout, userSession, hasPermi
                               <span className="text-sm font-medium text-gray-900 block truncate" title={donation.donorName || 'Anonymous'}>
                                 {donation.donorName || 'Anonymous'}
                               </span>
-                              <p className="text-xs font-mono text-gray-400 truncate" title={donation.stripePaymentIntentId}>
-                                {donation.stripePaymentIntentId || donation.transactionId || donation.id}
-                              </p>
                             </div>
                           </TableCell>
 

--- a/src/views/admin/KioskManagement.tsx
+++ b/src/views/admin/KioskManagement.tsx
@@ -133,6 +133,9 @@ export function KioskManagement({ onNavigate, onLogout, userSession, hasPermissi
   const [showAccessCodes, setShowAccessCodes] = useState<{ [key: string]: boolean }>({});
   const [copiedIds, setCopiedIds] = useState<{ [key: string]: boolean }>({});
 
+  const normalizeAssignedCampaigns = (campaignIds?: string[]) =>
+    Array.from(new Set((campaignIds || []).filter(Boolean)));
+
   // Configuration for AdminSearchFilterHeader
   const searchFilterConfig: AdminSearchFilterConfig = {
     filters: [
@@ -172,7 +175,7 @@ export function KioskManagement({ onNavigate, onLogout, userSession, hasPermissi
     
     setNewKiosk(prev => ({
       ...prev,
-      assignedCampaigns: [...prev.assignedCampaigns, campaignId]
+      assignedCampaigns: normalizeAssignedCampaigns([...prev.assignedCampaigns, campaignId])
     }));
   };
 
@@ -188,6 +191,8 @@ export function KioskManagement({ onNavigate, onLogout, userSession, hasPermissi
     
     setIsCreatingKiosk(true);
     try {
+      const normalizedAssignedCampaigns = normalizeAssignedCampaigns(newKiosk.assignedCampaigns);
+
       if (editingKiosk) {
         const updatedKioskData = {
           ...editingKiosk,
@@ -195,7 +200,7 @@ export function KioskManagement({ onNavigate, onLogout, userSession, hasPermissi
           location: newKiosk.location,
           accessCode: newKiosk.accessCode,
           status: newKiosk.status,
-          assignedCampaigns: newKiosk.assignedCampaigns,
+          assignedCampaigns: normalizedAssignedCampaigns,
           settings: {
             ...editingKiosk.settings,
             displayMode: newKiosk.displayLayout,
@@ -206,7 +211,7 @@ export function KioskManagement({ onNavigate, onLogout, userSession, hasPermissi
         await updateDoc(kioskRef, updatedKioskData);
         
         const oldAssignedCampaigns = editingKiosk.assignedCampaigns || [];
-        await syncCampaignsForKiosk(editingKiosk.id, newKiosk.assignedCampaigns, oldAssignedCampaigns);
+        await syncCampaignsForKiosk(editingKiosk.id, normalizedAssignedCampaigns, oldAssignedCampaigns);
       } else {
         // Create new kiosk
         const newKioskData: Omit<Kiosk, 'id'> = {
@@ -215,7 +220,7 @@ export function KioskManagement({ onNavigate, onLogout, userSession, hasPermissi
           lastActive: new Date().toISOString(),
           totalDonations: 0,
           totalRaised: 0,
-          assignedCampaigns: newKiosk.assignedCampaigns,
+          assignedCampaigns: normalizedAssignedCampaigns,
           defaultCampaign: '',
           deviceInfo: {},
           operatingHours: {},
@@ -229,7 +234,7 @@ export function KioskManagement({ onNavigate, onLogout, userSession, hasPermissi
         };
         const docRef = await addDoc(collection(db, 'kiosks'), newKioskData);
         
-        await syncCampaignsForKiosk(docRef.id, newKiosk.assignedCampaigns, []);
+        await syncCampaignsForKiosk(docRef.id, normalizedAssignedCampaigns, []);
       }
       refreshKiosks();
       refreshCampaigns(); // Refresh campaigns to show updated assignments
@@ -256,7 +261,7 @@ export function KioskManagement({ onNavigate, onLogout, userSession, hasPermissi
       location: kiosk.location,
       accessCode: kiosk.accessCode || '',
       status: kiosk.status,
-      assignedCampaigns: kiosk.assignedCampaigns || [],
+      assignedCampaigns: normalizeAssignedCampaigns(kiosk.assignedCampaigns),
       displayLayout: (kiosk.settings?.displayMode as 'grid' | 'list' | 'carousel') || 'grid'
     });
     setIsCreateDialogOpen(true);

--- a/src/views/admin/components/KioskForm.tsx
+++ b/src/views/admin/components/KioskForm.tsx
@@ -91,6 +91,23 @@ export function KioskForm({
     { id: 'display', label: 'DISPLAY' }
   ];
 
+  const assignedCampaignIds = useMemo(
+    () => Array.from(new Set((kioskData.assignedCampaigns || []).filter(Boolean))),
+    [kioskData.assignedCampaigns]
+  );
+
+  const assignedCampaigns = useMemo(
+    () => assignedCampaignIds
+      .map((campaignId) => campaigns.find((campaign) => campaign.id === campaignId))
+      .filter((campaign): campaign is Campaign => Boolean(campaign)),
+    [assignedCampaignIds, campaigns]
+  );
+
+  const unassignedCampaigns = useMemo(
+    () => campaigns.filter((campaign) => !assignedCampaignIds.includes(campaign.id)),
+    [campaigns, assignedCampaignIds]
+  );
+
   // IntersectionObserver for scroll-synced sidebar highlighting
   useEffect(() => {
     if (!open) return;
@@ -402,12 +419,12 @@ export function KioskForm({
                       </div>
                       <h3 className="text-base sm:text-lg font-medium text-gray-900">Assigned Campaigns</h3>
                       <Badge variant="secondary" className="bg-gray-100 text-gray-600 text-xs">
-                        {kioskData.assignedCampaigns.length}
+                        {assignedCampaigns.length}
                       </Badge>
                     </div>
                     
                     <div className="max-h-64 sm:max-h-80 overflow-y-auto">
-                      {kioskData.assignedCampaigns.length === 0 ? (
+                      {assignedCampaigns.length === 0 ? (
                         <div className="border-2 border-dashed border-gray-200 rounded-lg p-6 sm:p-8 text-center">
                           <button
                             onClick={() => {
@@ -429,10 +446,7 @@ export function KioskForm({
                         </div>
                       ) : (
                         <div className="space-y-3">
-                          {kioskData.assignedCampaigns.map(campaignId => {
-                            const campaign = campaigns.find(c => c.id === campaignId);
-                            if (!campaign) return null;
-                            
+                          {assignedCampaigns.map(campaign => {
                             const fundingPercentage = Math.round((campaign.raised / campaign.goal) * 100);
                             
                             return (
@@ -495,15 +509,13 @@ export function KioskForm({
                       <Plus className="w-5 h-5 text-gray-400" />
                       <h3 className="text-base sm:text-lg font-medium text-gray-900">Available Campaigns</h3>
                       <Badge variant="secondary" className="bg-gray-100 text-gray-600 text-xs">
-                        {campaigns.filter(c => !kioskData.assignedCampaigns.includes(c.id)).length}
+                        {unassignedCampaigns.length}
                       </Badge>
                     </div>
                     
                     <div className="max-h-64 sm:max-h-80 overflow-y-auto">
                       <div className="space-y-3">
-                        {campaigns
-                          .filter(campaign => !kioskData.assignedCampaigns.includes(campaign.id))
-                          .map(campaign => {
+                        {unassignedCampaigns.map(campaign => {
                             const fundingPercentage = Math.round((campaign.raised / campaign.goal) * 100);
                             
                             return (
@@ -557,7 +569,7 @@ export function KioskForm({
                             );
                           })}
                         
-                        {campaigns.filter(c => !kioskData.assignedCampaigns.includes(c.id)).length === 0 && (
+                        {unassignedCampaigns.length === 0 && (
                           <div className="text-center py-6 sm:py-8 text-gray-500">
                             <p className="text-sm sm:text-base">All available campaigns have been assigned to this kiosk.</p>
                           </div>


### PR DESCRIPTION
Removed transaction ID under donor name in donation table


Edited [DonationManagement.tsx] to show only donor name in that column.

KioskManagement + KioskForm: normalized assigned campaign IDs (dedupe + valid mapping) so “Assigned Campaigns” list/count doesn’t show wrong/duplicate data.

<img width="1919" height="866" alt="Screenshot 2026-02-07 181948" src="https://github.com/user-attachments/assets/f8273072-eea4-4960-80bc-0e42e9c60c7a" />

<img width="1247" height="770" alt="Screenshot 2026-02-07 182008" src="https://github.com/user-attachments/assets/1a28656d-1f3f-4903-8f8a-eb01111a21f3" />
