### PR TITLE
add donation email retry and dedup to prevent email

### DIFF
--- a/backend/functions/services/email.js
+++ b/backend/functions/services/email.js
@@ -217,8 +217,29 @@ const sendDonationThankYouEmail = async ({
     `,
   });
 
+  const normalizedRecipient = String(to || "").trim().toLowerCase();
+  if (donationId && normalizedRecipient) {
+    const existingSend = await admin
+        .firestore()
+        .collection("emailEvents")
+        .where("eventType", "==", "donation_thank_you")
+        .where("status", "==", "success")
+        .where("donationId", "==", donationId)
+        .where("recipient", "==", normalizedRecipient)
+        .limit(1)
+        .get();
+
+    if (!existingSend.empty) {
+      return {
+        statusCode: 200,
+        messageId: null,
+        deduplicated: true,
+      };
+    }
+  }
+
   return sendEmail({
-    to,
+    to: normalizedRecipient || to,
     subject,
     text: textLines.join("\n"),
     html,


### PR DESCRIPTION
## Summary
This PR fixes inconsistent donation receipt email behavior after payment by addressing two backend issues:

1. Race condition between payment completion and donation document availability.
2. Duplicate donation receipt sends caused by retries/re-clicks.

## Changes
### backend/functions/handlers/email.js
- Added `getDonationWithRetry(transactionId, attempts, delayMs)` to retry donation lookup before failing.
- Updated donation receipt handler to use retry lookup.
- Replaced immediate `404 Donation not found` with `409 Donation is still processing. Please retry in a few seconds.` when donation is not yet available.

### backend/functions/services/email.js
- Added donation receipt deduplication check against `emailEvents`:
  - `eventType = donation_thank_you`
  - `status = success`
  - same `donationId`
  - same recipient
- If a matching success event exists, return a deduplicated response and skip another SendGrid send.
- Normalized recipient email for dedup consistency.

## Why
Users reported:
- receipt emails arriving late or out of order,
- sometimes only one email arriving,
- old/missed receipt emails appearing later.

The main causes were webhook timing and repeated send attempts.

## Impact
- Donation receipts are more reliable immediately after payment.
- Duplicate donation receipts are prevented for the same transaction/email pair.
- Reduced confusion from delayed retry behavior.

## Verification
- `node --check backend/functions/handlers/email.js`
- `node --check backend/functions/services/email.js`

## Deploy Notes
Deploy functions after merge:
```bash
cd backend
firebase deploy --only functions
