### PR TITLE
Unify webhook donation+gift-aid persistence and add campaign title snapshots

### DIFF
--- a/backend/functions/handlers/webhooks.js
+++ b/backend/functions/handlers/webhooks.js
@@ -1,6 +1,111 @@
 const admin = require("firebase-admin");
 const {stripe, getWebhookSecrets, ensureStripeInitialized} = require("../services/stripe");
 
+const DEFAULT_GIFT_AID_DECLARATION_TEXT = "I confirm I have paid enough UK Income or Capital Gains Tax to cover all my Gift Aid donations in this tax year.";
+
+const toBoolean = (value) => value === true || value === "true" || value === "1";
+
+const toStringOrNull = (value) => {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
+const parseIsoDate = (value) => {
+  const normalized = toStringOrNull(value);
+  if (!normalized) return null;
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+};
+
+const getDonationDateFromPaymentIntent = (paymentIntent, metadata) => {
+  const metadataDonationDate = parseIsoDate(metadata.giftAidDonationDate);
+  if (metadataDonationDate) return metadataDonationDate;
+  if (typeof paymentIntent.created === "number") {
+    return new Date(paymentIntent.created * 1000).toISOString();
+  }
+  return new Date().toISOString();
+};
+
+const getTaxYear = (dateValue) => {
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  const startYear = month >= 3 ? year : year - 1;
+  const endYearShort = String((startYear + 1) % 100).padStart(2, "0");
+  return `${startYear}-${endYearShort}`;
+};
+
+const createGiftAidDeclarationIfNeeded = async ({
+  paymentIntent,
+  metadata,
+  campaignId,
+  campaignTitleSnapshot,
+  organizationId,
+}) => {
+  const isGiftAid = toBoolean(metadata.isGiftAid);
+  if (!isGiftAid) return;
+
+  const donationId = paymentIntent.id;
+  const giftAidRef = admin.firestore().collection("giftAidDeclarations").doc(donationId);
+  const existingGiftAid = await giftAidRef.get();
+
+  if (existingGiftAid.exists) {
+    return;
+  }
+
+  const donorFirstName = toStringOrNull(metadata.giftAidFirstName);
+  const donorSurname = toStringOrNull(metadata.giftAidSurname);
+  const donorName = toStringOrNull(metadata.donorName);
+  const parsedNames = donorName ? donorName.split(" ").filter(Boolean) : [];
+  const fallbackFirstName = parsedNames[0] || "Anonymous";
+  const fallbackSurname = parsedNames.slice(1).join(" ") || "Donor";
+
+  const donationDate = getDonationDateFromPaymentIntent(paymentIntent, metadata);
+  const declarationDate = parseIsoDate(metadata.giftAidDeclarationDate) || donationDate;
+  const now = new Date().toISOString();
+  const resolvedOrganizationId =
+    toStringOrNull(organizationId) ||
+    toStringOrNull(metadata.giftAidOrganizationId) ||
+    toStringOrNull(metadata.organizationId) ||
+    null;
+
+  const giftAidData = {
+    id: donationId,
+    donationId,
+    donorFirstName: donorFirstName || fallbackFirstName,
+    donorSurname: donorSurname || fallbackSurname,
+    donorHouseNumber: toStringOrNull(metadata.giftAidHouseNumber) || "",
+    donorAddressLine1: toStringOrNull(metadata.giftAidAddressLine1) || "",
+    donorAddressLine2: toStringOrNull(metadata.giftAidAddressLine2) || "",
+    donorTown: toStringOrNull(metadata.giftAidTown) || "",
+    donorPostcode: toStringOrNull(metadata.giftAidPostcode) || "",
+    declarationText:
+      toStringOrNull(metadata.giftAidDeclarationText) ||
+      DEFAULT_GIFT_AID_DECLARATION_TEXT,
+    declarationDate,
+    ukTaxpayerConfirmation: toBoolean(metadata.giftAidTaxpayer),
+    donationAmount: paymentIntent.amount,
+    giftAidAmount: Math.round(paymentIntent.amount * 0.25),
+    campaignId: campaignId || null,
+    campaignTitle: campaignTitleSnapshot || "Deleted Campaign",
+    organizationId: resolvedOrganizationId,
+    donationDate,
+    taxYear:
+      toStringOrNull(metadata.giftAidTaxYear) ||
+      getTaxYear(donationDate) ||
+      "unknown",
+    giftAidStatus: "pending",
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await giftAidRef.set(giftAidData);
+};
+
 /**
  * Handle Stripe account.updated webhook
  * @param {object} req - Express request object
@@ -90,42 +195,79 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
 
   if (event.type === "payment_intent.succeeded") {
     const paymentIntent = event.data.object;
+    const metadata = paymentIntent.metadata || {};
+    const campaignId = toStringOrNull(metadata.campaignId);
+    let organizationId = toStringOrNull(metadata.organizationId);
+    let campaignTitleSnapshot = toStringOrNull(metadata.campaignTitle) || "Deleted Campaign";
+    let campaignExists = false;
+
+    if (campaignId) {
+      const campaignRef = admin.firestore().collection("campaigns").doc(campaignId);
+      const campaignSnap = await campaignRef.get();
+
+      if (campaignSnap.exists) {
+        campaignExists = true;
+        const campaignData = campaignSnap.data() || {};
+        campaignTitleSnapshot =
+          toStringOrNull(campaignData.title) || campaignTitleSnapshot;
+        organizationId =
+          toStringOrNull(campaignData.organizationId) || organizationId;
+      } else {
+        console.warn("Campaign not found for payment intent:", paymentIntent.id, campaignId);
+      }
+    }
 
     // Check if donation already exists (idempotency)
     const donationRef = admin.firestore().collection("donations").doc(paymentIntent.id);
     const existingDonation = await donationRef.get();
     
     if (existingDonation.exists) {
-      console.log("Webhook retry ignored - donation already exists:", paymentIntent.id);
+      await createGiftAidDeclarationIfNeeded({
+        paymentIntent,
+        metadata,
+        campaignId,
+        campaignTitleSnapshot,
+        organizationId,
+      });
+      console.log("Webhook retry handled - donation already exists:", paymentIntent.id);
       res.status(200).send("OK");
       return;
     }
 
     const donationData = {
-      campaignId: paymentIntent.metadata.campaignId || null,
+      campaignId: campaignId || null,
+      campaignTitleSnapshot,
       amount: paymentIntent.amount,
       currency: paymentIntent.currency,
-      donorName: paymentIntent.metadata.donorName || "Anonymous",
-      donorEmail: paymentIntent.metadata.donorEmail || null,
-      donorPhone: paymentIntent.metadata.donorPhone || null,
-      donorMessage: paymentIntent.metadata.donorMessage || null,
-      isAnonymous: paymentIntent.metadata.isAnonymous === "true",
-      isGiftAid: paymentIntent.metadata.isGiftAid === "true",
-      isRecurring: paymentIntent.metadata.isRecurring === "true",
-      recurringInterval: paymentIntent.metadata.recurringInterval || null,
-      kioskId: paymentIntent.metadata.kioskId || null,
+      donorName: toStringOrNull(metadata.donorName) || "Anonymous",
+      donorEmail: toStringOrNull(metadata.donorEmail),
+      donorPhone: toStringOrNull(metadata.donorPhone),
+      donorMessage: toStringOrNull(metadata.donorMessage),
+      isAnonymous: toBoolean(metadata.isAnonymous),
+      isGiftAid: toBoolean(metadata.isGiftAid),
+      isRecurring: toBoolean(metadata.isRecurring),
+      recurringInterval: toStringOrNull(metadata.recurringInterval),
+      kioskId: toStringOrNull(metadata.kioskId),
       transactionId: paymentIntent.id,
       timestamp: admin.firestore.Timestamp.now(),
-      platform: paymentIntent.metadata.platform || "unknown",
-      organizationId: paymentIntent.metadata.organizationId || null,
+      platform: toStringOrNull(metadata.platform) || "unknown",
+      organizationId: organizationId || null,
       paymentStatus: "success",
+      source: "stripe_webhook",
     };
 
     await donationRef.set(donationData);
     console.log("Donation stored for:", paymentIntent.id);
 
-    const campaignId = paymentIntent.metadata.campaignId;
-    if (campaignId) {
+    await createGiftAidDeclarationIfNeeded({
+      paymentIntent,
+      metadata,
+      campaignId,
+      campaignTitleSnapshot,
+      organizationId,
+    });
+
+    if (campaignId && campaignExists) {
       const campaignRef = admin
           .firestore()
           .collection("campaigns")

--- a/src/views/admin/DonationManagement.tsx
+++ b/src/views/admin/DonationManagement.tsx
@@ -52,6 +52,8 @@ interface FetchedDonation extends Omit<Donation, 'timestamp'> {
   id: string;
   amount: number;
   campaignId: string;
+  campaignTitleSnapshot?: string;
+  campaignTitle?: string;
   currency: string;
   donorId: string;
   donorName: string;
@@ -158,8 +160,20 @@ export function DonationManagement({ onNavigate, onLogout, userSession, hasPermi
     }, {} as Record<string, Kiosk>);
   }, [kiosks]);
 
-  const getCampaignDisplayName = (campaignId: string) =>
-    campaignMap[campaignId] || 'Unknown Campaign';
+  const getCampaignDisplayName = (donation: FetchedDonation) => {
+    const snapshotTitle =
+      (donation.campaignTitleSnapshot || donation.campaignTitle || '').trim();
+
+    if (snapshotTitle) {
+      return snapshotTitle;
+    }
+
+    if (donation.campaignId && campaignMap[donation.campaignId]) {
+      return campaignMap[donation.campaignId];
+    }
+
+    return 'Deleted Campaign';
+  };
 
   // Configuration for AdminSearchFilterHeader
   const searchFilterConfig: AdminSearchFilterConfig = {
@@ -211,7 +225,7 @@ export function DonationManagement({ onNavigate, onLogout, userSession, hasPermi
 
   // Filter donations first
   const filteredDonationsData = donations.filter(donation => {
-    const campaignName = campaignMap[donation.campaignId] || '';
+    const campaignName = getCampaignDisplayName(donation);
     const matchesSearch = (donation.donorName && donation.donorName.toLowerCase().includes(searchTerm.toLowerCase())) ||
                          (donation.stripePaymentIntentId && donation.stripePaymentIntentId.toLowerCase().includes(searchTerm.toLowerCase())) ||
                          (donation.transactionId && donation.transactionId.toLowerCase().includes(searchTerm.toLowerCase())) ||
@@ -516,8 +530,8 @@ export function DonationManagement({ onNavigate, onLogout, userSession, hasPermi
 
                           <TableCell className="px-4 py-4 text-center align-middle">
                             <div className="flex items-center justify-center min-w-0">
-                              <p className="text-sm font-medium text-gray-900 truncate" title={getCampaignDisplayName(donation.campaignId)}>
-                                {getCampaignDisplayName(donation.campaignId)}
+                              <p className="text-sm font-medium text-gray-900 truncate" title={getCampaignDisplayName(donation)}>
+                                {getCampaignDisplayName(donation)}
                               </p>
                             </div>
                           </TableCell>
@@ -649,7 +663,7 @@ export function DonationManagement({ onNavigate, onLogout, userSession, hasPermi
                       <div className="flex justify-between items-center">
                         <div className="flex flex-col">
                           <span className="text-sm font-medium text-slate-600">
-                            {getCampaignDisplayName(donation.campaignId)}
+                            {getCampaignDisplayName(donation)}
                           </span>
                           <div className="flex gap-2 mt-1">
                             <span className="bg-indigo-50 text-indigo-700 text-[10px] px-2 py-0.5 rounded-full font-bold uppercase tracking-wide flex items-center gap-1">
@@ -740,7 +754,7 @@ export function DonationManagement({ onNavigate, onLogout, userSession, hasPermi
                 <div>
                   <Label className="text-sm font-medium text-gray-700">Campaign</Label>
                   <p className="text-sm text-gray-900 mt-1">
-                    {campaigns.find(c => c.id === selectedDonation.campaignId)?.title || "N/A"}
+                    {getCampaignDisplayName(selectedDonation)}
                   </p>
                 </div>
                 


### PR DESCRIPTION
## Description
Hardens payment and webhook handling to ensure donation and Gift Aid records are
persisted consistently and remain accurate even if campaigns are later deleted.
Adds historical campaign name snapshots to donations, canonicalizes server-side
metadata for payment flows, and aligns Donations UI fallbacks so campaign names
render reliably.

---

## Changes

### Payment Intent Creation Hardening
- Added campaign existence validation before creating payment intents
  - Returns 404 if the campaign no longer exists
- Built canonical metadata from server-side campaign/org data
- Reused canonical metadata for:
  - Customer creation
  - One-time payment intents
  - Subscription flows

---

### Webhook Persistence Improvements
- Added robust metadata parsing helpers
- On `payment_intent.succeeded`:
  - Resolves campaign and stores `campaignTitleSnapshot` on donation records
  - Stores `source: "stripe_webhook"` on donations
- Added idempotent Gift Aid declaration creation when `isGiftAid=true`
  - Uses `giftAidDeclarations/{paymentIntentId}`
- Webhook retries:
  - If donation already exists, still attempts Gift Aid declaration creation
- Campaign totals are updated only when the campaign exists

---

### Donations UI Consistency
- Implemented snapshot-first campaign name rendering:
  - `campaignTitleSnapshot` / `campaignTitle`
  - Fallback to live campaign map
  - Fallback to “Deleted Campaign”
- Applied fallback consistently across:
  - Desktop table rows
  - Mobile cards
  - Search/filter matching
  - Donation details modal

---

## Impact
- New donations retain historical campaign names even if campaigns are deleted
- Gift Aid declarations are created reliably via webhook flow
- Webhook retries are safe and idempotent
- Donations UI no longer shows “Unknown Campaign” for records with snapshots
- Server-side metadata is canonical and consistent across payment flows

---

## Acceptance Criteria Met
- [x] Campaign existence validated before creating payment intents
- [x] Canonical metadata used for all payment flows
- [x] Donation records include campaign title snapshots and source
- [x] Gift Aid declarations created idempotently from webhooks
- [x] Webhook retries remain safe and complete missing Gift Aid records
- [x] Donations UI renders campaign names reliably with fallbacks
- [x] No breaking changes introduced

---

## Deployment Notes
- Deploy backend functions:
  - handlePaymentCompletedStripeWebhook
  - createKioskPaymentIntent
- Deploy frontend for Donations UI updates

---

## Issue Reference
Closes #475 