### PR TITLE
Differentiate operator and viewer default permissions

### DIFF
--- a/src/shared/config/constants.ts
+++ b/src/shared/config/constants.ts
@@ -302,8 +302,14 @@ export const DEFAULT_USER_PERMISSIONS = {
   operator: [
     'view_dashboard',
     'view_campaigns',
+    'create_campaign',
+    'edit_campaign',
     'view_kiosks',
-    'view_donations'
+    'create_kiosk',
+    'edit_kiosk',
+    'assign_campaigns',
+    'view_donations',
+    'export_donations'
   ],
   viewer: [
     'view_dashboard',


### PR DESCRIPTION
## Description
Fixes role permission mappings so Viewer, Operator, and Manager have clearly
differentiated access levels. Viewer remains strictly read-only, Operator gains
operational edit permissions, and Manager builds on Operator with additional
user-management capabilities. This removes ambiguity in role behavior and
prevents overlapping permission sets.


---

## Changes

### Viewer Role (Read-Only)
- Permissions limited to:
  - View dashboard
  - View campaigns
  - View kiosks
  - View donations

---

### Operator Role (Operational Edit Access)
- Can view core areas:
  - Dashboard
  - Campaigns
  - Kiosks
  - Donations
- Gains operational permissions:
  - Create and edit campaigns
  - Create and edit kiosks
  - Assign campaigns to kiosks
  - Export donations
---

https://github.com/user-attachments/assets/dc263ddf-5430-4390-a87c-65d0e71cd6df

---

### Manager Role (Operations + User Management)
- Inherits all Operator permissions
- Additional user management permissions:
  - View users
  - Create users
  - Edit users

---

## Impact
- Viewer is strictly read-only
- Operator is focused on day-to-day operations and edits
- Manager includes operations plus user management
- Role boundaries are now clear and non-overlapping

---

## Acceptance Criteria Met
- [x] Viewer role is read-only
- [x] Operator role has operational edit rights
- [x] Manager role extends Operator with user management
- [x] No overlapping or ambiguous permissions remain
- [x] No breaking changes introduced

---

## Issue Reference
Closes #456 
