### PR TITLE
refactor(campaign-status): remove auto status transitions for goal/end-date and preserve manual control

### DIFF
--- a/src/shared/lib/campaignStatusEngine.ts
+++ b/src/shared/lib/campaignStatusEngine.ts
@@ -87,50 +87,9 @@ function reconcileCampaignStatus(
   now: Date
 ): CampaignStatusResolution {
   const status = campaign.status;
-  const goal = Number(campaign.goal) || 0;
-  const raisedMinor = Number(campaign.raised) || 0;
-  const raisedMajor = raisedMinor / 100;
-  const autoCompletedGoal = Number(campaign.autoCompletedGoal);
-  const alreadyAutoCompletedForThisGoal =
-    Number.isFinite(autoCompletedGoal) && autoCompletedGoal === goal;
-
-  if (goal > 0 && raisedMajor >= goal && !alreadyAutoCompletedForThisGoal) {
-    return {
-      status: 'completed',
-      updates: {
-        status: 'completed',
-        autoCompletedGoal: goal,
-        autoCompletedAt: now.toISOString(),
-      },
-    };
-  }
 
   if (status === 'completed') {
     return { status: 'completed' };
-  }
-
-  const endDate = parseCampaignDate(campaign.endDate);
-  if (endDate && endOfDay(endDate) < now) {
-    const endDateKey = endDate.toISOString();
-    const alreadyAutoPausedForThisEndDate =
-      campaign.autoPausedEndDate === endDateKey;
-
-    if (status !== 'paused' && !alreadyAutoPausedForThisEndDate) {
-      return {
-        status: 'paused',
-        updates: {
-          status: 'paused',
-          autoPausedEndDate: endDateKey,
-          autoPausedEndDateAt: now.toISOString(),
-        },
-      };
-    }
-
-    if (status === 'paused') {
-      return { status: 'paused' };
-    }
-
-    return { status: status === 'active' ? 'active' : 'paused' };
   }
 
   const startDate = parseCampaignDate(campaign.startDate);


### PR DESCRIPTION
## Description
Refactors campaign status handling to remove automatic status transitions based
on goal completion and end-date expiry, ensuring manual status control is always
respected during reconciliation. The only automatic guard retained is for
future start dates, which resolve campaigns to paused without auto-activating
them later. Kiosk visibility rules remain unchanged (only active campaigns are
shown).

---

## Summary
- Prevents automatic overrides of campaign status during reconciliation
- Preserves manual-first status control for admins/users
- Retains future start-date guard without auto-activation
- Keeps kiosk visibility behaviour unchanged
---
## Video



https://github.com/user-attachments/assets/b7650820-1388-4a3d-a5b1-b45321be0382


---

## Changes

### Removed Auto Status Transitions
- Removed auto-completion when raised amount reaches/exceeds goal
- Removed auto-pause when campaign end date has passed

---

### Manual-First Status Behaviour
- Status now remains whatever is set manually by admin/user
- Reconciliation no longer overrides manual status due to goal/end-date checks

---

### Start-Date Guard (Retained)
- Campaign with a future start date resolves to paused
- Campaign does not auto-switch to active when the start date arrives
- Manual activation is required after start date

---

### Kiosk Visibility (Unchanged)
- Only campaigns with status = active appear in kiosk donation flow
- Paused/completed campaigns remain hidden from kiosk

---

## Files Changed
- campaignStatusEngine.ts

---

## Impact
- Campaign status is no longer auto-updated by:
  - Goal reached
  - End date passed
- Manual status updates persist across reconciliation
- Kiosk donation flow behaviour remains consistent

---

## How to Test

### 1) Target reached should not auto-complete
- Create/open an active campaign with a goal
- Add donations until raised amount meets/exceeds the goal
- Refresh campaign list/details and kiosk campaign list  
**Expected:** Status remains manual (e.g., active)

---

### 2) End date passed should not auto-pause
- Set campaign end date to a past date
- Keep status as active
- Refresh/re-fetch campaigns  
**Expected:** Status remains manual (active unless changed by user)

---

### 3) Manual status changes still work
- Change a campaign to paused and save  
- Change it back to active and save  
**Expected:** Manual status persists and is not overridden

---

### 4) Start-date guard still applies
- Set start date to a future date and save  
- Refresh/reconcile  
**Expected:** Resolved status is paused  
- Move to/after start date and refresh  
**Expected:** Does not auto-switch to active; requires manual activation

---

### 5) Kiosk visibility unchanged
- Active campaigns appear in kiosk flow  
- Paused/completed campaigns do not appear  
**Expected:** Behaviour unchanged

---

## Acceptance Criteria Met
- [x] Auto-complete on goal reached removed
- [x] Auto-pause on end-date expiry removed
- [x] Manual status preserved during reconciliation
- [x] Start-date guard retained without auto-activation
- [x] Kiosk visibility rules unchanged
- [x] No breaking changes introduced

---

## Issue Reference
Closes #466 
