### PR TITLE
feat(donation-flow): persist donor name and email across payment redirect

### DIFF
--- a/app/campaign/[campaignId]/page.tsx
+++ b/app/campaign/[campaignId]/page.tsx
@@ -201,6 +201,7 @@ export default function CampaignPage({
         amount={initialAmount || 0}
         isCustomAmount={isCustomAmount || !initialAmount}
         currency={currentKioskSession?.organizationCurrency || 'GBP'}
+        initialDonorName={sessionStorage.getItem('donorName') || ''}
         onAcceptGiftAid={handleAcceptGiftAid}
         onDeclineGiftAid={handleDeclineGiftAid}
         onBack={handleBackFromGiftAid}

--- a/app/email-confirmation/page.tsx
+++ b/app/email-confirmation/page.tsx
@@ -13,8 +13,14 @@ function EmailConfirmationContent() {
   const [transactionId, setTransactionId] = useState<string | null>(null)
   const [receiptReferenceId, setReceiptReferenceId] = useState<string | null>(null)
   const [campaignTitle, setCampaignTitle] = useState<string>('')
+  const [donorEmail, setDonorEmail] = useState<string>('')
 
   useEffect(() => {
+    // Restore persisted donor email (survives payment redirect)
+    const storedEmail = sessionStorage.getItem('donorEmail')
+    if (storedEmail) {
+      setDonorEmail(storedEmail)
+    }
     // Get transaction ID from URL params or sessionStorage
     if (searchParams) {
       const urlTransactionId = searchParams.get('transactionId')
@@ -49,6 +55,8 @@ function EmailConfirmationContent() {
     // Clear stored data
     sessionStorage.removeItem('donation')
     sessionStorage.removeItem('paymentResult')
+    sessionStorage.removeItem('donorEmail')
+    sessionStorage.removeItem('donorName')
     
     if (userRole === 'admin' || userRole === 'super_admin' || userRole === 'manager' || userRole === 'operator' || userRole === 'viewer') {
       router.push('/admin')
@@ -68,6 +76,7 @@ function EmailConfirmationContent() {
       transactionId={transactionId}
       receiptReferenceId={receiptReferenceId || undefined}
       campaignName={campaignTitle || undefined}
+      initialEmail={donorEmail}
       onComplete={handleComplete}
     />
   )

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -50,6 +50,8 @@ function ResultContent() {
     // Clear stored data
     sessionStorage.removeItem('donation')
     sessionStorage.removeItem('paymentResult')
+    sessionStorage.removeItem('donorEmail')
+    sessionStorage.removeItem('donorName')
     
     if (userRole === 'admin' || userRole === 'super_admin' || userRole === 'manager' || userRole === 'operator' || userRole === 'viewer') {
       router.push('/admin')

--- a/src/features/kiosk-gift-aid/components/GiftAidDetailsPanel.tsx
+++ b/src/features/kiosk-gift-aid/components/GiftAidDetailsPanel.tsx
@@ -9,6 +9,7 @@ interface GiftAidDetailsPanelProps {
   currency: string;
   campaignTitle: string;
   organizationId: string;
+  initialFullName?: string;
   onSubmit: (details: GiftAidDetails) => void;
   onBack: () => void;
 }
@@ -18,9 +19,10 @@ export const GiftAidDetailsPanel: React.FC<GiftAidDetailsPanelProps> = ({
   currency,
   campaignTitle,
   organizationId,
+  initialFullName = '',
   onSubmit,
 }) => {
-  const [fullName, setFullName] = useState('');
+  const [fullName, setFullName] = useState(initialFullName);
   const [houseNumber, setHouseNumber] = useState('');
   const [addressLine1, setAddressLine1] = useState('');
   const [addressLine2, setAddressLine2] = useState('');

--- a/src/features/kiosk-gift-aid/pages/GiftAidPage.tsx
+++ b/src/features/kiosk-gift-aid/pages/GiftAidPage.tsx
@@ -9,6 +9,7 @@ interface GiftAidPageProps {
   amount: number;
   isCustomAmount: boolean;
   currency: string;
+  initialDonorName?: string;
   onAcceptGiftAid: (details: GiftAidDetails) => void;
   onDeclineGiftAid: (amount: number) => void;
   onBack: () => void;
@@ -19,6 +20,7 @@ export const GiftAidPage: React.FC<GiftAidPageProps> = ({
   amount,
   isCustomAmount,
   currency,
+  initialDonorName = '',
   onAcceptGiftAid,
   onDeclineGiftAid,
   onBack,
@@ -98,6 +100,7 @@ export const GiftAidPage: React.FC<GiftAidPageProps> = ({
                   currency={currency}
                   campaignTitle={campaign.title}
                   organizationId={campaign.organizationId || ''}
+                  initialFullName={initialDonorName}
                   onSubmit={handleDetailsSubmit}
                   onBack={handleBackFromDetails}
                 />

--- a/src/views/campaigns/EmailConfirmationScreen.tsx
+++ b/src/views/campaigns/EmailConfirmationScreen.tsx
@@ -6,6 +6,7 @@ interface EmailConfirmationScreenProps {
   transactionId?: string;
   receiptReferenceId?: string;
   campaignName?: string;
+  initialEmail?: string;
   onComplete: () => void;
 }
 
@@ -13,9 +14,10 @@ export function EmailConfirmationScreen({
   transactionId,
   receiptReferenceId,
   campaignName,
+  initialEmail = '',
   onComplete,
 }: EmailConfirmationScreenProps) {
-  const [email, setEmail] = useState('');
+  const [email, setEmail] = useState(initialEmail);
   const [isSending, setIsSending] = useState(false);
   const [emailSent, setEmailSent] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Introduction

During the kiosk donation flow, users enter their name and email before being redirected to a payment provider. On return, these fields were blank — forcing users to re-enter their details. This PR uses `sessionStorage` to persist `donorName` and `donorEmail` across the redirect, restoring them automatically when the user lands back on the confirmation or result screen.

- Closes #515 
---

## Changes

### Before
- The **Full Name** field on the Gift Aid details panel always started empty, even if the donor had already entered their name earlier in the flow.
- The **Email** field on the email confirmation screen was always empty after returning from the payment redirect.
- Users had to re-type their details after completing payment.

### After
- `donorName` is read from `sessionStorage` and passed as `initialDonorName` → `initialFullName` into the Gift Aid form, pre-filling the name field.
- `donorEmail` is read from `sessionStorage` on the email confirmation page and pre-fills the email input.
- Both `donorName` and `donorEmail` are cleaned up from `sessionStorage` after the flow completes (on both `/result` and `/email-confirmation` pages).

### Files changed
| File | Change |
|---|---|
| `app/campaign/[campaignId]/page.tsx` | Reads `donorName` from sessionStorage and passes as `initialDonorName` prop |
| `app/email-confirmation/page.tsx` | Reads `donorEmail` from sessionStorage; cleans up both keys on completion |
| `app/result/page.tsx` | Cleans up `donorEmail` and `donorName` from sessionStorage on completion |
| `src/features/kiosk-gift-aid/pages/GiftAidPage.tsx` | Accepts and forwards `initialDonorName` prop |
| `src/features/kiosk-gift-aid/components/GiftAidDetailsPanel.tsx` | Accepts `initialFullName` prop; initialises `fullName` state with it |
| `src/views/campaigns/EmailConfirmationScreen.tsx` | Accepts `initialEmail` prop; initialises `email` state with it |

---

## Test Cases

| # | Scenario | Expected Result |
|---|---|---|
| 1 | Donor enters name, proceeds to Gift Aid form | Full Name field is pre-filled with the stored name |
| 2 | Donor completes payment and lands on email confirmation | Email field is pre-filled with the stored email |
| 3 | Donor completes payment and lands on result page | `donorEmail` and `donorName` are removed from sessionStorage |
| 4 | Donor completes flow on email confirmation page | `donorEmail` and `donorName` are removed from sessionStorage |
| 5 | No name/email in sessionStorage (fresh session) | Fields default to empty string — no regression |
| 6 | Admin/operator completes a donation flow | Redirect to `/admin` works correctly; storage cleaned up as before |

---

## Additional Notes

- ✅ **No breaking changes** — all new props (`initialDonorName`, `initialFullName`, `initialEmail`) are optional with empty-string defaults, so existing usages are unaffected.
- ✅ **Self review done** — diff reviewed, no debug code, no unintended side-effects.
- sessionStorage is used (not localStorage) so data is tab-scoped and automatically cleared when the browser tab is closed.