### PR TITLE
Move campaign export to server side

### DIFF
--- a/backend/functions/handlers/campaignsExport.js
+++ b/backend/functions/handlers/campaignsExport.js
@@ -1,0 +1,146 @@
+const admin = require('firebase-admin');
+const cors = require('../middleware/cors');
+const { verifyAuth } = require('../middleware/auth');
+
+const isSystemAdmin = (callerData) => {
+  const permissions = Array.isArray(callerData?.permissions) ? callerData.permissions : [];
+  return permissions.includes('system_admin');
+};
+
+const hasCampaignExportPermission = (callerData) => {
+  const permissions = Array.isArray(callerData?.permissions) ? callerData.permissions : [];
+  return permissions.includes('view_campaigns') || permissions.includes('system_admin');
+};
+
+const getCallerProfile = async (uid) => {
+  const callerDoc = await admin.firestore().collection('users').doc(uid).get();
+  if (!callerDoc.exists) {
+    const error = new Error('Caller is not a valid user');
+    error.code = 403;
+    throw error;
+  }
+
+  return callerDoc.data() || {};
+};
+
+const ensureCampaignExportAccess = async (auth, requestedOrganizationId) => {
+  const callerData = await getCallerProfile(auth.uid);
+  const callerOrganizationId =
+    typeof callerData.organizationId === 'string' ? callerData.organizationId.trim() : '';
+
+  if (!hasCampaignExportPermission(callerData)) {
+    const error = new Error('You do not have permission to export campaigns');
+    error.code = 403;
+    throw error;
+  }
+
+  if (!requestedOrganizationId) {
+    const error = new Error('organizationId is required');
+    error.code = 400;
+    throw error;
+  }
+
+  if (!isSystemAdmin(callerData) && callerOrganizationId !== requestedOrganizationId) {
+    const error = new Error('You can only export campaigns for your organization');
+    error.code = 403;
+    throw error;
+  }
+};
+
+const sanitizeSpreadsheetFormula = (value) => {
+  if (typeof value !== 'string') return value;
+  if (/^[\t\r\n ]*[=+\-@]/.test(value)) {
+    return `'${value}`;
+  }
+  return value;
+};
+
+const serializeValue = (value) => {
+  if (value === undefined || value === null) return '';
+  if (typeof value.toDate === 'function') {
+    return value.toDate().toISOString();
+  }
+  if (typeof value?.seconds === 'number') {
+    return new Date(value.seconds * 1000).toISOString();
+  }
+  if (Array.isArray(value) || (value && typeof value === 'object')) {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+};
+
+const escapeCsvValue = (value) => {
+  const stringValue = String(sanitizeSpreadsheetFormula(serializeValue(value)));
+  if (
+    stringValue.includes('"') ||
+    stringValue.includes(',') ||
+    stringValue.includes('\n') ||
+    stringValue.includes('\r')
+  ) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+};
+
+const buildCsv = (rows, headers) => {
+  return [headers, ...rows].map((row) => row.map(escapeCsvValue).join(',')).join('\n');
+};
+
+const buildTimestampToken = (date) => {
+  const pad = (value) => String(value).padStart(2, '0');
+  const year = date.getUTCFullYear();
+  const month = pad(date.getUTCMonth() + 1);
+  const day = pad(date.getUTCDate());
+  const hours = pad(date.getUTCHours());
+  const minutes = pad(date.getUTCMinutes());
+  const seconds = pad(date.getUTCSeconds());
+  return `${year}${month}${day}-${hours}${minutes}${seconds}Z`;
+};
+
+const exportCampaigns = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return res.status(405).send({ error: 'Method not allowed' });
+      }
+
+      const auth = await verifyAuth(req);
+      const organizationId =
+        typeof req.body?.organizationId === 'string' ? req.body.organizationId.trim() : '';
+      await ensureCampaignExportAccess(auth, organizationId);
+
+      const snapshot = await admin
+        .firestore()
+        .collection('campaigns')
+        .where('organizationId', '==', organizationId)
+        .get();
+
+      const campaigns = snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
+      const headers = campaigns.length > 0 ? Object.keys(campaigns[0]) : ['id'];
+      const rows = campaigns.map((campaign) => headers.map((header) => campaign[header]));
+      const csvContent = buildCsv(rows, headers);
+
+      const timestampToken = buildTimestampToken(new Date());
+      const fileName = `campaigns-${organizationId}-${timestampToken}.csv`;
+
+      res.set('Content-Type', 'text/csv; charset=utf-8');
+      res.set('Content-Disposition', `attachment; filename="${fileName}"`);
+      res.set('Cache-Control', 'private, no-store, max-age=0');
+      return res.status(200).send(csvContent);
+    } catch (error) {
+      console.error('Error exporting campaigns:', error);
+      const statusCode = Number.isInteger(error.code) ? error.code : 500;
+      return res.status(statusCode).send({
+        error: error.message || 'Failed to export campaigns',
+      });
+    }
+  });
+};
+
+module.exports = {
+  exportCampaigns,
+};

--- a/backend/functions/handlers/campaignsExport.js
+++ b/backend/functions/handlers/campaignsExport.js
@@ -111,6 +111,12 @@ const exportCampaigns = (req, res) => {
       const auth = await verifyAuth(req);
       const organizationId =
         typeof req.body?.organizationId === 'string' ? req.body.organizationId.trim() : '';
+      const requestedCampaignIds = Array.isArray(req.body?.campaignIds)
+        ? req.body.campaignIds
+            .filter((value) => typeof value === 'string')
+            .map((value) => value.trim())
+            .filter((value) => Boolean(value))
+        : null;
       await ensureCampaignExportAccess(auth, organizationId);
 
       const snapshot = await admin
@@ -119,7 +125,24 @@ const exportCampaigns = (req, res) => {
         .where('organizationId', '==', organizationId)
         .get();
 
-      const campaigns = snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
+      const requestedCampaignIdSet = requestedCampaignIds ? new Set(requestedCampaignIds) : null;
+      const requestedCampaignIndex = requestedCampaignIds
+        ? new Map(requestedCampaignIds.map((id, index) => [id, index]))
+        : null;
+      const campaigns = snapshot.docs
+        .map((doc) => ({ ...doc.data(), id: doc.id }))
+        .filter((campaign) => {
+          if (!requestedCampaignIdSet) return true;
+          return requestedCampaignIdSet.has(campaign.id);
+        });
+
+      if (requestedCampaignIndex) {
+        campaigns.sort(
+          (a, b) =>
+            (requestedCampaignIndex.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+            (requestedCampaignIndex.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+        );
+      }
       const headers = campaigns.length > 0 ? Object.keys(campaigns[0]) : ['id'];
       const rows = campaigns.map((campaign) => headers.map((header) => campaign[header]));
       const csvContent = buildCsv(rows, headers);

--- a/backend/functions/handlers/campaignsExport.js
+++ b/backend/functions/handlers/campaignsExport.js
@@ -101,6 +101,68 @@ const buildTimestampToken = (date) => {
   return `${year}${month}${day}-${hours}${minutes}${seconds}Z`;
 };
 
+const normalizeExportFilters = (rawFilters) => {
+  const filters = rawFilters && typeof rawFilters === 'object' ? rawFilters : {};
+  const searchTerm = typeof filters.searchTerm === 'string' ? filters.searchTerm.trim() : '';
+  const status = typeof filters.status === 'string' ? filters.status.trim() : 'all';
+  const category = typeof filters.category === 'string' ? filters.category.trim() : 'all';
+  const dateRange = typeof filters.dateRange === 'string' ? filters.dateRange.trim() : 'all';
+
+  return {
+    searchTerm: searchTerm.toLowerCase(),
+    status: status || 'all',
+    category: category || 'all',
+    dateRange: dateRange || 'all',
+  };
+};
+
+const getDateRangeStart = (range) => {
+  const today = new Date();
+  switch (range) {
+    case 'last30':
+      return new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
+    case 'last90':
+      return new Date(today.getTime() - 90 * 24 * 60 * 60 * 1000);
+    case 'last365':
+      return new Date(today.getTime() - 365 * 24 * 60 * 60 * 1000);
+    default:
+      return null;
+  }
+};
+
+const toDateValue = (value) => {
+  if (!value) return null;
+  if (typeof value.toDate === 'function') return value.toDate();
+  if (typeof value?.seconds === 'number') return new Date(value.seconds * 1000);
+  if (value instanceof Date) return value;
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+};
+
+const campaignMatchesFilters = (campaign, filters) => {
+  const matchesSearch =
+    !filters.searchTerm ||
+    (typeof campaign.title === 'string' &&
+      campaign.title.toLowerCase().includes(filters.searchTerm)) ||
+    (typeof campaign.description === 'string' &&
+      campaign.description.toLowerCase().includes(filters.searchTerm)) ||
+    (Array.isArray(campaign.tags) &&
+      campaign.tags.some(
+        (tag) => typeof tag === 'string' && tag.toLowerCase().includes(filters.searchTerm),
+      ));
+
+  const matchesStatus = filters.status === 'all' || campaign.status === filters.status;
+  const matchesCategory = filters.category === 'all' || campaign.category === filters.category;
+  const dateRangeStart = getDateRangeStart(filters.dateRange);
+  const campaignEndDate = toDateValue(campaign.endDate);
+  const matchesDate = !dateRangeStart || !campaignEndDate || campaignEndDate >= dateRangeStart;
+
+  return matchesSearch && matchesStatus && matchesCategory && matchesDate;
+};
+
 const exportCampaigns = (req, res) => {
   cors(req, res, async () => {
     try {
@@ -117,6 +179,7 @@ const exportCampaigns = (req, res) => {
             .map((value) => value.trim())
             .filter((value) => Boolean(value))
         : null;
+      const requestedFilters = normalizeExportFilters(req.body?.filters);
       await ensureCampaignExportAccess(auth, organizationId);
 
       const snapshot = await admin
@@ -134,7 +197,8 @@ const exportCampaigns = (req, res) => {
         .filter((campaign) => {
           if (!requestedCampaignIdSet) return true;
           return requestedCampaignIdSet.has(campaign.id);
-        });
+        })
+        .filter((campaign) => campaignMatchesFilters(campaign, requestedFilters));
 
       if (requestedCampaignIndex) {
         campaigns.sort(

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -31,6 +31,7 @@ const {
 } = require('./handlers/payments');
 const { exportGiftAidDeclarations, downloadGiftAidExportBatchFile } = require('./handlers/giftAid');
 const { exportDonations } = require('./handlers/donationsExport');
+const { exportCampaigns } = require('./handlers/campaignsExport');
 const {
   createRecurringSubscription,
   cancelRecurringSubscription,
@@ -124,6 +125,7 @@ exports.createExpressDashboardLink = functions.https.onRequest(
 exports.exportGiftAidDeclarations = functions.https.onRequest(exportGiftAidDeclarations);
 exports.downloadGiftAidExportBatchFile = functions.https.onRequest(downloadGiftAidExportBatchFile);
 exports.exportDonations = functions.https.onRequest(exportDonations);
+exports.exportCampaigns = functions.https.onRequest(exportCampaigns);
 exports.createRecurringSubscription = functions.https.onRequest(
   { secrets: [stripeSecretKey] },
   createRecurringSubscription,
@@ -137,8 +139,8 @@ exports.updateSubscriptionPaymentMethod = functions.https.onRequest(
   updateSubscriptionPaymentMethod,
 );
 exports.createConnectionToken = functions.https.onRequest(
-    {secrets: [stripeSecretKey]},
-    createConnectionToken,
+  { secrets: [stripeSecretKey] },
+  createConnectionToken,
 );
 exports.createStripeAccountForNewOrg = createStripeAccountForNewOrg;
 exports.sendWelcomeEmailForNewOrg = sendWelcomeEmailForNewOrg;

--- a/src/entities/campaign/api/campaignExportApi.ts
+++ b/src/entities/campaign/api/campaignExportApi.ts
@@ -1,0 +1,77 @@
+import { getAuth } from 'firebase/auth';
+import { FUNCTION_URLS } from '@/shared/config/functions';
+
+export interface CampaignExportRequest {
+  organizationId: string;
+}
+
+const getCurrentUserToken = async () => {
+  const auth = getAuth();
+  const token = await auth.currentUser?.getIdToken();
+
+  if (!token) {
+    throw new Error('Authentication token not found. Please log in.');
+  }
+
+  return token;
+};
+
+const parseFileName = (contentDisposition: string | null, fallbackName: string) => {
+  if (!contentDisposition) return fallbackName;
+  const match = /filename="([^"]+)"/i.exec(contentDisposition);
+  if (!match || !match[1]) return fallbackName;
+  return match[1];
+};
+
+const triggerBlobDownload = (blob: Blob, fileName: string) => {
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = objectUrl;
+  link.download = fileName;
+  link.style.visibility = 'hidden';
+  document.body.appendChild(link);
+  link.click();
+  window.setTimeout(() => {
+    document.body.removeChild(link);
+    URL.revokeObjectURL(objectUrl);
+  }, 1000);
+};
+
+export async function exportCampaigns(request: CampaignExportRequest) {
+  const token = await getCurrentUserToken();
+  const url = FUNCTION_URLS.exportCampaigns;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(request),
+    });
+  } catch {
+    throw new Error(`Could not reach campaign export function at ${url}.`);
+  }
+
+  if (!response.ok) {
+    let errorMessage = 'Failed to export campaigns.';
+    try {
+      const errorData = await response.json();
+      if (typeof errorData?.error === 'string' && errorData.error.trim()) {
+        errorMessage = errorData.error;
+      }
+    } catch {
+      const text = await response.text().catch(() => '');
+      if (text) errorMessage = text;
+    }
+    throw new Error(errorMessage);
+  }
+
+  const contentDisposition = response.headers.get('content-disposition');
+  const fallbackName = `campaigns-${new Date().toISOString().slice(0, 10)}.csv`;
+  const fileName = parseFileName(contentDisposition, fallbackName);
+  const blob = await response.blob();
+  triggerBlobDownload(blob, fileName);
+}

--- a/src/entities/campaign/api/campaignExportApi.ts
+++ b/src/entities/campaign/api/campaignExportApi.ts
@@ -4,6 +4,12 @@ import { FUNCTION_URLS } from '@/shared/config/functions';
 export interface CampaignExportRequest {
   organizationId: string;
   campaignIds?: string[];
+  filters?: {
+    searchTerm?: string;
+    status?: string;
+    category?: string;
+    dateRange?: 'all' | 'last30' | 'last90' | 'last365';
+  };
 }
 
 const getCurrentUserToken = async () => {

--- a/src/entities/campaign/api/campaignExportApi.ts
+++ b/src/entities/campaign/api/campaignExportApi.ts
@@ -3,6 +3,7 @@ import { FUNCTION_URLS } from '@/shared/config/functions';
 
 export interface CampaignExportRequest {
   organizationId: string;
+  campaignIds?: string[];
 }
 
 const getCurrentUserToken = async () => {

--- a/src/entities/campaign/api/index.ts
+++ b/src/entities/campaign/api/index.ts
@@ -1,1 +1,2 @@
 export * from './campaignApi';
+export * from './campaignExportApi';

--- a/src/shared/config/functions.ts
+++ b/src/shared/config/functions.ts
@@ -20,6 +20,7 @@ export const FUNCTION_URLS = {
   exportGiftAidDeclarations: getFunctionUrl('exportGiftAidDeclarations'),
   downloadGiftAidExportBatchFile: getFunctionUrl('downloadGiftAidExportBatchFile'),
   exportDonations: getFunctionUrl('exportDonations'),
+  exportCampaigns: getFunctionUrl('exportCampaigns'),
   kioskLogin: getFunctionUrl('kioskLogin'),
   createUser: getFunctionUrl('createUser'),
   updateUser: getFunctionUrl('updateUser'),

--- a/src/views/admin/CampaignManagement.tsx
+++ b/src/views/admin/CampaignManagement.tsx
@@ -2340,12 +2340,14 @@ const CampaignManagement = ({
 
     setIsExporting(true);
     try {
-      const visibleCampaignIds = filteredAndSortedCampaigns
-        .map((campaign) => campaign.id)
-        .filter((campaignId): campaignId is string => Boolean(campaignId));
       await exportCampaigns({
         organizationId: userSession.user.organizationId,
-        campaignIds: visibleCampaignIds,
+        filters: {
+          searchTerm,
+          status: statusFilter,
+          category: categoryFilter,
+          dateRange: dateRange as 'all' | 'last30' | 'last90' | 'last365',
+        },
       });
       showToast('Campaign export started. Your download should begin shortly.', 'success');
     } catch (exportError) {

--- a/src/views/admin/CampaignManagement.tsx
+++ b/src/views/admin/CampaignManagement.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { Screen, AdminSession, Permission, Kiosk } from '../../shared/types';
 import { DEFAULT_CAMPAIGN_CONFIG } from '../../shared/config';
@@ -24,28 +23,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../../shared/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '../../shared/ui/select';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-} from '../../shared/ui/command';
 import { Badge } from '../../shared/ui/badge';
-import { X, Check, ChevronsUpDown, Trash2, Save } from 'lucide-react';
-import {
-  FaEdit,
-  FaUpload,
-  FaImage,
-  FaTrashAlt, // Added FaTrashAlt
-} from 'react-icons/fa';
+import { X, Save } from 'lucide-react';
+import { FaEdit, FaTrashAlt } from 'react-icons/fa';
 import {
   Plus,
   RefreshCw,
@@ -58,34 +38,13 @@ import {
   Download,
   Building2,
 } from 'lucide-react';
-import { Calendar } from '../../shared/ui/calendar';
-import { Popover, PopoverContent, PopoverTrigger } from '../../shared/ui/popover';
 import { AlertTriangle } from 'lucide-react'; // Import AlertTriangle
 import { Skeleton } from '../../shared/ui/skeleton';
 import { Ghost } from 'lucide-react';
 import { ImageWithFallback } from '../../shared/ui/figma/ImageWithFallback';
-
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '../../shared/ui/alert-dialog';
 import { AdminLayout } from './AdminLayout';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../shared/ui/card';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '../../shared/ui/table';
+import { Card, CardContent } from '../../shared/ui/card';
+import { Table, TableBody, TableCell, TableHeader, TableRow } from '../../shared/ui/table';
 import { useOrganization } from '../../shared/lib/hooks/useOrganization';
 import { useStripeOnboarding, StripeOnboardingDialog } from '../../features/stripe-onboarding';
 import {
@@ -104,6 +63,7 @@ import { CampaignForm, CampaignFormData } from './components/CampaignForm';
 import { Campaign } from '../../shared/types';
 import { exportCampaigns } from '../../entities/campaign/api';
 import { useToast } from '../../shared/ui/ToastProvider';
+import type { CampaignSaveData } from '../../shared/lib/hooks/useCampaignManagement';
 
 interface CampaignDialogProps {
   open: boolean;
@@ -112,6 +72,59 @@ interface CampaignDialogProps {
   organizationId: string; // Add organizationId prop
   onSave: (data: DocumentData, isNew: boolean, campaignId?: string) => Promise<void>;
 }
+
+type CampaignDialogTab = 'basic' | 'media-gallery' | 'funding-details' | 'kiosk-distribution';
+type UnknownRecord = Record<string, unknown>;
+type TimestampLike = { seconds: number; nanoseconds?: number; toDate?: () => Date };
+
+const isTimestampLike = (value: unknown): value is TimestampLike => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'seconds' in value &&
+    typeof (value as { seconds?: unknown }).seconds === 'number'
+  );
+};
+
+const toDateInputValue = (value: unknown): string => {
+  if (!value) return '';
+
+  if (isTimestampLike(value)) {
+    return new Date(value.seconds * 1000).toISOString().split('T')[0];
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString().split('T')[0];
+  }
+
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString().split('T')[0];
+    }
+  }
+
+  return '';
+};
+
+const toDateValue = (value: unknown): Date | null => {
+  if (!value) return null;
+
+  if (isTimestampLike(value)) {
+    return new Date(value.seconds * 1000);
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  return null;
+};
 
 const getInitialFormData = () => ({
   title: '',
@@ -186,9 +199,7 @@ const CampaignDialog = ({
   onSave,
 }: CampaignDialogProps) => {
   const [formData, setFormData] = useState<DocumentData>(getInitialFormData());
-  const [activeTab, setActiveTab] = useState<
-    'basic' | 'media-gallery' | 'funding-details' | 'kiosk-distribution'
-  >('basic');
+  const [activeTab, setActiveTab] = useState<CampaignDialogTab>('basic');
   const [kiosks, setKiosks] = useState<Kiosk[]>([]);
   const [loadingKiosks, setLoadingKiosks] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -236,7 +247,7 @@ const CampaignDialog = ({
         }
       });
 
-      setActiveTab(closestSection as any);
+      setActiveTab(closestSection as CampaignDialogTab);
     };
 
     container.addEventListener('scroll', handleScroll, { passive: true });
@@ -263,7 +274,6 @@ const CampaignDialog = ({
     fetchKiosks();
   }, [open, organizationId]);
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const isEditMode = !!campaign;
 
   const {
@@ -284,18 +294,11 @@ const CampaignDialog = ({
 
   // Tags dropdown state
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
-  const [tagSearchOpen, setTagSearchOpen] = useState(false);
-  const [tagSearchValue, setTagSearchValue] = useState('');
-
   // New state for advanced image uploads
   const [selectedOrganizationLogo, setSelectedOrganizationLogo] = useState<File | null>(null);
-  const [organizationLogoPreview, setOrganizationLogoPreview] = useState<string | null>(null);
   // New state for gallery image uploads
   const [selectedGalleryImages, setSelectedGalleryImages] = useState<File[]>([]);
   const [galleryImagePreviews, setGalleryImagePreviews] = useState<string[]>([]);
-
-  // New states for specific image upload loading
-  const [isUploadingOrganizationLogo, setIsUploadingOrganizationLogo] = useState(false);
   // Loading state for the dialog submit (create/save)
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -307,12 +310,8 @@ const CampaignDialog = ({
         status: campaign.status || 'active',
         goal: campaign.goal || 0,
         tags: Array.isArray(campaign.tags) ? campaign.tags.join(', ') : '',
-        startDate: campaign.startDate?.seconds
-          ? new Date(campaign.startDate.seconds * 1000).toISOString().split('T')[0]
-          : '',
-        endDate: campaign.endDate?.seconds
-          ? new Date(campaign.endDate.seconds * 1000).toISOString().split('T')[0]
-          : '',
+        startDate: toDateInputValue(campaign.startDate),
+        endDate: toDateInputValue(campaign.endDate),
         coverImageUrl: campaign.coverImageUrl || '',
 
         // New fields for advanced settings (initial subset)
@@ -388,9 +387,6 @@ const CampaignDialog = ({
       setSelectedTags(Array.isArray(campaign.tags) ? campaign.tags : []);
       setImagePreviewUrl(campaign.coverImageUrl || null);
       // Set initial previews for advanced images
-      if (campaign.organizationInfo?.logo) {
-        setOrganizationLogoPreview(campaign.organizationInfo.logo);
-      }
       // Set initial previews for gallery images
       if (Array.isArray(campaign.galleryImages) && campaign.galleryImages.length > 0) {
         setGalleryImagePreviews(campaign.galleryImages);
@@ -403,7 +399,6 @@ const CampaignDialog = ({
       clearGallerySelection(); // Clear the hook's gallery state
       // Clear advanced image selections/previews for add mode
       setSelectedOrganizationLogo(null);
-      setOrganizationLogoPreview(null);
       // Clear gallery image selections/previews for add mode
       setSelectedGalleryImages([]);
       setGalleryImagePreviews([]);
@@ -443,9 +438,6 @@ const CampaignDialog = ({
       } else if (inputName === 'organizationInfoLogo') {
         const file = files[0];
         setSelectedOrganizationLogo(file);
-        const reader = new FileReader();
-        reader.onload = (e) => setOrganizationLogoPreview(e.target?.result as string);
-        reader.readAsDataURL(file);
       } else if (inputName === 'galleryImages') {
         const newFiles = Array.from(files);
 
@@ -462,27 +454,6 @@ const CampaignDialog = ({
             setGalleryImagePreviews((prev) => [...prev, e.target?.result as string]);
           reader.readAsDataURL(file);
         });
-      }
-    }
-  };
-
-  const handleOrganizationLogoUpload = async () => {
-    if (selectedOrganizationLogo) {
-      setIsUploadingOrganizationLogo(true); // Set loading state
-      try {
-        const url = await uploadFile(
-          selectedOrganizationLogo,
-          `campaigns/${campaign?.id || 'new'}/organizationLogo/${selectedOrganizationLogo.name}`,
-        );
-        if (url) {
-          setFormData((prev) => ({ ...prev, organizationInfoLogo: url }));
-          setOrganizationLogoPreview(url);
-        }
-      } catch (error) {
-        console.error('Error uploading organization logo:', error);
-        alert('Failed to upload organization logo. Please try again.');
-      } finally {
-        setIsUploadingOrganizationLogo(false); // Reset loading state
       }
     }
   };
@@ -552,7 +523,7 @@ const CampaignDialog = ({
     // Upload cover image if a new one was selected
     if (selectedImage) {
       try {
-        const uploadedData = await handleImageUpload(campaign?.id, finalData as any);
+        const uploadedData = await handleImageUpload(campaign?.id, finalData as CampaignSaveData);
         if (uploadedData?.coverImageUrl) {
           finalData = { ...finalData, coverImageUrl: uploadedData.coverImageUrl };
           setImagePreviewUrl(uploadedData.coverImageUrl);
@@ -627,11 +598,8 @@ const CampaignDialog = ({
     setFormData(getInitialFormData()); // Reset for add mode
     // Clear tags
     setSelectedTags([]);
-    setTagSearchValue('');
-    setTagSearchOpen(false);
     // Clear advanced image selections/previews
     setSelectedOrganizationLogo(null);
-    setOrganizationLogoPreview(null);
     setSelectedGalleryImages([]);
     setGalleryImagePreviews([]);
   };
@@ -645,7 +613,6 @@ const CampaignDialog = ({
   const dialogDescription = isEditMode
     ? "Make changes to your campaign below. Click save when you're done."
     : 'Fill in the details below to create a new campaign.';
-  const saveButtonText = isEditMode ? 'Save Changes' : 'Create Campaign';
   const isSaveDisabled = uploadingImage || !formData.title || !formData.description;
 
   return (
@@ -1355,26 +1322,17 @@ const CampaignManagement = ({
   const [dateRange, setDateRange] = useState('all');
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [campaignToDelete, setCampaignToDelete] = useState<DocumentData | null>(null);
-  const [confirmDeleteInput, setConfirmDeleteInput] = useState('');
   const [isDeleting, setIsDeleting] = useState(false);
 
   // Error dialog state
   const [errorDialogOpen, setErrorDialogOpen] = useState(false);
   const [errorDialogMessage, setErrorDialogMessage] = useState('');
 
-  const {
-    campaigns: allCampaigns,
-    updateWithImage,
-    createWithImage,
-    remove,
-    loading,
-    uploadFile,
-    refresh,
-  } = useCampaignManagement(userSession.user.organizationId || '');
+  const { updateWithImage, createWithImage, remove, loading, uploadFile, refresh } =
+    useCampaignManagement(userSession.user.organizationId || '');
 
   const {
     campaigns,
-    loading: pagedLoading,
     fetching,
     pageNumber,
     canGoNext,
@@ -1394,7 +1352,7 @@ const CampaignManagement = ({
   const { organization, loading: orgLoading } = useOrganization(
     userSession.user.organizationId ?? null,
   );
-  const { isStripeOnboarded, needsOnboarding } = useStripeOnboarding(organization);
+  useStripeOnboarding(organization);
   const [showOnboardingDialog, setShowOnboardingDialog] = useState(false);
 
   const handleDeleteClick = (campaign: DocumentData) => {
@@ -1420,33 +1378,36 @@ const CampaignManagement = ({
     }
   };
 
-  // Helper function to remove undefined properties from an object
-  const removeUndefined = (obj: any): any => {
-    if (obj === null || typeof obj !== 'object') {
-      return obj;
+  const stripUndefined = (value: unknown): unknown => {
+    if (value === null || typeof value !== 'object') {
+      return value;
     }
 
-    if (Array.isArray(obj)) {
-      return obj.map(removeUndefined).filter((item) => item !== undefined);
+    if (Array.isArray(value)) {
+      return value.map(stripUndefined).filter((item) => item !== undefined);
     }
 
-    const newObj: any = {};
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        const value = obj[key];
-        if (value !== undefined) {
-          const processedValue = removeUndefined(value);
-          if (processedValue !== undefined) {
-            newObj[key] = processedValue;
-          }
-        }
+    const source = value as UnknownRecord;
+    const cleaned: UnknownRecord = {};
+    for (const [key, nestedValue] of Object.entries(source)) {
+      if (nestedValue === undefined) continue;
+      const processed = stripUndefined(nestedValue);
+      if (processed !== undefined) {
+        cleaned[key] = processed;
       }
     }
-    // If all properties of an object are undefined, return undefined so it can be removed from parent.
-    if (Object.keys(newObj).length === 0 && Object.keys(obj).length > 0) {
+
+    if (Object.keys(cleaned).length === 0 && Object.keys(source).length > 0) {
       return undefined;
     }
-    return newObj;
+
+    return cleaned;
+  };
+
+  // Helper function to remove undefined properties while preserving the input type.
+  const removeUndefined = <T extends UnknownRecord>(obj: T): T => {
+    const cleaned = stripUndefined(obj);
+    return (cleaned && typeof cleaned === 'object' ? cleaned : {}) as unknown as T;
   };
 
   const handleEditClick = (campaign: DocumentData) => {
@@ -1463,12 +1424,8 @@ const CampaignManagement = ({
       predefinedAmounts: Array.isArray(campaign.configuration?.predefinedAmounts)
         ? campaign.configuration.predefinedAmounts.slice(0, 3)
         : [25, 50, 100],
-      startDate: campaign.startDate?.seconds
-        ? new Date(campaign.startDate.seconds * 1000).toISOString().split('T')[0]
-        : '',
-      endDate: campaign.endDate?.seconds
-        ? new Date(campaign.endDate.seconds * 1000).toISOString().split('T')[0]
-        : '',
+      startDate: toDateInputValue(campaign.startDate),
+      endDate: toDateInputValue(campaign.endDate),
       enableRecurring:
         campaign.configuration?.enableRecurring ?? DEFAULT_CAMPAIGN_CONFIG.enableRecurring,
       recurringIntervals: Array.isArray(campaign.configuration?.recurringIntervals)
@@ -1523,7 +1480,7 @@ const CampaignManagement = ({
 
   const handleSave = async (data: DocumentData, isNew: boolean, campaignId?: string) => {
     try {
-      const dataToSave: { [key: string]: any } = {
+      const dataToSave: UnknownRecord = {
         title: data.title,
         description: data.description,
         status: data.status,
@@ -1611,11 +1568,8 @@ const CampaignManagement = ({
 
       const finalDataToSave = removeUndefined(dataToSave);
 
-      let savedCampaignId = campaignId;
-
       if (isNew) {
-        const newCampaign = await createWithImage(finalDataToSave);
-        savedCampaignId = newCampaign.id;
+        const newCampaign = await createWithImage(finalDataToSave as Omit<Campaign, 'id'>);
 
         try {
           await syncKiosksForCampaign(
@@ -1627,7 +1581,7 @@ const CampaignManagement = ({
           console.error('Kiosk sync failed after campaign create (campaign was saved):', syncError);
         }
       } else if (campaignId) {
-        await updateWithImage(campaignId, finalDataToSave);
+        await updateWithImage(campaignId, finalDataToSave as Partial<Campaign>);
 
         const oldAssignedKiosks = normalizeAssignments(editingCampaign?.assignedKiosks);
         try {
@@ -1704,7 +1658,7 @@ const CampaignManagement = ({
         }
       }
 
-      const dataToSave: { [key: string]: any } = {
+      const dataToSave: UnknownRecord = {
         title: newCampaignFormData.title,
         description: newCampaignFormData.briefOverview,
         longDescription: newCampaignFormData.description,
@@ -1737,7 +1691,7 @@ const CampaignManagement = ({
       }
 
       const finalDataToSave = removeUndefined(dataToSave);
-      const newCampaign = await createWithImage(finalDataToSave);
+      const newCampaign = await createWithImage(finalDataToSave as Omit<Campaign, 'id'>);
 
       try {
         await syncKiosksForCampaign(
@@ -1864,7 +1818,7 @@ const CampaignManagement = ({
         }
       }
 
-      const dataToSave: { [key: string]: any } = {
+      const dataToSave: UnknownRecord = {
         title: newCampaignFormData.title,
         description: newCampaignFormData.briefOverview,
         longDescription: newCampaignFormData.description,
@@ -1897,7 +1851,7 @@ const CampaignManagement = ({
       }
 
       const finalDataToSave = removeUndefined(dataToSave);
-      const newCampaign = await createWithImage(finalDataToSave);
+      const newCampaign = await createWithImage(finalDataToSave as Omit<Campaign, 'id'>);
 
       try {
         await syncKiosksForCampaign(
@@ -1983,7 +1937,7 @@ const CampaignManagement = ({
         }
       }
 
-      const dataToSave: { [key: string]: any } = {
+      const dataToSave: UnknownRecord = {
         title: editCampaignFormData.title,
         description: editCampaignFormData.briefOverview,
         longDescription: editCampaignFormData.description,
@@ -2016,7 +1970,7 @@ const CampaignManagement = ({
       }
 
       const finalDataToSave = removeUndefined(dataToSave);
-      await updateWithImage(editingCampaignForNewForm.id, finalDataToSave);
+      await updateWithImage(editingCampaignForNewForm.id, finalDataToSave as Partial<Campaign>);
 
       try {
         await syncKiosksForCampaign(
@@ -2117,7 +2071,7 @@ const CampaignManagement = ({
         }
       }
 
-      const dataToSave: { [key: string]: any } = {
+      const dataToSave: UnknownRecord = {
         title: editCampaignFormData.title,
         description: editCampaignFormData.briefOverview,
         longDescription: editCampaignFormData.description,
@@ -2150,7 +2104,7 @@ const CampaignManagement = ({
       }
 
       const finalDataToSave = removeUndefined(dataToSave);
-      await updateWithImage(editingCampaignForNewForm.id, finalDataToSave);
+      await updateWithImage(editingCampaignForNewForm.id, finalDataToSave as Partial<Campaign>);
 
       try {
         await syncKiosksForCampaign(
@@ -2247,21 +2201,21 @@ const CampaignManagement = ({
 
   const uniqueCategories: string[] = Array.from(
     new Set(
-      (campaigns as any[])
+      campaigns
         .map((c) => (typeof c.category === 'string' ? c.category : ''))
         .filter((v): v is string => Boolean(v)),
     ),
   );
 
   const totalCampaigns = campaigns.length;
-  const activeCampaigns = campaigns.filter((campaign: any) => campaign.status === 'active').length;
+  const activeCampaigns = campaigns.filter((campaign) => campaign.status === 'active').length;
   const totalRaised = campaigns.reduce(
-    (sum: number, campaign: any) => sum + (Number(campaign.raised) || 0),
+    (sum: number, campaign) => sum + (Number(campaign.raised) || 0),
     0,
   );
   const progressValues = campaigns
-    .filter((campaign: any) => campaign.goal && campaign.raised)
-    .map((campaign: any) =>
+    .filter((campaign) => campaign.goal && campaign.raised)
+    .map((campaign) =>
       Math.min((Number(campaign.raised) / 100 / Number(campaign.goal)) * 100, 100),
     );
   const averageProgress =
@@ -2339,7 +2293,7 @@ const CampaignManagement = ({
     dateRange,
   };
 
-  const handleFilterChange = (key: string, value: any) => {
+  const handleFilterChange = (key: string, value: string) => {
     switch (key) {
       case 'statusFilter':
         setStatusFilter(value);
@@ -2354,7 +2308,7 @@ const CampaignManagement = ({
   };
 
   // Client-side search, status, category, and date filters on current page
-  const filteredCampaigns = campaigns.filter((campaign: any) => {
+  const filteredCampaigns = campaigns.filter((campaign) => {
     const matchesSearch =
       !searchTerm ||
       campaign.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -2363,11 +2317,7 @@ const CampaignManagement = ({
         campaign.tags.some((tag: string) => tag.toLowerCase().includes(searchTerm.toLowerCase())));
     const matchesStatus = statusFilter === 'all' || campaign.status === statusFilter;
     const matchesCategory = categoryFilter === 'all' || campaign.category === categoryFilter;
-    const campaignEndDate = campaign.endDate?.seconds
-      ? new Date(campaign.endDate.seconds * 1000)
-      : campaign.endDate
-        ? new Date(campaign.endDate)
-        : null;
+    const campaignEndDate = toDateValue(campaign.endDate);
     const matchesDate = !dateRangeStart || !campaignEndDate || campaignEndDate >= dateRangeStart;
     return matchesSearch && matchesStatus && matchesCategory && matchesDate;
   });
@@ -2576,7 +2526,7 @@ const CampaignManagement = ({
                           : 'space-y-4 md:hidden'
                       }`}
                     >
-                      {filteredAndSortedCampaigns.map((campaign: any) => {
+                      {filteredAndSortedCampaigns.map((campaign) => {
                         const raisedAmount = Number(campaign.raised) || 0;
                         const goalAmount = Number(campaign.goal) || 0;
                         const donationCount = Number(campaign.donationCount) || 0;
@@ -2754,7 +2704,7 @@ const CampaignManagement = ({
                           </TableRow>
                         </TableHeader>
                         <TableBody>
-                          {filteredAndSortedCampaigns.map((campaign: any) => {
+                          {filteredAndSortedCampaigns.map((campaign) => {
                             const raisedAmount = Number(campaign.raised) || 0;
                             const goalAmount = Number(campaign.goal) || 0;
                             const progress =

--- a/src/views/admin/CampaignManagement.tsx
+++ b/src/views/admin/CampaignManagement.tsx
@@ -2340,8 +2340,12 @@ const CampaignManagement = ({
 
     setIsExporting(true);
     try {
+      const visibleCampaignIds = filteredAndSortedCampaigns
+        .map((campaign) => campaign.id)
+        .filter((campaignId): campaignId is string => Boolean(campaignId));
       await exportCampaigns({
         organizationId: userSession.user.organizationId,
+        campaignIds: visibleCampaignIds,
       });
       showToast('Campaign export started. Your download should begin shortly.', 'success');
     } catch (exportError) {

--- a/src/views/admin/CampaignManagement.tsx
+++ b/src/views/admin/CampaignManagement.tsx
@@ -1,50 +1,51 @@
-import React, { useEffect, useState, useRef, useCallback } from "react";
-import { Screen, AdminSession, Permission, Kiosk } from "../../shared/types";
-import { DEFAULT_CAMPAIGN_CONFIG } from "../../shared/config";
-import { DocumentData, Timestamp } from "firebase/firestore";
-import { useCampaignManagement } from "../../shared/lib/hooks/useCampaignManagement";
-import { useCampaignsPaginated } from "../../shared/lib/hooks/useCampaignsPaginated";
-import { PaginationControls } from "../../shared/ui/PaginationControls";
-import { useOrganizationTags } from "../../shared/lib/hooks/useOrganizationTags";
-import { formatCurrency, formatCurrencyFromMajor } from "../../shared/lib/currencyFormatter";
-import { kioskApi } from "../../entities/kiosk/api";
-import { Button } from "../../shared/ui/button";
-import { Input } from "../../shared/ui/input";
-import { Label } from "../../shared/ui/label";
-import { 
-  syncKiosksForCampaign, 
-  normalizeAssignments 
-} from "../../shared/lib/sync/campaignKioskSync";
-import { Textarea } from "../../shared/ui/textarea";
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { Screen, AdminSession, Permission, Kiosk } from '../../shared/types';
+import { DEFAULT_CAMPAIGN_CONFIG } from '../../shared/config';
+import { DocumentData, Timestamp } from 'firebase/firestore';
+import { useCampaignManagement } from '../../shared/lib/hooks/useCampaignManagement';
+import { useCampaignsPaginated } from '../../shared/lib/hooks/useCampaignsPaginated';
+import { PaginationControls } from '../../shared/ui/PaginationControls';
+import { useOrganizationTags } from '../../shared/lib/hooks/useOrganizationTags';
+import { formatCurrency, formatCurrencyFromMajor } from '../../shared/lib/currencyFormatter';
+import { kioskApi } from '../../entities/kiosk/api';
+import { Button } from '../../shared/ui/button';
+import { Input } from '../../shared/ui/input';
+import { Label } from '../../shared/ui/label';
+import {
+  syncKiosksForCampaign,
+  normalizeAssignments,
+} from '../../shared/lib/sync/campaignKioskSync';
+import { Textarea } from '../../shared/ui/textarea';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "../../shared/ui/dialog";
+} from '../../shared/ui/dialog';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "../../shared/ui/select";
+} from '../../shared/ui/select';
 import {
   Command,
   CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
-} from "../../shared/ui/command";
-import { Badge } from "../../shared/ui/badge";
-import { X, Check, ChevronsUpDown, Trash2, Save } from "lucide-react";
+} from '../../shared/ui/command';
+import { Badge } from '../../shared/ui/badge';
+import { X, Check, ChevronsUpDown, Trash2, Save } from 'lucide-react';
 import {
   FaEdit,
   FaUpload,
   FaImage,
   FaTrashAlt, // Added FaTrashAlt
-} from "react-icons/fa";
+} from 'react-icons/fa';
 import {
   Plus,
   RefreshCw,
@@ -56,13 +57,13 @@ import {
   Wallet,
   Download,
   Building2,
-} from "lucide-react";
-import { Calendar } from "../../shared/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "../../shared/ui/popover";
-import { AlertTriangle } from "lucide-react"; // Import AlertTriangle
-import { Skeleton } from "../../shared/ui/skeleton";
-import { Ghost } from "lucide-react";
-import { ImageWithFallback } from "../../shared/ui/figma/ImageWithFallback";
+} from 'lucide-react';
+import { Calendar } from '../../shared/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '../../shared/ui/popover';
+import { AlertTriangle } from 'lucide-react'; // Import AlertTriangle
+import { Skeleton } from '../../shared/ui/skeleton';
+import { Ghost } from 'lucide-react';
+import { ImageWithFallback } from '../../shared/ui/figma/ImageWithFallback';
 
 import {
   AlertDialog,
@@ -74,15 +75,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "../../shared/ui/alert-dialog";
-import { AdminLayout } from "./AdminLayout";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "../../shared/ui/card";
+} from '../../shared/ui/alert-dialog';
+import { AdminLayout } from './AdminLayout';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../shared/ui/card';
 import {
   Table,
   TableBody,
@@ -90,72 +85,72 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "../../shared/ui/table";
-import { useOrganization } from "../../shared/lib/hooks/useOrganization";
-import { useStripeOnboarding, StripeOnboardingDialog } from "../../features/stripe-onboarding";
+} from '../../shared/ui/table';
+import { useOrganization } from '../../shared/lib/hooks/useOrganization';
+import { useStripeOnboarding, StripeOnboardingDialog } from '../../features/stripe-onboarding';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "../../shared/ui/dropdown-menu";
-import { AdminSearchFilterHeader, AdminSearchFilterConfig } from "./components/AdminSearchFilterHeader";
-import { SortableTableHeader } from "./components/SortableTableHeader";
-import { useTableSort } from "../../shared/lib/hooks/useTableSort";
-import { CampaignForm, CampaignFormData } from "./components/CampaignForm";
-import { Campaign } from "../../shared/types";
-import { exportToCsv } from "../../shared/utils/csvExport";
+} from '../../shared/ui/dropdown-menu';
+import {
+  AdminSearchFilterHeader,
+  AdminSearchFilterConfig,
+} from './components/AdminSearchFilterHeader';
+import { SortableTableHeader } from './components/SortableTableHeader';
+import { useTableSort } from '../../shared/lib/hooks/useTableSort';
+import { CampaignForm, CampaignFormData } from './components/CampaignForm';
+import { Campaign } from '../../shared/types';
+import { exportCampaigns } from '../../entities/campaign/api';
+import { useToast } from '../../shared/ui/ToastProvider';
 
 interface CampaignDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   campaign?: DocumentData | null; // Optional campaign for editing
   organizationId: string; // Add organizationId prop
-  onSave: (
-    data: DocumentData,
-    isNew: boolean,
-    campaignId?: string
-  ) => Promise<void>;
+  onSave: (data: DocumentData, isNew: boolean, campaignId?: string) => Promise<void>;
 }
 
 const getInitialFormData = () => ({
-  title: "",
-  description: "",
-  status: "active",
+  title: '',
+  description: '',
+  status: 'active',
   goal: 0,
   tags: [],
-  startDate: "",
-  endDate: "",
-  coverImageUrl: "",
+  startDate: '',
+  endDate: '',
+  coverImageUrl: '',
   // New fields for advanced settings (initial subset)
-  category: "",
-  organizationId: "",
-  longDescription: "",
-  videoUrl: "",
+  category: '',
+  organizationId: '',
+  longDescription: '',
+  videoUrl: '',
   // Adding more fields for advanced settings
-  assignedKiosks: "", // Stored as comma-separated string
+  assignedKiosks: '', // Stored as comma-separated string
   selectedKiosks: [] as string[], // Array of kiosk IDs
   isGlobal: false,
-  galleryImages: "", // Stored as comma-separated string
-  organizationInfoName: "",
-  organizationInfoDescription: "",
-  organizationInfoWebsite: "",
-  organizationInfoLogo: "",
+  galleryImages: '', // Stored as comma-separated string
+  organizationInfoName: '',
+  organizationInfoDescription: '',
+  organizationInfoWebsite: '',
+  organizationInfoLogo: '',
   impactMetricsPeopleHelped: 0,
   impactMetricsItemsProvided: 0,
-  impactMetricsCustomMetricLabel: "",
+  impactMetricsCustomMetricLabel: '',
   impactMetricsCustomMetricValue: 0,
-  impactMetricsCustomMetricUnit: "",
+  impactMetricsCustomMetricUnit: '',
 
   // CampaignConfiguration fields - flattened for form handling (initial subset)
-  predefinedAmounts: DEFAULT_CAMPAIGN_CONFIG.predefinedAmounts.join(","),
+  predefinedAmounts: DEFAULT_CAMPAIGN_CONFIG.predefinedAmounts.join(','),
   allowCustomAmount: DEFAULT_CAMPAIGN_CONFIG.allowCustomAmount,
   minCustomAmount: DEFAULT_CAMPAIGN_CONFIG.minCustomAmount,
   maxCustomAmount: DEFAULT_CAMPAIGN_CONFIG.maxCustomAmount,
   // Adding more CampaignConfiguration fields
-  suggestedAmounts: DEFAULT_CAMPAIGN_CONFIG.suggestedAmounts.join(","),
+  suggestedAmounts: DEFAULT_CAMPAIGN_CONFIG.suggestedAmounts.join(','),
   enableRecurring: DEFAULT_CAMPAIGN_CONFIG.enableRecurring,
-  recurringIntervals: DEFAULT_CAMPAIGN_CONFIG.recurringIntervals.join(","),
+  recurringIntervals: DEFAULT_CAMPAIGN_CONFIG.recurringIntervals.join(','),
   defaultRecurringInterval: DEFAULT_CAMPAIGN_CONFIG.defaultRecurringInterval,
   recurringDiscount: DEFAULT_CAMPAIGN_CONFIG.recurringDiscount,
   // Adding Display Settings fields
@@ -166,19 +161,19 @@ const getInitialFormData = () => ({
   maxRecentDonations: DEFAULT_CAMPAIGN_CONFIG.maxRecentDonations,
   // Adding Call-to-Action fields
   primaryCTAText: DEFAULT_CAMPAIGN_CONFIG.primaryCTAText,
-  secondaryCTAText: DEFAULT_CAMPAIGN_CONFIG.secondaryCTAText || "",
-  urgencyMessage: "",
+  secondaryCTAText: DEFAULT_CAMPAIGN_CONFIG.secondaryCTAText || '',
+  urgencyMessage: '',
   // Adding Visual Customization fields
-  accentColor: "#4F46E5",
-  backgroundImage: "",
+  accentColor: '#4F46E5',
+  backgroundImage: '',
   theme: DEFAULT_CAMPAIGN_CONFIG.theme,
   // Adding Form Configuration fields
-  requiredFields: DEFAULT_CAMPAIGN_CONFIG.requiredFields.join(","),
-  optionalFields: DEFAULT_CAMPAIGN_CONFIG.optionalFields.join(","),
+  requiredFields: DEFAULT_CAMPAIGN_CONFIG.requiredFields.join(','),
+  optionalFields: DEFAULT_CAMPAIGN_CONFIG.optionalFields.join(','),
   enableAnonymousDonations: DEFAULT_CAMPAIGN_CONFIG.enableAnonymousDonations,
   // Adding Social Features fields
   enableSocialSharing: DEFAULT_CAMPAIGN_CONFIG.enableSocialSharing,
-  shareMessage: "",
+  shareMessage: '',
   enableDonorWall: DEFAULT_CAMPAIGN_CONFIG.enableDonorWall,
   enableComments: DEFAULT_CAMPAIGN_CONFIG.enableComments,
 });
@@ -191,7 +186,9 @@ const CampaignDialog = ({
   onSave,
 }: CampaignDialogProps) => {
   const [formData, setFormData] = useState<DocumentData>(getInitialFormData());
-  const [activeTab, setActiveTab] = useState<"basic" | "media-gallery" | "funding-details" | "kiosk-distribution">("basic");
+  const [activeTab, setActiveTab] = useState<
+    'basic' | 'media-gallery' | 'funding-details' | 'kiosk-distribution'
+  >('basic');
   const [kiosks, setKiosks] = useState<Kiosk[]>([]);
   const [loadingKiosks, setLoadingKiosks] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -209,14 +206,18 @@ const CampaignDialog = ({
       // Find the section closest to center of view
       const basicInfoSection = container.querySelector('[data-section="basic"]') as HTMLElement;
       const mediaSection = container.querySelector('[data-section="media-gallery"]') as HTMLElement;
-      const fundingSection = container.querySelector('[data-section="funding-details"]') as HTMLElement;
-      const kioskSection = container.querySelector('[data-section="kiosk-distribution"]') as HTMLElement;
+      const fundingSection = container.querySelector(
+        '[data-section="funding-details"]',
+      ) as HTMLElement;
+      const kioskSection = container.querySelector(
+        '[data-section="kiosk-distribution"]',
+      ) as HTMLElement;
 
       const sections = [
         { element: basicInfoSection, id: 'basic' },
         { element: mediaSection, id: 'media-gallery' },
         { element: fundingSection, id: 'funding-details' },
-        { element: kioskSection, id: 'kiosk-distribution' }
+        { element: kioskSection, id: 'kiosk-distribution' },
       ];
 
       let closestSection = 'basic';
@@ -278,26 +279,20 @@ const CampaignDialog = ({
   } = useCampaignManagement();
 
   // Organization tags hook
-  const { tags: organizationTags, addMultipleTags: addMultipleOrganizationTags } = useOrganizationTags(organizationId);
+  const { tags: organizationTags, addMultipleTags: addMultipleOrganizationTags } =
+    useOrganizationTags(organizationId);
 
   // Tags dropdown state
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [tagSearchOpen, setTagSearchOpen] = useState(false);
-  const [tagSearchValue, setTagSearchValue] = useState("");
+  const [tagSearchValue, setTagSearchValue] = useState('');
 
   // New state for advanced image uploads
-  const [selectedOrganizationLogo, setSelectedOrganizationLogo] =
-    useState<File | null>(null);
-  const [organizationLogoPreview, setOrganizationLogoPreview] = useState<
-    string | null
-  >(null);
+  const [selectedOrganizationLogo, setSelectedOrganizationLogo] = useState<File | null>(null);
+  const [organizationLogoPreview, setOrganizationLogoPreview] = useState<string | null>(null);
   // New state for gallery image uploads
-  const [selectedGalleryImages, setSelectedGalleryImages] = useState<File[]>(
-    []
-  );
-  const [galleryImagePreviews, setGalleryImagePreviews] = useState<string[]>(
-    []
-  );
+  const [selectedGalleryImages, setSelectedGalleryImages] = useState<File[]>([]);
+  const [galleryImagePreviews, setGalleryImagePreviews] = useState<string[]>([]);
 
   // New states for specific image upload loading
   const [isUploadingOrganizationLogo, setIsUploadingOrganizationLogo] = useState(false);
@@ -307,102 +302,85 @@ const CampaignDialog = ({
   useEffect(() => {
     if (isEditMode && campaign) {
       const editableData = {
-        title: campaign.title || "",
-        description: campaign.description || "",
-        status: campaign.status || "active",
+        title: campaign.title || '',
+        description: campaign.description || '',
+        status: campaign.status || 'active',
         goal: campaign.goal || 0,
-        tags: Array.isArray(campaign.tags) ? campaign.tags.join(", ") : "",
+        tags: Array.isArray(campaign.tags) ? campaign.tags.join(', ') : '',
         startDate: campaign.startDate?.seconds
-          ? new Date(campaign.startDate.seconds * 1000)
-            .toISOString()
-            .split("T")[0]
-          : "",
+          ? new Date(campaign.startDate.seconds * 1000).toISOString().split('T')[0]
+          : '',
         endDate: campaign.endDate?.seconds
-          ? new Date(campaign.endDate.seconds * 1000)
-            .toISOString()
-            .split("T")[0]
-          : "",
-        coverImageUrl: campaign.coverImageUrl || "",
+          ? new Date(campaign.endDate.seconds * 1000).toISOString().split('T')[0]
+          : '',
+        coverImageUrl: campaign.coverImageUrl || '',
 
         // New fields for advanced settings (initial subset)
-        category: campaign.category || "",
-        organizationId: campaign.organizationId || "",
-        longDescription: campaign.longDescription || "",
-        videoUrl: campaign.videoUrl || "",
+        category: campaign.category || '',
+        organizationId: campaign.organizationId || '',
+        longDescription: campaign.longDescription || '',
+        videoUrl: campaign.videoUrl || '',
         // Adding more fields for advanced settings
         assignedKiosks: Array.isArray(campaign.assignedKiosks)
-          ? campaign.assignedKiosks.join(", ")
-          : "",
+          ? campaign.assignedKiosks.join(', ')
+          : '',
         isGlobal: campaign.isGlobal || false,
         galleryImages: Array.isArray(campaign.galleryImages)
-          ? campaign.galleryImages.join(", ")
-          : "",
-        organizationInfoName: campaign.organizationInfo?.name || "",
-        organizationInfoDescription:
-          campaign.organizationInfo?.description || "",
-        organizationInfoWebsite: campaign.organizationInfo?.website || "",
-        organizationInfoLogo: campaign.organizationInfo?.logo || "",
+          ? campaign.galleryImages.join(', ')
+          : '',
+        organizationInfoName: campaign.organizationInfo?.name || '',
+        organizationInfoDescription: campaign.organizationInfo?.description || '',
+        organizationInfoWebsite: campaign.organizationInfo?.website || '',
+        organizationInfoLogo: campaign.organizationInfo?.logo || '',
         impactMetricsPeopleHelped: campaign.impactMetrics?.peopleHelped || 0,
         impactMetricsItemsProvided: campaign.impactMetrics?.itemsProvided || 0,
-        impactMetricsCustomMetricLabel:
-          campaign.impactMetrics?.customMetric?.label || "",
-        impactMetricsCustomMetricValue:
-          campaign.impactMetrics?.customMetric?.value || 0,
-        impactMetricsCustomMetricUnit:
-          campaign.impactMetrics?.customMetric?.unit || "",
+        impactMetricsCustomMetricLabel: campaign.impactMetrics?.customMetric?.label || '',
+        impactMetricsCustomMetricValue: campaign.impactMetrics?.customMetric?.value || 0,
+        impactMetricsCustomMetricUnit: campaign.impactMetrics?.customMetric?.unit || '',
 
         // CampaignConfiguration fields
-        predefinedAmounts: Array.isArray(
-          campaign.configuration?.predefinedAmounts
-        )
-          ? campaign.configuration.predefinedAmounts.join(", ")
-          : "",
+        predefinedAmounts: Array.isArray(campaign.configuration?.predefinedAmounts)
+          ? campaign.configuration.predefinedAmounts.join(', ')
+          : '',
         allowCustomAmount: campaign.configuration?.allowCustomAmount ?? true,
         minCustomAmount: campaign.configuration?.minCustomAmount ?? 1,
         maxCustomAmount: campaign.configuration?.maxCustomAmount ?? 1000,
         // Adding more CampaignConfiguration fields
-        suggestedAmounts: Array.isArray(
-          campaign.configuration?.suggestedAmounts
-        )
-          ? campaign.configuration.suggestedAmounts.join(", ")
-          : "",
-        enableRecurring: campaign.configuration?.enableRecurring ?? DEFAULT_CAMPAIGN_CONFIG.enableRecurring,
-        recurringIntervals: Array.isArray(
-          campaign.configuration?.recurringIntervals
-        )
-          ? campaign.configuration.recurringIntervals.join(", ")
-          : DEFAULT_CAMPAIGN_CONFIG.recurringIntervals.join(", "),
-        defaultRecurringInterval:
-          campaign.configuration?.defaultRecurringInterval || "monthly",
+        suggestedAmounts: Array.isArray(campaign.configuration?.suggestedAmounts)
+          ? campaign.configuration.suggestedAmounts.join(', ')
+          : '',
+        enableRecurring:
+          campaign.configuration?.enableRecurring ?? DEFAULT_CAMPAIGN_CONFIG.enableRecurring,
+        recurringIntervals: Array.isArray(campaign.configuration?.recurringIntervals)
+          ? campaign.configuration.recurringIntervals.join(', ')
+          : DEFAULT_CAMPAIGN_CONFIG.recurringIntervals.join(', '),
+        defaultRecurringInterval: campaign.configuration?.defaultRecurringInterval || 'monthly',
         recurringDiscount: campaign.configuration?.recurringDiscount ?? 0,
         // Adding Display Settings fields
-        displayStyle: campaign.configuration?.displayStyle || "grid",
+        displayStyle: campaign.configuration?.displayStyle || 'grid',
         showProgressBar: campaign.configuration?.showProgressBar ?? true,
         showDonorCount: campaign.configuration?.showDonorCount ?? true,
-        showRecentDonations:
-          campaign.configuration?.showRecentDonations ?? true,
+        showRecentDonations: campaign.configuration?.showRecentDonations ?? true,
         maxRecentDonations: campaign.configuration?.maxRecentDonations ?? 5,
         // Adding Call-to-Action fields
-        primaryCTAText: campaign.configuration?.primaryCTAText || "Donate",
-        secondaryCTAText: campaign.configuration?.secondaryCTAText || "",
-        urgencyMessage: campaign.configuration?.urgencyMessage || "",
+        primaryCTAText: campaign.configuration?.primaryCTAText || 'Donate',
+        secondaryCTAText: campaign.configuration?.secondaryCTAText || '',
+        urgencyMessage: campaign.configuration?.urgencyMessage || '',
         // Adding Visual Customization fields
-        accentColor: campaign.configuration?.accentColor || "#4F46E5",
-        backgroundImage: campaign.configuration?.backgroundImage || "",
-        theme: campaign.configuration?.theme || "default",
+        accentColor: campaign.configuration?.accentColor || '#4F46E5',
+        backgroundImage: campaign.configuration?.backgroundImage || '',
+        theme: campaign.configuration?.theme || 'default',
         // Adding Form Configuration fields
         requiredFields: Array.isArray(campaign.configuration?.requiredFields)
-          ? campaign.configuration.requiredFields.join(", ")
-          : "",
+          ? campaign.configuration.requiredFields.join(', ')
+          : '',
         optionalFields: Array.isArray(campaign.configuration?.optionalFields)
-          ? campaign.configuration.optionalFields.join(", ")
-          : "",
-        enableAnonymousDonations:
-          campaign.configuration?.enableAnonymousDonations ?? true,
+          ? campaign.configuration.optionalFields.join(', ')
+          : '',
+        enableAnonymousDonations: campaign.configuration?.enableAnonymousDonations ?? true,
         // Adding Social Features fields
-        enableSocialSharing:
-          campaign.configuration?.enableSocialSharing ?? true,
-        shareMessage: campaign.configuration?.shareMessage || "",
+        enableSocialSharing: campaign.configuration?.enableSocialSharing ?? true,
+        shareMessage: campaign.configuration?.shareMessage || '',
         enableDonorWall: campaign.configuration?.enableDonorWall ?? true,
         enableComments: campaign.configuration?.enableComments ?? true,
       };
@@ -414,10 +392,7 @@ const CampaignDialog = ({
         setOrganizationLogoPreview(campaign.organizationInfo.logo);
       }
       // Set initial previews for gallery images
-      if (
-        Array.isArray(campaign.galleryImages) &&
-        campaign.galleryImages.length > 0
-      ) {
+      if (Array.isArray(campaign.galleryImages) && campaign.galleryImages.length > 0) {
         setGalleryImagePreviews(campaign.galleryImages);
       }
     } else if (!isEditMode) {
@@ -436,14 +411,12 @@ const CampaignDialog = ({
   }, [campaign, isEditMode, setImagePreviewUrl, clearImageSelection, clearGallerySelection]);
 
   const handleChange = (
-    e: React.ChangeEvent<
-      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
-    >
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
   ) => {
     const { name, value, type, checked } = e.target as HTMLInputElement; // Cast to HTMLInputElement to access 'checked' for checkboxes
     setFormData((prev) => ({
       ...prev,
-      [name]: type === "checkbox" ? checked : value,
+      [name]: type === 'checkbox' ? checked : value,
     }));
   };
 
@@ -465,21 +438,20 @@ const CampaignDialog = ({
     const inputName = e.target.name;
 
     if (files) {
-      if (inputName === "coverImageUrl") {
+      if (inputName === 'coverImageUrl') {
         handleImageSelect(e);
-      } else if (inputName === "organizationInfoLogo") {
+      } else if (inputName === 'organizationInfoLogo') {
         const file = files[0];
         setSelectedOrganizationLogo(file);
         const reader = new FileReader();
-        reader.onload = (e) =>
-          setOrganizationLogoPreview(e.target?.result as string);
+        reader.onload = (e) => setOrganizationLogoPreview(e.target?.result as string);
         reader.readAsDataURL(file);
-      } else if (inputName === "galleryImages") {
+      } else if (inputName === 'galleryImages') {
         const newFiles = Array.from(files);
 
         // Limit to a maximum of 4 images including existing ones
         if (selectedGalleryImages.length + newFiles.length > 4) {
-          alert("You can only upload a maximum of 4 gallery images.");
+          alert('You can only upload a maximum of 4 gallery images.');
           return;
         }
 
@@ -487,10 +459,7 @@ const CampaignDialog = ({
         newFiles.forEach((file) => {
           const reader = new FileReader();
           reader.onload = (e) =>
-            setGalleryImagePreviews((prev) => [
-              ...prev,
-              e.target?.result as string,
-            ]);
+            setGalleryImagePreviews((prev) => [...prev, e.target?.result as string]);
           reader.readAsDataURL(file);
         });
       }
@@ -503,16 +472,15 @@ const CampaignDialog = ({
       try {
         const url = await uploadFile(
           selectedOrganizationLogo,
-          `campaigns/${campaign?.id || "new"}/organizationLogo/${selectedOrganizationLogo.name
-          }`
+          `campaigns/${campaign?.id || 'new'}/organizationLogo/${selectedOrganizationLogo.name}`,
         );
         if (url) {
           setFormData((prev) => ({ ...prev, organizationInfoLogo: url }));
           setOrganizationLogoPreview(url);
         }
       } catch (error) {
-        console.error("Error uploading organization logo:", error);
-        alert("Failed to upload organization logo. Please try again.");
+        console.error('Error uploading organization logo:', error);
+        alert('Failed to upload organization logo. Please try again.');
       } finally {
         setIsUploadingOrganizationLogo(false); // Reset loading state
       }
@@ -520,16 +488,17 @@ const CampaignDialog = ({
   };
 
   const handleRemoveCoverImage = () => {
-    setFormData((prev) => ({ ...prev, coverImageUrl: "" }));
+    setFormData((prev) => ({ ...prev, coverImageUrl: '' }));
     setImagePreviewUrl(null);
     clearImageSelection();
   };
 
   const handleDeleteGalleryImage = (imageToDelete: string, index: number) => {
-    const existingUrls = (formData.galleryImages as string)
-      ?.split(",")
-      .map((url) => url.trim())
-      .filter(Boolean) || [];
+    const existingUrls =
+      (formData.galleryImages as string)
+        ?.split(',')
+        .map((url) => url.trim())
+        .filter(Boolean) || [];
     const existingCount = existingUrls.length;
 
     // Remove from previews
@@ -540,7 +509,7 @@ const CampaignDialog = ({
       const updatedExisting = existingUrls.filter((_, i) => i !== index);
       setFormData((prev) => ({
         ...prev,
-        galleryImages: updatedExisting.join(","),
+        galleryImages: updatedExisting.join(','),
       }));
     } else {
       // Removing a newly selected image; update the pending files.
@@ -559,17 +528,17 @@ const CampaignDialog = ({
 
   const handleSaveChanges = async () => {
     if (!formData.title || !formData.description) {
-      alert("Title and Description are required.");
+      alert('Title and Description are required.');
       return;
     }
 
     let finalData = { ...formData };
 
     // Process tags - convert selectedTags array to comma-separated string for formData
-    finalData.tags = selectedTags.join(", ");
+    finalData.tags = selectedTags.join(', ');
 
     // Add new tags to organization if they don't exist
-    const newTags = selectedTags.filter(tag => !organizationTags.includes(tag));
+    const newTags = selectedTags.filter((tag) => !organizationTags.includes(tag));
     if (newTags.length > 0) {
       try {
         await addMultipleOrganizationTags(newTags);
@@ -589,27 +558,27 @@ const CampaignDialog = ({
           setImagePreviewUrl(uploadedData.coverImageUrl);
         }
       } catch (error) {
-        console.error("Error uploading cover image:", error);
-        alert("Failed to upload cover image. Please try again.");
+        console.error('Error uploading cover image:', error);
+        alert('Failed to upload cover image. Please try again.');
         setIsSubmitting(false);
         return;
       }
     }
 
     // Upload organization logo
-    if (selectedOrganizationLogo && !finalData.organizationInfoLogo) { // Only upload if not already uploaded
+    if (selectedOrganizationLogo && !finalData.organizationInfoLogo) {
+      // Only upload if not already uploaded
       try {
         const url = await uploadFile(
           selectedOrganizationLogo,
-          `campaigns/${campaign?.id || "new"}/organizationLogo/${selectedOrganizationLogo.name
-          }`
+          `campaigns/${campaign?.id || 'new'}/organizationLogo/${selectedOrganizationLogo.name}`,
         );
         if (url) {
           finalData = { ...finalData, organizationInfoLogo: url };
         }
       } catch (error) {
-        console.error("Error uploading organization logo:", error);
-        alert("Failed to upload organization logo. Please try again.");
+        console.error('Error uploading organization logo:', error);
+        alert('Failed to upload organization logo. Please try again.');
         setIsSubmitting(false);
         return;
       }
@@ -619,14 +588,14 @@ const CampaignDialog = ({
     if (selectedGalleryImages.length > 0) {
       const uploadedUrls: string[] = [];
       const existingUrls = finalData.galleryImages
-        ? String(finalData.galleryImages).split(",").filter(Boolean)
+        ? String(finalData.galleryImages).split(',').filter(Boolean)
         : [];
 
       for (const file of selectedGalleryImages) {
         try {
           const url = await uploadFile(
             file,
-            `campaigns/${campaign?.id || "new"}/galleryImages/${file.name}`
+            `campaigns/${campaign?.id || 'new'}/galleryImages/${file.name}`,
           );
           if (url) uploadedUrls.push(url);
         } catch (error) {
@@ -639,7 +608,7 @@ const CampaignDialog = ({
 
       if (uploadedUrls.length > 0 || existingUrls.length > 0) {
         const finalGalleryImages = [...existingUrls, ...uploadedUrls];
-        finalData = { ...finalData, galleryImages: finalGalleryImages.join(",") };
+        finalData = { ...finalData, galleryImages: finalGalleryImages.join(',') };
         setGalleryImagePreviews(finalGalleryImages);
       }
     }
@@ -658,7 +627,7 @@ const CampaignDialog = ({
     setFormData(getInitialFormData()); // Reset for add mode
     // Clear tags
     setSelectedTags([]);
-    setTagSearchValue("");
+    setTagSearchValue('');
     setTagSearchOpen(false);
     // Clear advanced image selections/previews
     setSelectedOrganizationLogo(null);
@@ -672,37 +641,32 @@ const CampaignDialog = ({
     onOpenChange(false);
   };
 
-  const dialogTitle = isEditMode
-    ? `Edit Campaign: ${campaign?.title}`
-    : "Add New Campaign";
+  const dialogTitle = isEditMode ? `Edit Campaign: ${campaign?.title}` : 'Add New Campaign';
   const dialogDescription = isEditMode
     ? "Make changes to your campaign below. Click save when you're done."
-    : "Fill in the details below to create a new campaign.";
-  const saveButtonText = isEditMode ? "Save Changes" : "Create Campaign";
-  const isSaveDisabled =
-    uploadingImage || !formData.title || !formData.description;
+    : 'Fill in the details below to create a new campaign.';
+  const saveButtonText = isEditMode ? 'Save Changes' : 'Create Campaign';
+  const isSaveDisabled = uploadingImage || !formData.title || !formData.description;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[900px] max-h-[95vh] flex flex-col p-0">
         {/* Header */}
         <div className="px-6 py-5 border-b border-gray-200 bg-white">
-          <DialogTitle className="text-2xl font-bold text-gray-900">
-            {dialogTitle}
-          </DialogTitle>
+          <DialogTitle className="text-2xl font-bold text-gray-900">{dialogTitle}</DialogTitle>
           <DialogDescription className="mt-2 text-gray-600 text-sm">
             {dialogDescription}
           </DialogDescription>
         </div>
 
         {/* Single Scroll Container - Unified scrolling for left + right */}
-        <div 
+        <div
           ref={contentRef}
           className="flex flex-1 overflow-y-scroll bg-gray-50"
           style={{
             scrollbarGutter: 'stable',
             scrollBehavior: 'smooth',
-            scrollbarWidth: 'none'
+            scrollbarWidth: 'none',
           }}
         >
           {/* Hide scrollbar for webkit browsers (Chrome, Safari) */}
@@ -716,65 +680,67 @@ const CampaignDialog = ({
           <div className="w-56 border-r border-gray-200 bg-linear-to-b from-white to-gray-50 shadow-sm sticky top-0 h-fit">
             <div className="p-5 space-y-3">
               <div className="mb-6">
-                <h3 className="text-xs font-bold text-gray-700 uppercase tracking-widest">Configuration</h3>
-                <div className="h-1 w-12 rounded mt-2" style={{backgroundColor: '#03AC13'}}></div>
+                <h3 className="text-xs font-bold text-gray-700 uppercase tracking-widest">
+                  Configuration
+                </h3>
+                <div className="h-1 w-12 rounded mt-2" style={{ backgroundColor: '#03AC13' }}></div>
               </div>
-              
+
               <button
-                onClick={() => setActiveTab("basic")}
+                onClick={() => setActiveTab('basic')}
                 style={{
-                  backgroundColor: activeTab === "basic" ? '#03AC13' : 'transparent',
-                  color: activeTab === "basic" ? 'white' : '#374151'
+                  backgroundColor: activeTab === 'basic' ? '#03AC13' : 'transparent',
+                  color: activeTab === 'basic' ? 'white' : '#374151',
                 }}
                 className={`w-full text-left px-4 py-3 rounded-lg text-sm font-semibold transition-all duration-200 ${
-                  activeTab === "basic"
-                    ? "shadow-md hover:shadow-lg"
-                    : "hover:bg-gray-200 hover:text-gray-900"
+                  activeTab === 'basic'
+                    ? 'shadow-md hover:shadow-lg'
+                    : 'hover:bg-gray-200 hover:text-gray-900'
                 }`}
               >
                 Basic Info
               </button>
-              
+
               <button
-                onClick={() => setActiveTab("media-gallery")}
+                onClick={() => setActiveTab('media-gallery')}
                 style={{
-                  backgroundColor: activeTab === "media-gallery" ? '#03AC13' : 'transparent',
-                  color: activeTab === "media-gallery" ? 'white' : '#374151'
+                  backgroundColor: activeTab === 'media-gallery' ? '#03AC13' : 'transparent',
+                  color: activeTab === 'media-gallery' ? 'white' : '#374151',
                 }}
                 className={`w-full text-left px-4 py-3 rounded-lg text-sm font-semibold transition-all duration-200 ${
-                  activeTab === "media-gallery"
-                    ? "shadow-md hover:shadow-lg"
-                    : "hover:bg-gray-200 hover:text-gray-900"
+                  activeTab === 'media-gallery'
+                    ? 'shadow-md hover:shadow-lg'
+                    : 'hover:bg-gray-200 hover:text-gray-900'
                 }`}
               >
                 Media & Gallery
               </button>
-              
+
               <button
-                onClick={() => setActiveTab("funding-details")}
+                onClick={() => setActiveTab('funding-details')}
                 style={{
-                  backgroundColor: activeTab === "funding-details" ? '#03AC13' : 'transparent',
-                  color: activeTab === "funding-details" ? 'white' : '#374151'
+                  backgroundColor: activeTab === 'funding-details' ? '#03AC13' : 'transparent',
+                  color: activeTab === 'funding-details' ? 'white' : '#374151',
                 }}
                 className={`w-full text-left px-4 py-3 rounded-lg text-sm font-semibold transition-all duration-200 ${
-                  activeTab === "funding-details"
-                    ? "shadow-md hover:shadow-lg"
-                    : "hover:bg-gray-200 hover:text-gray-900"
+                  activeTab === 'funding-details'
+                    ? 'shadow-md hover:shadow-lg'
+                    : 'hover:bg-gray-200 hover:text-gray-900'
                 }`}
               >
                 Funding Details
               </button>
-              
+
               <button
-                onClick={() => setActiveTab("kiosk-distribution")}
+                onClick={() => setActiveTab('kiosk-distribution')}
                 style={{
-                  backgroundColor: activeTab === "kiosk-distribution" ? '#03AC13' : 'transparent',
-                  color: activeTab === "kiosk-distribution" ? 'white' : '#374151'
+                  backgroundColor: activeTab === 'kiosk-distribution' ? '#03AC13' : 'transparent',
+                  color: activeTab === 'kiosk-distribution' ? 'white' : '#374151',
                 }}
                 className={`w-full text-left px-4 py-3 rounded-lg text-sm font-semibold transition-all duration-200 ${
-                  activeTab === "kiosk-distribution"
-                    ? "shadow-md hover:shadow-lg"
-                    : "hover:bg-gray-200 hover:text-gray-900"
+                  activeTab === 'kiosk-distribution'
+                    ? 'shadow-md hover:shadow-lg'
+                    : 'hover:bg-gray-200 hover:text-gray-900'
                 }`}
               >
                 Kiosk Distribution
@@ -784,9 +750,15 @@ const CampaignDialog = ({
 
           {/* Right Content - Form */}
           <div className="flex-1 bg-gray-50">
-            <form onSubmit={(e) => { e.preventDefault(); handleSaveChanges(); }} className="p-8 space-y-8">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleSaveChanges();
+              }}
+              className="p-8 space-y-8"
+            >
               {/* Basic Info Tab */}
-              {activeTab === "basic" && (
+              {activeTab === 'basic' && (
                 <div data-section="basic" className="space-y-8">
                   <div>
                     <h2 className="text-3xl font-bold text-gray-900 mb-2">General Information</h2>
@@ -795,7 +767,10 @@ const CampaignDialog = ({
 
                   {/* Campaign Title */}
                   <div className="bg-white rounded-xl p-6 shadow-sm border border-gray-200">
-                    <Label htmlFor="title" className="block text-sm font-semibold text-gray-900 mb-3">
+                    <Label
+                      htmlFor="title"
+                      className="block text-sm font-semibold text-gray-900 mb-3"
+                    >
                       Campaign Title <span className="text-red-500">*</span>
                     </Label>
                     <Input
@@ -806,12 +781,17 @@ const CampaignDialog = ({
                       placeholder="e.g. Clean Water Initiative"
                       className="w-full h-11 px-4 border border-gray-300 rounded-lg focus:border-teal-500 focus:ring-2 focus:ring-teal-200 focus:outline-none transition-all text-gray-900"
                     />
-                    <p className="text-xs text-gray-500 mt-2">Create a clear, descriptive title for your campaign</p>
+                    <p className="text-xs text-gray-500 mt-2">
+                      Create a clear, descriptive title for your campaign
+                    </p>
                   </div>
 
                   {/* Brief Overview */}
                   <div>
-                    <Label htmlFor="description" className="block text-xs font-medium text-gray-700 mb-2 uppercase tracking-wide">
+                    <Label
+                      htmlFor="description"
+                      className="block text-xs font-medium text-gray-700 mb-2 uppercase tracking-wide"
+                    >
                       Brief Overview
                     </Label>
                     <Textarea
@@ -827,7 +807,10 @@ const CampaignDialog = ({
 
                   {/* Detailed Campaign Story */}
                   <div>
-                    <Label htmlFor="longDescription" className="block text-xs font-medium text-gray-700 mb-2 uppercase tracking-wide">
+                    <Label
+                      htmlFor="longDescription"
+                      className="block text-xs font-medium text-gray-700 mb-2 uppercase tracking-wide"
+                    >
                       Detailed Campaign Story
                     </Label>
                     <div className="border border-gray-300 rounded-lg overflow-hidden">
@@ -861,7 +844,7 @@ const CampaignDialog = ({
               )}
 
               {/* Media & Gallery Tab */}
-              {activeTab === "media-gallery" && (
+              {activeTab === 'media-gallery' && (
                 <div data-section="media-gallery" className="space-y-6">
                   <h2 className="text-2xl font-bold text-gray-900">Visual Identity</h2>
 
@@ -889,15 +872,36 @@ const CampaignDialog = ({
                       <label
                         htmlFor="coverImage"
                         className="flex flex-col items-center justify-center w-full h-48 border-2 rounded-lg cursor-pointer transition"
-                        style={{borderColor: '#03AC13', borderStyle: 'dashed', backgroundColor: 'rgba(3, 172, 19, 0.05)'}}
-                        onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'rgba(3, 172, 19, 0.1)'}
-                        onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'rgba(3, 172, 19, 0.05)'}
+                        style={{
+                          borderColor: '#03AC13',
+                          borderStyle: 'dashed',
+                          backgroundColor: 'rgba(3, 172, 19, 0.05)',
+                        }}
+                        onMouseEnter={(e) =>
+                          (e.currentTarget.style.backgroundColor = 'rgba(3, 172, 19, 0.1)')
+                        }
+                        onMouseLeave={(e) =>
+                          (e.currentTarget.style.backgroundColor = 'rgba(3, 172, 19, 0.05)')
+                        }
                       >
                         <div className="flex flex-col items-center justify-center pt-5 pb-6">
-                          <svg className="w-12 h-12 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" style={{color: '#03AC13'}}>
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                          <svg
+                            className="w-12 h-12 mb-2"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            style={{ color: '#03AC13' }}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                            />
                           </svg>
-                          <p className="text-sm font-medium" style={{color: '#03AC13'}}>CLICK TO UPLOAD COVER</p>
+                          <p className="text-sm font-medium" style={{ color: '#03AC13' }}>
+                            CLICK TO UPLOAD COVER
+                          </p>
                         </div>
                         <input
                           id="coverImage"
@@ -961,7 +965,10 @@ const CampaignDialog = ({
 
                   {/* YouTube Presentation */}
                   <div>
-                    <Label htmlFor="videoUrl" className="block text-xs font-medium text-gray-700 mb-2 uppercase tracking-wide">
+                    <Label
+                      htmlFor="videoUrl"
+                      className="block text-xs font-medium text-gray-700 mb-2 uppercase tracking-wide"
+                    >
                       YouTube Presentation
                     </Label>
                     <Input
@@ -977,11 +984,13 @@ const CampaignDialog = ({
               )}
 
               {/* Funding Details Tab */}
-              {activeTab === "funding-details" && (
+              {activeTab === 'funding-details' && (
                 <div data-section="funding-details" className="space-y-8">
                   <div>
                     <h2 className="text-3xl font-bold text-gray-900 mb-2">Financial Goals</h2>
-                    <p className="text-sm text-gray-600">Set your fundraising target and donation tiers</p>
+                    <p className="text-sm text-gray-600">
+                      Set your fundraising target and donation tiers
+                    </p>
                   </div>
 
                   {/* Fundraising Target & Donation Tiers */}
@@ -989,7 +998,10 @@ const CampaignDialog = ({
                     <h3 className="text-lg font-semibold text-gray-900 mb-6">Donation Targets</h3>
                     <div className="grid grid-cols-4 gap-4">
                       <div>
-                        <Label htmlFor="goal" className="block text-sm font-semibold text-gray-900 mb-3">
+                        <Label
+                          htmlFor="goal"
+                          className="block text-sm font-semibold text-gray-900 mb-3"
+                        >
                           Fundraising Target (£) <span className="text-red-500">*</span>
                         </Label>
                         <Input
@@ -1001,12 +1013,17 @@ const CampaignDialog = ({
                           placeholder="1000"
                           className="w-full h-11 px-4 border border-gray-300 rounded-lg focus:border-teal-500 focus:ring-2 focus:ring-teal-200 focus:outline-none transition-all text-gray-900"
                         />
-                        <p className="text-xs text-gray-500 mt-2">Your campaign's fundraising goal</p>
+                        <p className="text-xs text-gray-500 mt-2">
+                          Your campaign's fundraising goal
+                        </p>
                       </div>
 
-                      {[0, 1, 2].map(index => (
+                      {[0, 1, 2].map((index) => (
                         <div key={index}>
-                          <Label htmlFor={`tier-${index}`} className="block text-sm font-semibold text-gray-900 mb-3">
+                          <Label
+                            htmlFor={`tier-${index}`}
+                            className="block text-sm font-semibold text-gray-900 mb-3"
+                          >
                             Tier {index + 1}
                           </Label>
                           <div className="flex items-center">
@@ -1033,7 +1050,10 @@ const CampaignDialog = ({
                     <h3 className="text-lg font-semibold text-gray-900 mb-6">Campaign Duration</h3>
                     <div className="grid grid-cols-2 gap-6">
                       <div>
-                        <Label htmlFor="startDate" className="block text-sm font-semibold text-gray-900 mb-3">
+                        <Label
+                          htmlFor="startDate"
+                          className="block text-sm font-semibold text-gray-900 mb-3"
+                        >
                           Start Date <span className="text-red-500">*</span>
                         </Label>
                         <Input
@@ -1048,7 +1068,10 @@ const CampaignDialog = ({
                       </div>
 
                       <div>
-                        <Label htmlFor="endDate" className="block text-sm font-semibold text-gray-900 mb-3">
+                        <Label
+                          htmlFor="endDate"
+                          className="block text-sm font-semibold text-gray-900 mb-3"
+                        >
                           End Date <span className="text-red-500">*</span>
                         </Label>
                         <Input
@@ -1067,30 +1090,48 @@ const CampaignDialog = ({
               )}
 
               {/* Kiosk Distribution Tab */}
-              {activeTab === "kiosk-distribution" && (
+              {activeTab === 'kiosk-distribution' && (
                 <div data-section="kiosk-distribution" className="space-y-6">
                   <h2 className="text-2xl font-bold text-gray-900">Kiosk Distribution</h2>
 
                   {/* Global Broadcast Option */}
-                  <label className="flex items-center p-4 rounded-lg cursor-pointer transition"
-                    style={{border: '2px solid #03AC13', backgroundColor: 'rgba(3, 172, 19, 0.05)'}}
-                    onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'rgba(3, 172, 19, 0.1)'}
-                    onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'rgba(3, 172, 19, 0.05)'}>
+                  <label
+                    className="flex items-center p-4 rounded-lg cursor-pointer transition"
+                    style={{
+                      border: '2px solid #03AC13',
+                      backgroundColor: 'rgba(3, 172, 19, 0.05)',
+                    }}
+                    onMouseEnter={(e) =>
+                      (e.currentTarget.style.backgroundColor = 'rgba(3, 172, 19, 0.1)')
+                    }
+                    onMouseLeave={(e) =>
+                      (e.currentTarget.style.backgroundColor = 'rgba(3, 172, 19, 0.05)')
+                    }
+                  >
                     <input
                       type="checkbox"
                       checked={formData.isGlobal}
                       onChange={handleChange}
                       name="isGlobal"
                       className="w-5 h-5"
-                      style={{color: '#03AC13'}}
+                      style={{ color: '#03AC13' }}
                     />
                     <div className="ml-4 flex-1">
                       <p className="font-semibold text-teal-900">BROADCAST GLOBALLY</p>
                       <p className="text-sm text-teal-700">DISPLAY ON EVERY ACTIVE TERMINAL</p>
                     </div>
                     {formData.isGlobal && (
-                      <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20" style={{color: '#03AC13'}}>
-                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                      <svg
+                        className="w-6 h-6"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                        style={{ color: '#03AC13' }}
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clipRule="evenodd"
+                        />
                       </svg>
                     )}
                   </label>
@@ -1099,7 +1140,7 @@ const CampaignDialog = ({
                   {!formData.isGlobal && (
                     <div>
                       <h3 className="text-lg font-semibold text-gray-900 mb-4">Select Kiosks</h3>
-                      
+
                       {loadingKiosks ? (
                         <div className="flex items-center justify-center py-8">
                           <Skeleton className="h-12 w-full" />
@@ -1120,16 +1161,20 @@ const CampaignDialog = ({
                                 checked={(formData.selectedKiosks || []).includes(kiosk.id)}
                                 onChange={() => handleKioskToggle(kiosk.id)}
                                 className="w-5 h-5 rounded"
-                                style={{accentColor: '#03AC13'}}
+                                style={{ accentColor: '#03AC13' }}
                               />
                               <div className="ml-3 flex-1">
                                 <p className="font-semibold text-gray-900">{kiosk.name}</p>
                                 <p className="text-sm text-gray-500">{kiosk.location}</p>
-                                <span className={`text-xs px-2 py-1 rounded-full mt-2 inline-block ${
-                                  kiosk.status === 'online' ? 'bg-green-100 text-green-800' :
-                                  kiosk.status === 'offline' ? 'bg-gray-100 text-gray-800' :
-                                  'bg-yellow-100 text-yellow-800'
-                                }`}>
+                                <span
+                                  className={`text-xs px-2 py-1 rounded-full mt-2 inline-block ${
+                                    kiosk.status === 'online'
+                                      ? 'bg-green-100 text-green-800'
+                                      : kiosk.status === 'offline'
+                                        ? 'bg-gray-100 text-gray-800'
+                                        : 'bg-yellow-100 text-yellow-800'
+                                  }`}
+                                >
                                   {kiosk.status}
                                 </span>
                               </div>
@@ -1146,7 +1191,7 @@ const CampaignDialog = ({
                           </p>
                           <div className="flex flex-wrap gap-2">
                             {(formData.selectedKiosks || []).map((kioskId: string) => {
-                              const kiosk = kiosks.find(k => k.id === kioskId);
+                              const kiosk = kiosks.find((k) => k.id === kioskId);
                               return kiosk ? (
                                 <Badge key={kioskId} className="bg-blue-600 text-white">
                                   {kiosk.name}
@@ -1166,8 +1211,8 @@ const CampaignDialog = ({
 
         {/* Footer - Fixed at bottom */}
         <div className="flex justify-between items-center px-6 py-4 border-t border-gray-200 bg-white">
-          <Button 
-            variant="outline" 
+          <Button
+            variant="outline"
             type="button"
             className="text-gray-700 flex items-center gap-2 hover:bg-gray-100 border-gray-300 font-medium"
             onClick={() => {
@@ -1192,10 +1237,16 @@ const CampaignDialog = ({
               type="submit"
               onClick={handleSaveChanges}
               disabled={isSaveDisabled || isSubmitting}
-                      className="px-7 h-11 text-white hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed font-medium shadow-md hover:shadow-lg transition-all"
-                      style={{backgroundColor: '#03AC13'}}
+              className="px-7 h-11 text-white hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed font-medium shadow-md hover:shadow-lg transition-all"
+              style={{ backgroundColor: '#03AC13' }}
             >
-              {isSubmitting ? (isEditMode ? "Saving..." : "Publishing...") : (isEditMode ? "Save Changes" : "Publish Campaign")}
+              {isSubmitting
+                ? isEditMode
+                  ? 'Saving...'
+                  : 'Publishing...'
+                : isEditMode
+                  ? 'Save Changes'
+                  : 'Publish Campaign'}
             </Button>
           </div>
         </div>
@@ -1217,14 +1268,13 @@ const CampaignManagement = ({
   userSession,
   hasPermission,
 }: CampaignManagementProps) => {
-  const [searchTerm, setSearchTerm] = useState("");
-  const [viewMode, setViewMode] = useState<"table" | "grid">("table");
+  const { showToast } = useToast();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [viewMode, setViewMode] = useState<'table' | 'grid'>('table');
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [addDialogKey, setAddDialogKey] = useState(0); // Key to force remount
-  const [editingCampaign, setEditingCampaign] = useState<DocumentData | null>(
-    null
-  );
+  const [editingCampaign, setEditingCampaign] = useState<DocumentData | null>(null);
 
   // New CampaignForm state
   const [isNewCampaignFormOpen, setIsNewCampaignFormOpen] = useState(false);
@@ -1232,7 +1282,7 @@ const CampaignManagement = ({
   const [editingCampaignForNewForm, setEditingCampaignForNewForm] = useState<Campaign | null>(null);
   const [isOverviewOpen, setIsOverviewOpen] = useState(false);
   const [selectedCampaign, setSelectedCampaign] = useState<Campaign | null>(null);
-  
+
   // Separate state for create and edit
   const [newCampaignFormData, setNewCampaignFormData] = useState<CampaignFormData>({
     title: '',
@@ -1252,9 +1302,9 @@ const CampaignManagement = ({
     tags: [],
     isGlobal: false,
     assignedKiosks: [],
-    giftAidEnabled: false
+    giftAidEnabled: false,
   });
-  
+
   const [editCampaignFormData, setEditCampaignFormData] = useState<CampaignFormData>({
     title: '',
     briefOverview: '',
@@ -1273,38 +1323,54 @@ const CampaignManagement = ({
     tags: [],
     isGlobal: false,
     assignedKiosks: [],
-    giftAidEnabled: false
+    giftAidEnabled: false,
   });
-  
-  const [selectedNewCampaignImageFile, setSelectedNewCampaignImageFile] = useState<File | null>(null);
-  const [selectedEditCampaignImageFile, setSelectedEditCampaignImageFile] = useState<File | null>(null);
-  const [selectedNewCampaignGalleryFiles, setSelectedNewCampaignGalleryFiles] = useState<File[]>([]);
-  const [selectedEditCampaignGalleryFiles, setSelectedEditCampaignGalleryFiles] = useState<File[]>([]);
+
+  const [selectedNewCampaignImageFile, setSelectedNewCampaignImageFile] = useState<File | null>(
+    null,
+  );
+  const [selectedEditCampaignImageFile, setSelectedEditCampaignImageFile] = useState<File | null>(
+    null,
+  );
+  const [selectedNewCampaignGalleryFiles, setSelectedNewCampaignGalleryFiles] = useState<File[]>(
+    [],
+  );
+  const [selectedEditCampaignGalleryFiles, setSelectedEditCampaignGalleryFiles] = useState<File[]>(
+    [],
+  );
 
   // Submission states to prevent double-submission
   const [isSubmittingNewCampaign, setIsSubmittingNewCampaign] = useState(false);
   const [isSavingNewDraft, setIsSavingNewDraft] = useState(false);
   const [isSubmittingEditCampaign, setIsSubmittingEditCampaign] = useState(false);
   const [isSavingEditDraft, setIsSavingEditDraft] = useState(false);
-  
+  const [isExporting, setIsExporting] = useState(false);
+
   // Date validation error states
   const [newCampaignDateError, setNewCampaignDateError] = useState(false);
   const [editCampaignDateError, setEditCampaignDateError] = useState(false);
 
-  const [statusFilter, setStatusFilter] = useState("all");
-  const [categoryFilter, setCategoryFilter] = useState("all");
-  const [dateRange, setDateRange] = useState("all");
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [categoryFilter, setCategoryFilter] = useState('all');
+  const [dateRange, setDateRange] = useState('all');
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [campaignToDelete, setCampaignToDelete] = useState<DocumentData | null>(null);
-  const [confirmDeleteInput, setConfirmDeleteInput] = useState("");
+  const [confirmDeleteInput, setConfirmDeleteInput] = useState('');
   const [isDeleting, setIsDeleting] = useState(false);
-  
+
   // Error dialog state
   const [errorDialogOpen, setErrorDialogOpen] = useState(false);
-  const [errorDialogMessage, setErrorDialogMessage] = useState("");
+  const [errorDialogMessage, setErrorDialogMessage] = useState('');
 
-  const { campaigns: allCampaigns, updateWithImage, createWithImage, remove, loading, uploadFile, refresh } =
-    useCampaignManagement(userSession.user.organizationId || "");
+  const {
+    campaigns: allCampaigns,
+    updateWithImage,
+    createWithImage,
+    remove,
+    loading,
+    uploadFile,
+    refresh,
+  } = useCampaignManagement(userSession.user.organizationId || '');
 
   const {
     campaigns,
@@ -1317,7 +1383,7 @@ const CampaignManagement = ({
     goPrev,
     pageSize,
     refresh: refreshPaged,
-  } = useCampaignsPaginated(userSession.user.organizationId || "");
+  } = useCampaignsPaginated(userSession.user.organizationId || '');
 
   // Invalidates both the management hook cache and the paginated query cache
   const refreshAll = useCallback(() => {
@@ -1326,7 +1392,7 @@ const CampaignManagement = ({
   }, [refresh, refreshPaged]);
 
   const { organization, loading: orgLoading } = useOrganization(
-    userSession.user.organizationId ?? null
+    userSession.user.organizationId ?? null,
   );
   const { isStripeOnboarded, needsOnboarding } = useStripeOnboarding(organization);
   const [showOnboardingDialog, setShowOnboardingDialog] = useState(false);
@@ -1346,7 +1412,7 @@ const CampaignManagement = ({
         refreshPaged();
         // Optionally, show a success toast or message
       } catch (error) {
-        console.error("Error deleting campaign:", error);
+        console.error('Error deleting campaign:', error);
         // Optionally, show an error toast or message
       } finally {
         setIsDeleting(false);
@@ -1356,7 +1422,7 @@ const CampaignManagement = ({
 
   // Helper function to remove undefined properties from an object
   const removeUndefined = (obj: any): any => {
-    if (obj === null || typeof obj !== "object") {
+    if (obj === null || typeof obj !== 'object') {
       return obj;
     }
 
@@ -1394,7 +1460,7 @@ const CampaignManagement = ({
       coverImageUrl: campaign.coverImageUrl || '',
       videoUrl: campaign.videoUrl || '',
       galleryImages: Array.isArray(campaign.galleryImages) ? campaign.galleryImages : [],
-      predefinedAmounts: Array.isArray(campaign.configuration?.predefinedAmounts) 
+      predefinedAmounts: Array.isArray(campaign.configuration?.predefinedAmounts)
         ? campaign.configuration.predefinedAmounts.slice(0, 3)
         : [25, 50, 100],
       startDate: campaign.startDate?.seconds
@@ -1403,16 +1469,17 @@ const CampaignManagement = ({
       endDate: campaign.endDate?.seconds
         ? new Date(campaign.endDate.seconds * 1000).toISOString().split('T')[0]
         : '',
-      enableRecurring: campaign.configuration?.enableRecurring ?? DEFAULT_CAMPAIGN_CONFIG.enableRecurring,
+      enableRecurring:
+        campaign.configuration?.enableRecurring ?? DEFAULT_CAMPAIGN_CONFIG.enableRecurring,
       recurringIntervals: Array.isArray(campaign.configuration?.recurringIntervals)
         ? campaign.configuration.recurringIntervals
         : [...DEFAULT_CAMPAIGN_CONFIG.recurringIntervals],
       tags: Array.isArray(campaign.tags) ? campaign.tags : [],
       isGlobal: campaign.isGlobal || false,
       assignedKiosks: normalizeAssignments(campaign.assignedKiosks),
-      giftAidEnabled: campaign.configuration?.giftAidEnabled || false
+      giftAidEnabled: campaign.configuration?.giftAidEnabled || false,
     };
-    
+
     setEditCampaignFormData(formData);
     setEditingCampaignForNewForm(campaign as Campaign);
     setIsEditCampaignFormOpen(true);
@@ -1433,59 +1500,55 @@ const CampaignManagement = ({
   const handlePauseCampaign = async () => {
     if (!selectedCampaign?.id) return;
     try {
-      const updated = await updateWithImage(selectedCampaign.id, { status: "paused" });
+      const updated = await updateWithImage(selectedCampaign.id, { status: 'paused' });
       setSelectedCampaign((prev) =>
-        prev
-          ? { ...prev, ...(updated as unknown as Campaign), status: "paused" }
-          : prev
+        prev ? { ...prev, ...(updated as unknown as Campaign), status: 'paused' } : prev,
       );
     } catch (error) {
-      console.error("Failed to pause campaign:", error);
+      console.error('Failed to pause campaign:', error);
     }
   };
 
   const handleResumeCampaign = async () => {
     if (!selectedCampaign?.id) return;
     try {
-      const updated = await updateWithImage(selectedCampaign.id, { status: "active" });
+      const updated = await updateWithImage(selectedCampaign.id, { status: 'active' });
       setSelectedCampaign((prev) =>
-        prev
-          ? { ...prev, ...(updated as unknown as Campaign), status: "active" }
-          : prev
+        prev ? { ...prev, ...(updated as unknown as Campaign), status: 'active' } : prev,
       );
     } catch (error) {
-      console.error("Failed to resume campaign:", error);
+      console.error('Failed to resume campaign:', error);
     }
   };
 
-  const handleSave = async (
-    data: DocumentData,
-    isNew: boolean,
-    campaignId?: string
-  ) => {
+  const handleSave = async (data: DocumentData, isNew: boolean, campaignId?: string) => {
     try {
       const dataToSave: { [key: string]: any } = {
         title: data.title,
         description: data.description,
         status: data.status,
         goal: Number(data.goal),
-        tags: typeof data.tags === "string"
-        ? data.tags.split(",").map((t: string) => t.trim()).filter(Boolean)
-        : [],
-        coverImageUrl: data.coverImageUrl || "",
-        category: data.category || "",
-        organizationId: userSession.user.organizationId || "",
+        tags:
+          typeof data.tags === 'string'
+            ? data.tags
+                .split(',')
+                .map((t: string) => t.trim())
+                .filter(Boolean)
+            : [],
+        coverImageUrl: data.coverImageUrl || '',
+        category: data.category || '',
+        organizationId: userSession.user.organizationId || '',
         assignedKiosks: normalizeAssignments(data.assignedKiosks),
         isGlobal: data.isGlobal,
-        longDescription: data.longDescription || "",
-        videoUrl: data.videoUrl || "",
+        longDescription: data.longDescription || '',
+        videoUrl: data.videoUrl || '',
         galleryImages: data.galleryImages
-          .split(",")
+          .split(',')
           .map((t: string) => t.trim())
           .filter(Boolean),
         organizationInfo: {
-          name: data.organizationInfoName || "",
-          description: data.organizationInfoDescription || "",
+          name: data.organizationInfoName || '',
+          description: data.organizationInfoDescription || '',
           website: data.organizationInfoWebsite || undefined,
           logo: data.organizationInfoLogo || undefined,
         },
@@ -1494,30 +1557,24 @@ const CampaignManagement = ({
           itemsProvided: Number(data.impactMetricsItemsProvided) || undefined,
           customMetric:
             data.impactMetricsCustomMetricLabel ||
-              data.impactMetricsCustomMetricValue ||
-              data.impactMetricsCustomMetricUnit
+            data.impactMetricsCustomMetricValue ||
+            data.impactMetricsCustomMetricUnit
               ? {
-                label: data.impactMetricsCustomMetricLabel || "",
-                value: Number(data.impactMetricsCustomMetricValue) || 0,
-                unit: data.impactMetricsCustomMetricUnit || "",
-              }
+                  label: data.impactMetricsCustomMetricLabel || '',
+                  value: Number(data.impactMetricsCustomMetricValue) || 0,
+                  unit: data.impactMetricsCustomMetricUnit || '',
+                }
               : undefined,
         },
         configuration: {
-          predefinedAmounts: data.predefinedAmounts
-            .split(",")
-            .map(Number)
-            .filter(Boolean),
+          predefinedAmounts: data.predefinedAmounts.split(',').map(Number).filter(Boolean),
           allowCustomAmount: data.allowCustomAmount,
           minCustomAmount: Number(data.minCustomAmount),
           maxCustomAmount: Number(data.maxCustomAmount),
-          suggestedAmounts: data.suggestedAmounts
-            .split(",")
-            .map(Number)
-            .filter(Boolean),
+          suggestedAmounts: data.suggestedAmounts.split(',').map(Number).filter(Boolean),
           enableRecurring: data.enableRecurring,
           recurringIntervals: data.recurringIntervals
-            .split(",")
+            .split(',')
             .map((t: string) => t.trim())
             .filter(Boolean),
           defaultRecurringInterval: data.defaultRecurringInterval,
@@ -1527,18 +1584,18 @@ const CampaignManagement = ({
           showDonorCount: data.showDonorCount,
           showRecentDonations: data.showRecentDonations,
           maxRecentDonations: Number(data.maxRecentDonations),
-          primaryCTAText: data.primaryCTAText || "",
+          primaryCTAText: data.primaryCTAText || '',
           secondaryCTAText: data.secondaryCTAText || undefined,
           urgencyMessage: data.urgencyMessage || undefined,
           accentColor: data.accentColor || undefined,
           backgroundImage: data.backgroundImage || undefined,
-          theme: data.theme || "default",
+          theme: data.theme || 'default',
           requiredFields: data.requiredFields
-            .split(",")
+            .split(',')
             .map((t: string) => t.trim())
             .filter(Boolean),
           optionalFields: data.optionalFields
-            .split(",")
+            .split(',')
             .map((t: string) => t.trim())
             .filter(Boolean),
           enableAnonymousDonations: data.enableAnonymousDonations,
@@ -1549,50 +1606,43 @@ const CampaignManagement = ({
         },
       };
 
-      if (data.startDate)
-        dataToSave.startDate = Timestamp.fromDate(new Date(data.startDate));
-      if (data.endDate)
-        dataToSave.endDate = Timestamp.fromDate(new Date(data.endDate));
+      if (data.startDate) dataToSave.startDate = Timestamp.fromDate(new Date(data.startDate));
+      if (data.endDate) dataToSave.endDate = Timestamp.fromDate(new Date(data.endDate));
 
       const finalDataToSave = removeUndefined(dataToSave);
 
       let savedCampaignId = campaignId;
-      
+
       if (isNew) {
         const newCampaign = await createWithImage(finalDataToSave);
         savedCampaignId = newCampaign.id;
-        
+
         try {
           await syncKiosksForCampaign(
             newCampaign.id,
             normalizeAssignments(data.assignedKiosks),
-            []
+            [],
           );
         } catch (syncError) {
-          console.error("Kiosk sync failed after campaign create (campaign was saved):", syncError);
+          console.error('Kiosk sync failed after campaign create (campaign was saved):', syncError);
         }
       } else if (campaignId) {
         await updateWithImage(campaignId, finalDataToSave);
-        
+
         const oldAssignedKiosks = normalizeAssignments(editingCampaign?.assignedKiosks);
         try {
           await syncKiosksForCampaign(
             campaignId,
             normalizeAssignments(data.assignedKiosks),
-            oldAssignedKiosks
+            oldAssignedKiosks,
           );
         } catch (syncError) {
-          console.error("Kiosk sync failed after campaign update (campaign was saved):", syncError);
+          console.error('Kiosk sync failed after campaign update (campaign was saved):', syncError);
         }
       }
     } catch (error) {
-      console.error(
-        isNew ? "Error creating campaign: " : "Error updating document: ",
-        error
-      );
-      alert(
-        `Failed to ${isNew ? "create" : "update"} campaign. Please try again.`
-      );
+      console.error(isNew ? 'Error creating campaign: ' : 'Error updating document: ', error);
+      alert(`Failed to ${isNew ? 'create' : 'update'} campaign. Please try again.`);
     } finally {
       setIsEditDialogOpen(false);
       setIsAddDialogOpen(false);
@@ -1604,7 +1654,9 @@ const CampaignManagement = ({
   const handleNewCampaignFormSubmit = async () => {
     // Hard guard: prevent re-entry while submission is in progress
     if (isSubmittingNewCampaign) {
-      console.warn('[CampaignManagement] Submission already in progress, ignoring duplicate request');
+      console.warn(
+        '[CampaignManagement] Submission already in progress, ignoring duplicate request',
+      );
       return;
     }
 
@@ -1612,63 +1664,65 @@ const CampaignManagement = ({
     if (newCampaignFormData.startDate && newCampaignFormData.endDate) {
       const startDate = new Date(newCampaignFormData.startDate);
       const endDate = new Date(newCampaignFormData.endDate);
-      
+
       if (endDate <= startDate) {
         setNewCampaignDateError(true);
         return;
       }
     }
-    
+
     // Clear date error if validation passes
     setNewCampaignDateError(false);
 
     setIsSubmittingNewCampaign(true);
-    
+
     try {
       let coverImageUrl = newCampaignFormData.coverImageUrl;
-      
+
       // Upload cover image file if one was selected
       if (selectedNewCampaignImageFile) {
         const uploadedUrl = await uploadFile(
           selectedNewCampaignImageFile,
-          `campaigns/new/${Date.now()}_${selectedNewCampaignImageFile.name}`
+          `campaigns/new/${Date.now()}_${selectedNewCampaignImageFile.name}`,
         );
         if (uploadedUrl) {
           coverImageUrl = uploadedUrl;
         }
       }
-      
+
       // Upload gallery images if any were selected
       const galleryImageUrls = [...newCampaignFormData.galleryImages];
       if (selectedNewCampaignGalleryFiles.length > 0) {
         for (const file of selectedNewCampaignGalleryFiles) {
           const uploadedUrl = await uploadFile(
             file,
-            `campaigns/new/gallery/${Date.now()}_${file.name}`
+            `campaigns/new/gallery/${Date.now()}_${file.name}`,
           );
           if (uploadedUrl) {
             galleryImageUrls.push(uploadedUrl);
           }
         }
       }
-      
+
       const dataToSave: { [key: string]: any } = {
         title: newCampaignFormData.title,
         description: newCampaignFormData.briefOverview,
         longDescription: newCampaignFormData.description,
         status: newCampaignFormData.status,
         goal: Number(newCampaignFormData.goal),
-        tags: Array.isArray(newCampaignFormData.tags) ? newCampaignFormData.tags.filter(t => t.trim().length > 0) : [],
-        coverImageUrl: coverImageUrl || "",
-        videoUrl: newCampaignFormData.videoUrl || "",
+        tags: Array.isArray(newCampaignFormData.tags)
+          ? newCampaignFormData.tags.filter((t) => t.trim().length > 0)
+          : [],
+        coverImageUrl: coverImageUrl || '',
+        videoUrl: newCampaignFormData.videoUrl || '',
         galleryImages: galleryImageUrls,
-        category: newCampaignFormData.category || "",
-        organizationId: userSession.user.organizationId || "",
+        category: newCampaignFormData.category || '',
+        organizationId: userSession.user.organizationId || '',
         assignedKiosks: normalizeAssignments(newCampaignFormData.assignedKiosks),
         isGlobal: newCampaignFormData.isGlobal,
         configuration: {
           ...DEFAULT_CAMPAIGN_CONFIG,
-          predefinedAmounts: newCampaignFormData.predefinedAmounts.filter(a => a > 0),
+          predefinedAmounts: newCampaignFormData.predefinedAmounts.filter((a) => a > 0),
           enableRecurring: newCampaignFormData.enableRecurring,
           recurringIntervals: newCampaignFormData.recurringIntervals,
           giftAidEnabled: newCampaignFormData.giftAidEnabled,
@@ -1684,13 +1738,17 @@ const CampaignManagement = ({
 
       const finalDataToSave = removeUndefined(dataToSave);
       const newCampaign = await createWithImage(finalDataToSave);
-      
+
       try {
-        await syncKiosksForCampaign(newCampaign.id, normalizeAssignments(newCampaignFormData.assignedKiosks), []);
+        await syncKiosksForCampaign(
+          newCampaign.id,
+          normalizeAssignments(newCampaignFormData.assignedKiosks),
+          [],
+        );
       } catch (syncError) {
-        console.error("Kiosk sync failed after campaign create (campaign was saved):", syncError);
+        console.error('Kiosk sync failed after campaign create (campaign was saved):', syncError);
       }
-      
+
       // Reset form and close
       refreshAll();
       setIsNewCampaignFormOpen(false);
@@ -1714,23 +1772,26 @@ const CampaignManagement = ({
         tags: [],
         isGlobal: false,
         assignedKiosks: [],
-        giftAidEnabled: false
+        giftAidEnabled: false,
       });
     } catch (error) {
-      console.error("Error creating campaign:", error);
-      
+      console.error('Error creating campaign:', error);
+
       // Extract error message
-      let errorMessage = "Failed to create campaign. Please try again.";
+      let errorMessage = 'Failed to create campaign. Please try again.';
       if (error instanceof Error) {
-        if (error.message.includes("storage/unauthorized") || error.message.includes("permission")) {
-          errorMessage = "Insufficient storage permissions. Failed to create campaign.";
-        } else if (error.message.includes("storage")) {
-          errorMessage = "Storage error occurred. Failed to create campaign.";
+        if (
+          error.message.includes('storage/unauthorized') ||
+          error.message.includes('permission')
+        ) {
+          errorMessage = 'Insufficient storage permissions. Failed to create campaign.';
+        } else if (error.message.includes('storage')) {
+          errorMessage = 'Storage error occurred. Failed to create campaign.';
         } else {
           errorMessage = error.message;
         }
       }
-      
+
       setErrorDialogMessage(errorMessage);
       setErrorDialogOpen(true);
     } finally {
@@ -1760,64 +1821,68 @@ const CampaignManagement = ({
       tags: [],
       isGlobal: false,
       assignedKiosks: [],
-      giftAidEnabled: false
+      giftAidEnabled: false,
     });
   };
 
   const handleNewCampaignFormSaveDraft = async () => {
     // Hard guard: prevent re-entry while saving draft
     if (isSavingNewDraft) {
-      console.warn('[CampaignManagement] Draft save already in progress, ignoring duplicate request');
+      console.warn(
+        '[CampaignManagement] Draft save already in progress, ignoring duplicate request',
+      );
       return;
     }
 
     setIsSavingNewDraft(true);
-    
+
     try {
       let coverImageUrl = newCampaignFormData.coverImageUrl;
-      
+
       // Upload cover image file if one was selected
       if (selectedNewCampaignImageFile) {
         const uploadedUrl = await uploadFile(
           selectedNewCampaignImageFile,
-          `campaigns/new/${Date.now()}_${selectedNewCampaignImageFile.name}`
+          `campaigns/new/${Date.now()}_${selectedNewCampaignImageFile.name}`,
         );
         if (uploadedUrl) {
           coverImageUrl = uploadedUrl;
         }
       }
-      
+
       // Upload gallery images if any were selected
       const galleryImageUrls = [...newCampaignFormData.galleryImages];
       if (selectedNewCampaignGalleryFiles.length > 0) {
         for (const file of selectedNewCampaignGalleryFiles) {
           const uploadedUrl = await uploadFile(
             file,
-            `campaigns/new/gallery/${Date.now()}_${file.name}`
+            `campaigns/new/gallery/${Date.now()}_${file.name}`,
           );
           if (uploadedUrl) {
             galleryImageUrls.push(uploadedUrl);
           }
         }
       }
-      
+
       const dataToSave: { [key: string]: any } = {
         title: newCampaignFormData.title,
         description: newCampaignFormData.briefOverview,
         longDescription: newCampaignFormData.description,
         status: 'paused',
         goal: Number(newCampaignFormData.goal),
-        tags: Array.isArray(newCampaignFormData.tags) ? newCampaignFormData.tags.filter(t => t.trim().length > 0) : [],
-        coverImageUrl: coverImageUrl || "",
-        videoUrl: newCampaignFormData.videoUrl || "",
+        tags: Array.isArray(newCampaignFormData.tags)
+          ? newCampaignFormData.tags.filter((t) => t.trim().length > 0)
+          : [],
+        coverImageUrl: coverImageUrl || '',
+        videoUrl: newCampaignFormData.videoUrl || '',
         galleryImages: galleryImageUrls,
-        category: newCampaignFormData.category || "",
-        organizationId: userSession.user.organizationId || "",
+        category: newCampaignFormData.category || '',
+        organizationId: userSession.user.organizationId || '',
         assignedKiosks: normalizeAssignments(newCampaignFormData.assignedKiosks),
         isGlobal: newCampaignFormData.isGlobal,
         configuration: {
           ...DEFAULT_CAMPAIGN_CONFIG,
-          predefinedAmounts: newCampaignFormData.predefinedAmounts.filter(a => a > 0),
+          predefinedAmounts: newCampaignFormData.predefinedAmounts.filter((a) => a > 0),
           enableRecurring: newCampaignFormData.enableRecurring,
           recurringIntervals: newCampaignFormData.recurringIntervals,
           giftAidEnabled: newCampaignFormData.giftAidEnabled,
@@ -1833,13 +1898,17 @@ const CampaignManagement = ({
 
       const finalDataToSave = removeUndefined(dataToSave);
       const newCampaign = await createWithImage(finalDataToSave);
-      
+
       try {
-        await syncKiosksForCampaign(newCampaign.id, normalizeAssignments(newCampaignFormData.assignedKiosks), []);
+        await syncKiosksForCampaign(
+          newCampaign.id,
+          normalizeAssignments(newCampaignFormData.assignedKiosks),
+          [],
+        );
       } catch (syncError) {
-        console.error("Kiosk sync failed after draft create (campaign was saved):", syncError);
+        console.error('Kiosk sync failed after draft create (campaign was saved):', syncError);
       }
-      
+
       // Reset form and close
       refreshAll();
       setIsNewCampaignFormOpen(false);
@@ -1863,11 +1932,11 @@ const CampaignManagement = ({
         tags: [],
         isGlobal: false,
         assignedKiosks: [],
-        giftAidEnabled: false
+        giftAidEnabled: false,
       });
     } catch (error) {
-      console.error("Error saving campaign draft:", error);
-      alert("Failed to save campaign draft. Please try again.");
+      console.error('Error saving campaign draft:', error);
+      alert('Failed to save campaign draft. Please try again.');
     } finally {
       setIsSavingNewDraft(false);
     }
@@ -1878,57 +1947,61 @@ const CampaignManagement = ({
 
     // Hard guard: prevent re-entry while saving draft
     if (isSavingEditDraft) {
-      console.warn('[CampaignManagement] Edit draft save already in progress, ignoring duplicate request');
+      console.warn(
+        '[CampaignManagement] Edit draft save already in progress, ignoring duplicate request',
+      );
       return;
     }
 
     setIsSavingEditDraft(true);
-    
+
     try {
       let coverImageUrl = editCampaignFormData.coverImageUrl;
-      
+
       // Upload cover image file if one was selected
       if (selectedEditCampaignImageFile) {
         const uploadedUrl = await uploadFile(
           selectedEditCampaignImageFile,
-          `campaigns/${editingCampaignForNewForm.id}/${Date.now()}_${selectedEditCampaignImageFile.name}`
+          `campaigns/${editingCampaignForNewForm.id}/${Date.now()}_${selectedEditCampaignImageFile.name}`,
         );
         if (uploadedUrl) {
           coverImageUrl = uploadedUrl;
         }
       }
-      
+
       // Upload gallery images if any were selected
       const galleryImageUrls = [...editCampaignFormData.galleryImages];
       if (selectedEditCampaignGalleryFiles.length > 0) {
         for (const file of selectedEditCampaignGalleryFiles) {
           const uploadedUrl = await uploadFile(
             file,
-            `campaigns/${editingCampaignForNewForm.id}/gallery/${Date.now()}_${file.name}`
+            `campaigns/${editingCampaignForNewForm.id}/gallery/${Date.now()}_${file.name}`,
           );
           if (uploadedUrl) {
             galleryImageUrls.push(uploadedUrl);
           }
         }
       }
-      
+
       const dataToSave: { [key: string]: any } = {
         title: editCampaignFormData.title,
         description: editCampaignFormData.briefOverview,
         longDescription: editCampaignFormData.description,
         status: editCampaignFormData.status || editingCampaignForNewForm.status || 'paused',
         goal: Number(editCampaignFormData.goal),
-        tags: Array.isArray(editCampaignFormData.tags) ? editCampaignFormData.tags.filter(t => t.trim().length > 0) : [],
-        coverImageUrl: coverImageUrl || "",
-        videoUrl: editCampaignFormData.videoUrl || "",
+        tags: Array.isArray(editCampaignFormData.tags)
+          ? editCampaignFormData.tags.filter((t) => t.trim().length > 0)
+          : [],
+        coverImageUrl: coverImageUrl || '',
+        videoUrl: editCampaignFormData.videoUrl || '',
         galleryImages: galleryImageUrls,
-        category: editCampaignFormData.category || "",
+        category: editCampaignFormData.category || '',
         assignedKiosks: normalizeAssignments(editCampaignFormData.assignedKiosks),
         isGlobal: editCampaignFormData.isGlobal,
         configuration: {
           ...DEFAULT_CAMPAIGN_CONFIG,
           ...(editingCampaignForNewForm.configuration || {}),
-          predefinedAmounts: editCampaignFormData.predefinedAmounts.filter(a => a > 0),
+          predefinedAmounts: editCampaignFormData.predefinedAmounts.filter((a) => a > 0),
           enableRecurring: editCampaignFormData.enableRecurring,
           recurringIntervals: editCampaignFormData.recurringIntervals,
           giftAidEnabled: editCampaignFormData.giftAidEnabled,
@@ -1944,17 +2017,17 @@ const CampaignManagement = ({
 
       const finalDataToSave = removeUndefined(dataToSave);
       await updateWithImage(editingCampaignForNewForm.id, finalDataToSave);
-      
+
       try {
         await syncKiosksForCampaign(
           editingCampaignForNewForm.id,
           normalizeAssignments(editCampaignFormData.assignedKiosks),
-          normalizeAssignments(editingCampaignForNewForm.assignedKiosks)
+          normalizeAssignments(editingCampaignForNewForm.assignedKiosks),
         );
       } catch (syncError) {
-        console.error("Kiosk sync failed after draft update (campaign was saved):", syncError);
+        console.error('Kiosk sync failed after draft update (campaign was saved):', syncError);
       }
-      
+
       // Reset form and close
       refreshAll();
       setIsEditCampaignFormOpen(false);
@@ -1979,11 +2052,11 @@ const CampaignManagement = ({
         tags: [],
         isGlobal: false,
         assignedKiosks: [],
-        giftAidEnabled: false
+        giftAidEnabled: false,
       });
     } catch (error) {
-      console.error("Error saving campaign draft:", error);
-      alert("Failed to save campaign draft. Please try again.");
+      console.error('Error saving campaign draft:', error);
+      alert('Failed to save campaign draft. Please try again.');
     } finally {
       setIsSavingEditDraft(false);
     }
@@ -1994,7 +2067,9 @@ const CampaignManagement = ({
 
     // Hard guard: prevent re-entry while submission is in progress
     if (isSubmittingEditCampaign) {
-      console.warn('[CampaignManagement] Edit submission already in progress, ignoring duplicate request');
+      console.warn(
+        '[CampaignManagement] Edit submission already in progress, ignoring duplicate request',
+      );
       return;
     }
 
@@ -2002,63 +2077,65 @@ const CampaignManagement = ({
     if (editCampaignFormData.startDate && editCampaignFormData.endDate) {
       const startDate = new Date(editCampaignFormData.startDate);
       const endDate = new Date(editCampaignFormData.endDate);
-      
+
       if (endDate <= startDate) {
         setEditCampaignDateError(true);
         return;
       }
     }
-    
+
     // Clear date error if validation passes
     setEditCampaignDateError(false);
 
     setIsSubmittingEditCampaign(true);
-    
+
     try {
       let coverImageUrl = editCampaignFormData.coverImageUrl;
-      
+
       // Upload cover image file if one was selected
       if (selectedEditCampaignImageFile) {
         const uploadedUrl = await uploadFile(
           selectedEditCampaignImageFile,
-          `campaigns/${editingCampaignForNewForm.id}/${Date.now()}_${selectedEditCampaignImageFile.name}`
+          `campaigns/${editingCampaignForNewForm.id}/${Date.now()}_${selectedEditCampaignImageFile.name}`,
         );
         if (uploadedUrl) {
           coverImageUrl = uploadedUrl;
         }
       }
-      
+
       // Upload gallery images if any were selected
       const galleryImageUrls = [...editCampaignFormData.galleryImages];
       if (selectedEditCampaignGalleryFiles.length > 0) {
         for (const file of selectedEditCampaignGalleryFiles) {
           const uploadedUrl = await uploadFile(
             file,
-            `campaigns/${editingCampaignForNewForm.id}/gallery/${Date.now()}_${file.name}`
+            `campaigns/${editingCampaignForNewForm.id}/gallery/${Date.now()}_${file.name}`,
           );
           if (uploadedUrl) {
             galleryImageUrls.push(uploadedUrl);
           }
         }
       }
-      
+
       const dataToSave: { [key: string]: any } = {
         title: editCampaignFormData.title,
         description: editCampaignFormData.briefOverview,
         longDescription: editCampaignFormData.description,
         status: editCampaignFormData.status,
         goal: Number(editCampaignFormData.goal),
-        tags: Array.isArray(editCampaignFormData.tags) ? editCampaignFormData.tags.filter(t => t.trim().length > 0) : [],
-        coverImageUrl: coverImageUrl || "",
-        videoUrl: editCampaignFormData.videoUrl || "",
+        tags: Array.isArray(editCampaignFormData.tags)
+          ? editCampaignFormData.tags.filter((t) => t.trim().length > 0)
+          : [],
+        coverImageUrl: coverImageUrl || '',
+        videoUrl: editCampaignFormData.videoUrl || '',
         galleryImages: galleryImageUrls,
-        category: editCampaignFormData.category || "",
+        category: editCampaignFormData.category || '',
         assignedKiosks: normalizeAssignments(editCampaignFormData.assignedKiosks),
         isGlobal: editCampaignFormData.isGlobal,
         configuration: {
           ...DEFAULT_CAMPAIGN_CONFIG,
           ...(editingCampaignForNewForm.configuration || {}),
-          predefinedAmounts: editCampaignFormData.predefinedAmounts.filter(a => a > 0),
+          predefinedAmounts: editCampaignFormData.predefinedAmounts.filter((a) => a > 0),
           enableRecurring: editCampaignFormData.enableRecurring,
           recurringIntervals: editCampaignFormData.recurringIntervals,
           giftAidEnabled: editCampaignFormData.giftAidEnabled,
@@ -2074,17 +2151,17 @@ const CampaignManagement = ({
 
       const finalDataToSave = removeUndefined(dataToSave);
       await updateWithImage(editingCampaignForNewForm.id, finalDataToSave);
-    
+
       try {
         await syncKiosksForCampaign(
           editingCampaignForNewForm.id,
           normalizeAssignments(editCampaignFormData.assignedKiosks),
-          normalizeAssignments(editingCampaignForNewForm.assignedKiosks)
+          normalizeAssignments(editingCampaignForNewForm.assignedKiosks),
         );
       } catch (syncError) {
-        console.error("Kiosk sync failed after campaign update (campaign was saved):", syncError);
+        console.error('Kiosk sync failed after campaign update (campaign was saved):', syncError);
       }
-  
+
       // Reset form and close
       refreshAll();
       setIsEditCampaignFormOpen(false);
@@ -2109,10 +2186,10 @@ const CampaignManagement = ({
         tags: [],
         isGlobal: false,
         assignedKiosks: [],
-        giftAidEnabled: false
+        giftAidEnabled: false,
       });
     } catch (error) {
-      console.error("Error updating campaign:", error);
+      console.error('Error updating campaign:', error);
       const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
       alert(`Failed to update campaign: ${errorMessage}`);
     } finally {
@@ -2143,49 +2220,49 @@ const CampaignManagement = ({
       tags: [],
       isGlobal: false,
       assignedKiosks: [],
-      giftAidEnabled: false
+      giftAidEnabled: false,
     });
   };
 
   const getStatusColor = (status: string) => {
     switch (status.toLowerCase()) {
-      case "active":
-        return "bg-green-100 text-green-800";
-      case "paused":
-        return "bg-yellow-100 text-yellow-800";
-      case "completed":
-        return "bg-blue-100 text-blue-800";
-      case "draft":
-        return "bg-slate-100 text-slate-700";
+      case 'active':
+        return 'bg-green-100 text-green-800';
+      case 'paused':
+        return 'bg-yellow-100 text-yellow-800';
+      case 'completed':
+        return 'bg-blue-100 text-blue-800';
+      case 'draft':
+        return 'bg-slate-100 text-slate-700';
       default:
-        return "bg-gray-100 text-gray-800";
+        return 'bg-gray-100 text-gray-800';
     }
   };
 
   const getProgressColor = (progress: number) => {
-    if (progress >= 85) return "bg-emerald-700";
-    if (progress >= 60) return "bg-emerald-600";
-    return "bg-emerald-500";
+    if (progress >= 85) return 'bg-emerald-700';
+    if (progress >= 60) return 'bg-emerald-600';
+    return 'bg-emerald-500';
   };
 
   const uniqueCategories: string[] = Array.from(
     new Set(
       (campaigns as any[])
         .map((c) => (typeof c.category === 'string' ? c.category : ''))
-        .filter((v): v is string => Boolean(v))
-    )
+        .filter((v): v is string => Boolean(v)),
+    ),
   );
 
   const totalCampaigns = campaigns.length;
-  const activeCampaigns = campaigns.filter((campaign: any) => campaign.status === "active").length;
+  const activeCampaigns = campaigns.filter((campaign: any) => campaign.status === 'active').length;
   const totalRaised = campaigns.reduce(
     (sum: number, campaign: any) => sum + (Number(campaign.raised) || 0),
-    0
+    0,
   );
   const progressValues = campaigns
     .filter((campaign: any) => campaign.goal && campaign.raised)
     .map((campaign: any) =>
-      Math.min(((Number(campaign.raised) / 100) / Number(campaign.goal)) * 100, 100)
+      Math.min((Number(campaign.raised) / 100 / Number(campaign.goal)) * 100, 100),
     );
   const averageProgress =
     progressValues.length > 0
@@ -2198,19 +2275,19 @@ const CampaignManagement = ({
       : 0;
   const progressStatus =
     averageProgress >= 70
-      ? { label: "On Track", className: "bg-emerald-100 text-emerald-700" }
+      ? { label: 'On Track', className: 'bg-emerald-100 text-emerald-700' }
       : averageProgress >= 45
-      ? { label: "Needs Attention", className: "bg-amber-100 text-amber-700" }
-      : { label: "At Risk", className: "bg-red-100 text-red-700" };
+        ? { label: 'Needs Attention', className: 'bg-amber-100 text-amber-700' }
+        : { label: 'At Risk', className: 'bg-red-100 text-red-700' };
 
   const getDateRangeStart = (range: string) => {
     const today = new Date();
     switch (range) {
-      case "last30":
+      case 'last30':
         return new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000);
-      case "last90":
+      case 'last90':
         return new Date(today.getTime() - 90 * 24 * 60 * 60 * 1000);
-      case "last365":
+      case 'last365':
         return new Date(today.getTime() - 365 * 24 * 60 * 60 * 1000);
       default:
         return null;
@@ -2222,35 +2299,35 @@ const CampaignManagement = ({
   const searchFilterConfig: AdminSearchFilterConfig = {
     filters: [
       {
-        key: "statusFilter",
-        label: "Status",
-        type: "select",
+        key: 'statusFilter',
+        label: 'Status',
+        type: 'select',
         options: [
-          { label: "Active", value: "active" },
-          { label: "Paused", value: "paused" },
-          { label: "Completed", value: "completed" },
-          { label: "Draft", value: "draft" },
+          { label: 'Active', value: 'active' },
+          { label: 'Paused', value: 'paused' },
+          { label: 'Completed', value: 'completed' },
+          { label: 'Draft', value: 'draft' },
         ],
       },
       {
-        key: "categoryFilter",
-        label: "Category",
-        type: "select",
+        key: 'categoryFilter',
+        label: 'Category',
+        type: 'select',
         options: uniqueCategories.map((category) => ({
           label: category,
           value: category,
         })),
       },
       {
-        key: "dateRange",
-        label: "Date Range",
-        type: "select",
+        key: 'dateRange',
+        label: 'Date Range',
+        type: 'select',
         includeAllOption: false,
         options: [
-          { label: "All time", value: "all" },
-          { label: "Last 30 Days", value: "last30" },
-          { label: "Last 90 Days", value: "last90" },
-          { label: "Last 12 Months", value: "last365" },
+          { label: 'All time', value: 'all' },
+          { label: 'Last 30 Days', value: 'last30' },
+          { label: 'Last 90 Days', value: 'last90' },
+          { label: 'Last 12 Months', value: 'last365' },
         ],
       },
     ],
@@ -2264,13 +2341,13 @@ const CampaignManagement = ({
 
   const handleFilterChange = (key: string, value: any) => {
     switch (key) {
-      case "statusFilter":
+      case 'statusFilter':
         setStatusFilter(value);
         break;
-      case "categoryFilter":
+      case 'categoryFilter':
         setCategoryFilter(value);
         break;
-      case "dateRange":
+      case 'dateRange':
         setDateRange(value);
         break;
     }
@@ -2278,25 +2355,54 @@ const CampaignManagement = ({
 
   // Client-side search, status, category, and date filters on current page
   const filteredCampaigns = campaigns.filter((campaign: any) => {
-    const matchesSearch = !searchTerm ||
+    const matchesSearch =
+      !searchTerm ||
       campaign.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
       campaign.description?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      (Array.isArray(campaign.tags) && campaign.tags.some((tag: string) => tag.toLowerCase().includes(searchTerm.toLowerCase())));
-    const matchesStatus = statusFilter === "all" || campaign.status === statusFilter;
-    const matchesCategory = categoryFilter === "all" || campaign.category === categoryFilter;
+      (Array.isArray(campaign.tags) &&
+        campaign.tags.some((tag: string) => tag.toLowerCase().includes(searchTerm.toLowerCase())));
+    const matchesStatus = statusFilter === 'all' || campaign.status === statusFilter;
+    const matchesCategory = categoryFilter === 'all' || campaign.category === categoryFilter;
     const campaignEndDate = campaign.endDate?.seconds
       ? new Date(campaign.endDate.seconds * 1000)
       : campaign.endDate
-      ? new Date(campaign.endDate)
-      : null;
+        ? new Date(campaign.endDate)
+        : null;
     const matchesDate = !dateRangeStart || !campaignEndDate || campaignEndDate >= dateRangeStart;
     return matchesSearch && matchesStatus && matchesCategory && matchesDate;
   });
 
   // Use sorting hook
-  const { sortedData: filteredAndSortedCampaigns, sortKey, sortDirection, handleSort } = useTableSort({
-    data: filteredCampaigns
+  const {
+    sortedData: filteredAndSortedCampaigns,
+    sortKey,
+    sortDirection,
+    handleSort,
+  } = useTableSort({
+    data: filteredCampaigns,
   });
+
+  const handleExportCampaigns = async () => {
+    if (!userSession.user.organizationId) {
+      showToast('Organization ID is required to export campaigns.', 'warning');
+      return;
+    }
+
+    setIsExporting(true);
+    try {
+      await exportCampaigns({
+        organizationId: userSession.user.organizationId,
+      });
+      showToast('Campaign export started. Your download should begin shortly.', 'success');
+    } catch (exportError) {
+      console.error('Campaign export failed:', exportError);
+      const message =
+        exportError instanceof Error ? exportError.message : 'Failed to export campaigns.';
+      showToast(message, 'error');
+    } finally {
+      setIsExporting(false);
+    }
+  };
 
   return (
     <AdminLayout
@@ -2305,7 +2411,7 @@ const CampaignManagement = ({
       userSession={userSession}
       hasPermission={hasPermission}
       activeScreen="admin-campaigns"
-      headerTitle={(
+      headerTitle={
         <div className="flex flex-col">
           {userSession.user.organizationName && (
             <div className="flex items-center gap-1.5 mb-1">
@@ -2315,26 +2421,25 @@ const CampaignManagement = ({
               </span>
             </div>
           )}
-          <h1 className="text-2xl font-semibold text-slate-800 tracking-tight">
-            Campaigns
-          </h1>
+          <h1 className="text-2xl font-semibold text-slate-800 tracking-tight">Campaigns</h1>
         </div>
-      )}
+      }
       headerSubtitle="Manage your donation campaigns"
       headerSearchPlaceholder="Search campaigns..."
       headerSearchValue={searchTerm}
       onHeaderSearchChange={setSearchTerm}
-      headerTopRightActions={(
+      headerTopRightActions={
         <Button
           variant="outline"
           size="sm"
           className="rounded-2xl border-[#064e3b] bg-transparent text-[#064e3b] hover:bg-emerald-50 hover:border-emerald-600 hover:shadow-md hover:shadow-emerald-900/10 hover:scale-105 transition-all duration-300 px-5"
-          onClick={() => exportToCsv(filteredAndSortedCampaigns, "campaigns")}
+          onClick={handleExportCampaigns}
+          disabled={isExporting}
         >
           <Download className="h-4 w-4 sm:hidden" />
-          <span className="hidden sm:inline">Export</span>
+          <span className="hidden sm:inline">{isExporting ? 'Exporting...' : 'Export'}</span>
         </Button>
-      )}
+      }
       headerInlineActions={
         hasPermission('create_campaign') ? (
           <Button
@@ -2359,10 +2464,16 @@ const CampaignManagement = ({
                     <Rocket className="h-6 w-6" />
                   </div>
                   <div>
-                    <p className="text-xs uppercase tracking-widest text-gray-400">Total active campaigns</p>
+                    <p className="text-xs uppercase tracking-widest text-gray-400">
+                      Total active campaigns
+                    </p>
                     <div className="mt-2 flex items-center gap-3">
-                      <span className="text-2xl font-semibold text-gray-900">{activeCampaigns}</span>
-                      <span className="text-xs font-semibold text-emerald-600">+{activeDelta}%</span>
+                      <span className="text-2xl font-semibold text-gray-900">
+                        {activeCampaigns}
+                      </span>
+                      <span className="text-xs font-semibold text-emerald-600">
+                        +{activeDelta}%
+                      </span>
                     </div>
                   </div>
                 </CardContent>
@@ -2374,10 +2485,16 @@ const CampaignManagement = ({
                     <Wallet className="h-6 w-6" />
                   </div>
                   <div>
-                    <p className="text-xs uppercase tracking-widest text-gray-400">Funds raised this month</p>
+                    <p className="text-xs uppercase tracking-widest text-gray-400">
+                      Funds raised this month
+                    </p>
                     <div className="mt-2 flex items-center gap-3">
-                      <span className="text-2xl font-semibold text-gray-900">{formatCurrency(totalRaised)}</span>
-                      <span className="text-xs font-semibold text-emerald-600">+{raisedDelta}%</span>
+                      <span className="text-2xl font-semibold text-gray-900">
+                        {formatCurrency(totalRaised)}
+                      </span>
+                      <span className="text-xs font-semibold text-emerald-600">
+                        +{raisedDelta}%
+                      </span>
                     </div>
                   </div>
                 </CardContent>
@@ -2389,10 +2506,16 @@ const CampaignManagement = ({
                     <TrendingUp className="h-6 w-6" />
                   </div>
                   <div>
-                    <p className="text-xs uppercase tracking-widest text-gray-400">Average progress</p>
+                    <p className="text-xs uppercase tracking-widest text-gray-400">
+                      Average progress
+                    </p>
                     <div className="mt-2 flex items-center gap-3">
-                      <span className="text-2xl font-semibold text-gray-900">{averageProgress}%</span>
-                      <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${progressStatus.className}`}>
+                      <span className="text-2xl font-semibold text-gray-900">
+                        {averageProgress}%
+                      </span>
+                      <span
+                        className={`text-xs font-semibold px-2 py-0.5 rounded-full ${progressStatus.className}`}
+                      >
                         {progressStatus.label}
                       </span>
                     </div>
@@ -2410,8 +2533,8 @@ const CampaignManagement = ({
                   <Button
                     variant="outline"
                     size="icon"
-                    className={`h-9 w-9 rounded-xl border-gray-200 ${viewMode === "table" ? "bg-emerald-50 text-emerald-700" : "bg-white text-gray-500"}`}
-                    onClick={() => setViewMode("table")}
+                    className={`h-9 w-9 rounded-xl border-gray-200 ${viewMode === 'table' ? 'bg-emerald-50 text-emerald-700' : 'bg-white text-gray-500'}`}
+                    onClick={() => setViewMode('table')}
                     aria-label="Table view"
                   >
                     <List className="h-4 w-4" />
@@ -2419,8 +2542,8 @@ const CampaignManagement = ({
                   <Button
                     variant="outline"
                     size="icon"
-                    className={`h-9 w-9 rounded-xl border-gray-200 ${viewMode === "grid" ? "bg-emerald-50 text-emerald-700" : "bg-white text-gray-500"}`}
-                    onClick={() => setViewMode("grid")}
+                    className={`h-9 w-9 rounded-xl border-gray-200 ${viewMode === 'grid' ? 'bg-emerald-50 text-emerald-700' : 'bg-white text-gray-500'}`}
+                    onClick={() => setViewMode('grid')}
                     aria-label="Grid view"
                   >
                     <LayoutGrid className="h-4 w-4" />
@@ -2430,344 +2553,361 @@ const CampaignManagement = ({
             />
             {/* Campaigns Table/List */}
             <Card className="overflow-hidden rounded-3xl border border-gray-100 shadow-sm mt-6">
-            <CardContent className="p-0">
-              {loading ? (
-                <div className="space-y-4 p-6">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <div key={i} className="grid grid-cols-6 gap-4 py-4 border-b border-gray-200">
-                      <Skeleton className="h-10 w-full col-span-2" />
-                      <Skeleton className="h-10 w-full col-span-1" />
-                      <Skeleton className="h-10 w-full col-span-1" />
-                      <Skeleton className="h-10 w-full col-span-1" />
-                      <Skeleton className="h-10 w-full col-span-1" />
-                    </div>
-                  ))}
-                </div>
-              ) : filteredAndSortedCampaigns.length > 0 ? (
-                <>
-                  {/* Card View (mobile default, optional desktop) */}
-                  <div
-                    className={`p-4 ${
-                      viewMode === "grid"
-                        ? "grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4"
-                        : "space-y-4 md:hidden"
-                    }`}
-                  >
-                    {filteredAndSortedCampaigns.map((campaign: any) => {
-                      const raisedAmount = Number(campaign.raised) || 0;
-                      const goalAmount = Number(campaign.goal) || 0;
-                      const donationCount = Number(campaign.donationCount) || 0;
-                      const progress =
-                        goalAmount > 0
-                          ? Math.min(((raisedAmount / 100) / goalAmount) * 100, 100)
-                          : 0;
-
-                      return (
-                        <div
-                          key={campaign.id ?? campaign.title}
-                          className="rounded-2xl border border-gray-100 bg-white p-4 shadow-sm"
-                        >
-                          <div className="flex items-start justify-between gap-3">
-                            <div
-                              className="flex items-center gap-3 cursor-pointer"
-                              onClick={() => handleOpenOverview(campaign as Campaign)}
-                              role="button"
-                              tabIndex={0}
-                              onKeyDown={(event) => {
-                                if (event.key === "Enter" || event.key === " ") {
-                                  event.preventDefault();
-                                  handleOpenOverview(campaign as Campaign);
-                                }
-                              }}
-                            >
-                              <ImageWithFallback
-                                src={campaign.coverImageUrl}
-                                alt={campaign.title}
-                                className="h-12 w-12 rounded-2xl border border-gray-200 object-cover bg-gray-100"
-                                fallbackSrc="/campaign-fallback.svg"
-                              />
-                              <div>
-                                <div className="text-sm font-semibold text-gray-900">
-                                  {campaign.title}
-                                </div>
-                              </div>
-                            </div>
-                            <DropdownMenu>
-                              <DropdownMenuTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-8 w-8 text-gray-500 hover:bg-gray-100"
-                                  aria-label="Campaign actions"
-                                  disabled={!hasPermission('edit_campaign') && !hasPermission('delete_campaign')}
-                                >
-                                  <MoreVertical className="h-4 w-4" />
-                                </Button>
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end">
-                                {hasPermission('edit_campaign') && (
-                                  <DropdownMenuItem
-                                    onSelect={() => handleEditClick(campaign)}
-                                    className="flex items-center gap-2"
-                                  >
-                                    <FaEdit className="h-4 w-4" />
-                                    Edit
-                                  </DropdownMenuItem>
-                                )}
-                                {hasPermission('delete_campaign') && (
-                                  <DropdownMenuItem
-                                    onSelect={() => handleDeleteClick(campaign)}
-                                    className="flex items-center gap-2 text-red-600 focus:text-red-600"
-                                  >
-                                    <FaTrashAlt className="h-4 w-4" />
-                                    Delete
-                                  </DropdownMenuItem>
-                                )}
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          </div>
-
-                          <div className="mt-3 flex flex-wrap items-center gap-2">
-                            <Badge
-                              className={`text-xs px-2 py-1 rounded-full inline-flex items-center gap-1 ${getStatusColor(
-                                campaign.status ?? "unknown"
-                              )}`}
-                            >
-                              <span className="h-1.5 w-1.5 rounded-full bg-current" />
-                              {campaign.status ?? "Unknown"}
-                            </Badge>
-                            {campaign.category && (
-                              <Badge variant="secondary" className="text-xs uppercase tracking-wide">
-                                {campaign.category}
-                              </Badge>
-                            )}
-                          </div>
-
-                          <div className="mt-4">
-                            <div className="flex items-center justify-between text-xs text-gray-500">
-                              <span>
-                                {formatCurrency(raisedAmount)} / {formatCurrencyFromMajor(goalAmount)}
-                              </span>
-                              <span>{progress.toFixed(0)}%</span>
-                            </div>
-                            <div className="mt-2 h-2 w-full rounded-full bg-gray-100 overflow-hidden">
-                              <div
-                                className={`h-full ${getProgressColor(progress)} transition-all duration-300`}
-                                style={{ width: `${progress}%` }}
-                              />
-                            </div>
-                          </div>
-
-                          <div className="mt-4 flex items-center justify-between text-xs text-gray-500">
-                            <span>Donors</span>
-                            <span className="text-sm font-semibold text-gray-900">
-                              {donationCount.toLocaleString()}
-                            </span>
-                          </div>
-                        </div>
-                      );
-                    })}
+              <CardContent className="p-0">
+                {loading ? (
+                  <div className="space-y-4 p-6">
+                    {Array.from({ length: 5 }).map((_, i) => (
+                      <div key={i} className="grid grid-cols-6 gap-4 py-4 border-b border-gray-200">
+                        <Skeleton className="h-10 w-full col-span-2" />
+                        <Skeleton className="h-10 w-full col-span-1" />
+                        <Skeleton className="h-10 w-full col-span-1" />
+                        <Skeleton className="h-10 w-full col-span-1" />
+                        <Skeleton className="h-10 w-full col-span-1" />
+                      </div>
+                    ))}
                   </div>
+                ) : filteredAndSortedCampaigns.length > 0 ? (
+                  <>
+                    {/* Card View (mobile default, optional desktop) */}
+                    <div
+                      className={`p-4 ${
+                        viewMode === 'grid'
+                          ? 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4'
+                          : 'space-y-4 md:hidden'
+                      }`}
+                    >
+                      {filteredAndSortedCampaigns.map((campaign: any) => {
+                        const raisedAmount = Number(campaign.raised) || 0;
+                        const goalAmount = Number(campaign.goal) || 0;
+                        const donationCount = Number(campaign.donationCount) || 0;
+                        const progress =
+                          goalAmount > 0
+                            ? Math.min((raisedAmount / 100 / goalAmount) * 100, 100)
+                            : 0;
 
-                  {/* Desktop Table View */}
-                  {viewMode === "table" && (
-                    <Table className="hidden md:table w-full">
-                      <TableHeader>
-                        <TableRow className="bg-gray-100 border-b-2 border-gray-200 text-gray-700 grid grid-cols-[1.3fr_0.7fr_1fr_1.1fr_0.5fr] items-center">
-                          <SortableTableHeader
-                            sortKey="title"
-                            currentSortKey={sortKey}
-                            currentSortDirection={sortDirection}
-                            onSort={handleSort}
-                            className="px-4 py-3 text-xs font-semibold text-gray-700 uppercase tracking-wide"
+                        return (
+                          <div
+                            key={campaign.id ?? campaign.title}
+                            className="rounded-2xl border border-gray-100 bg-white p-4 shadow-sm"
                           >
-                            Campaign Details
-                          </SortableTableHeader>
-                          <SortableTableHeader
-                            sortKey="status"
-                            currentSortKey={sortKey}
-                            currentSortDirection={sortDirection}
-                            onSort={handleSort}
-                            className="px-4 py-3 pl-6 text-xs font-semibold text-gray-700 uppercase tracking-wide"
-                          >
-                            Status
-                          </SortableTableHeader>
-                          <SortableTableHeader
-                            sortKey="category"
-                            currentSortKey={sortKey}
-                            currentSortDirection={sortDirection}
-                            onSort={handleSort}
-                            className="px-4 py-3 text-xs font-semibold text-gray-700 uppercase tracking-wide"
-                          >
-                            Category
-                          </SortableTableHeader>
-                          <SortableTableHeader
-                            sortable={false}
-                            sortKey="progress"
-                            currentSortKey={sortKey}
-                            currentSortDirection={sortDirection}
-                            onSort={handleSort}
-                            className="px-4 py-3 text-xs font-semibold text-gray-700 uppercase tracking-wide"
-                          >
-                            Progress
-                          </SortableTableHeader>
-                          <SortableTableHeader
-                            sortable={false}
-                            sortKey="actions"
-                            currentSortKey={sortKey}
-                            currentSortDirection={sortDirection}
-                            onSort={handleSort}
-                            className="px-4 py-3 text-xs font-semibold text-gray-700 uppercase tracking-wide text-right"
-                          >
-                            Actions
-                          </SortableTableHeader>
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {filteredAndSortedCampaigns.map((campaign: any) => {
-                          const raisedAmount = Number(campaign.raised) || 0;
-                          const goalAmount = Number(campaign.goal) || 0;
-                          const progress =
-                            goalAmount > 0
-                              ? Math.min(((raisedAmount / 100) / goalAmount) * 100, 100)
-                              : 0;
-                          const status = (campaign.status ?? "inactive").toString();
-                          const statusTone = status.toLowerCase();
-                          const statusClass =
-                            statusTone === "active"
-                              ? "bg-green-100 text-green-800"
-                              : statusTone === "paused"
-                              ? "bg-yellow-100 text-yellow-800"
-                              : statusTone === "completed"
-                              ? "bg-blue-100 text-blue-800"
-                              : "bg-gray-100 text-gray-700";
-
-                          return (
-                            <TableRow
-                              key={campaign.id ?? campaign.title}
-                              className="border border-gray-100 hover:bg-gray-50 grid grid-cols-[1.3fr_0.7fr_1fr_1.1fr_0.5fr] items-center"
-                            >
-                              <TableCell
-                                className="px-4 py-3 whitespace-normal cursor-pointer"
+                            <div className="flex items-start justify-between gap-3">
+                              <div
+                                className="flex items-center gap-3 cursor-pointer"
                                 onClick={() => handleOpenOverview(campaign as Campaign)}
                                 role="button"
                                 tabIndex={0}
                                 onKeyDown={(event) => {
-                                  if (event.key === "Enter" || event.key === " ") {
+                                  if (event.key === 'Enter' || event.key === ' ') {
                                     event.preventDefault();
                                     handleOpenOverview(campaign as Campaign);
                                   }
                                 }}
                               >
-                                <div className="flex items-center gap-2">
-                                  <ImageWithFallback
-                                    src={campaign.coverImageUrl}
-                                    alt={campaign.title}
-                                    className="w-10 h-10 object-cover rounded-lg border border-gray-200 shrink-0 bg-gray-100"
-                                    fallbackSrc="/campaign-fallback.svg"
-                                  />
-                                  <div className="min-w-0">
-                                    <p className="font-medium text-gray-900 text-sm whitespace-normal break-normal">
-                                      {campaign.title}
-                                    </p>
+                                <ImageWithFallback
+                                  src={campaign.coverImageUrl}
+                                  alt={campaign.title}
+                                  className="h-12 w-12 rounded-2xl border border-gray-200 object-cover bg-gray-100"
+                                  fallbackSrc="/campaign-fallback.svg"
+                                />
+                                <div>
+                                  <div className="text-sm font-semibold text-gray-900">
+                                    {campaign.title}
                                   </div>
                                 </div>
-                              </TableCell>
-                              <TableCell className="px-4 py-3 pl-6">
-                                <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${statusClass}`}>
-                                  {status}
-                                </span>
-                              </TableCell>
-                              <TableCell className="px-4 py-3 whitespace-normal">
-                                {campaign.category ? (
-                                  <Badge variant="secondary" className="text-xs uppercase tracking-wide whitespace-normal break-normal text-left">
-                                    {campaign.category}
-                                  </Badge>
-                                ) : (
-                                  <span className="text-xs text-gray-400">--</span>
-                                )}
-                              </TableCell>
-                              <TableCell className="px-4 py-3">
-                                <div className="w-[220px] max-w-full">
-                                  <div className="flex items-center justify-between text-xs text-gray-500">
-                                    <span>
-                                      {formatCurrency(raisedAmount)} / {formatCurrencyFromMajor(goalAmount)}
-                                    </span>
-                                    <span>{progress.toFixed(0)}%</span>
-                                  </div>
-                                  <div className="mt-2 h-2 w-full rounded-full bg-gray-100 overflow-hidden">
-                                    <div
-                                      className={`h-full ${getProgressColor(progress)} transition-all duration-300`}
-                                      style={{ width: `${progress}%` }}
-                                    />
-                                  </div>
-                                </div>
-                              </TableCell>
-                              <TableCell className="px-4 py-3 text-right">
-                                <DropdownMenu>
-                                  <DropdownMenuTrigger asChild>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8 text-gray-500 hover:bg-gray-100"
-                                      aria-label="Campaign actions"
-                                      disabled={!hasPermission('edit_campaign') && !hasPermission('delete_campaign')}
+                              </div>
+                              <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-8 w-8 text-gray-500 hover:bg-gray-100"
+                                    aria-label="Campaign actions"
+                                    disabled={
+                                      !hasPermission('edit_campaign') &&
+                                      !hasPermission('delete_campaign')
+                                    }
+                                  >
+                                    <MoreVertical className="h-4 w-4" />
+                                  </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                  {hasPermission('edit_campaign') && (
+                                    <DropdownMenuItem
+                                      onSelect={() => handleEditClick(campaign)}
+                                      className="flex items-center gap-2"
                                     >
-                                      <MoreVertical className="h-4 w-4" />
-                                    </Button>
-                                  </DropdownMenuTrigger>
-                                  <DropdownMenuContent align="end">
-                                    {hasPermission('edit_campaign') && (
-                                      <DropdownMenuItem
-                                        onSelect={() => handleEditClick(campaign)}
-                                        className="flex items-center gap-2"
-                                      >
-                                        <FaEdit className="h-4 w-4" />
-                                        Edit
-                                      </DropdownMenuItem>
-                                    )}
-                                    {hasPermission('delete_campaign') && (
-                                      <DropdownMenuItem
-                                        onSelect={() => handleDeleteClick(campaign)}
-                                        className="flex items-center gap-2 text-red-600 focus:text-red-600"
-                                      >
-                                        <FaTrashAlt className="h-4 w-4" />
-                                        Delete
-                                      </DropdownMenuItem>
-                                    )}
-                                  </DropdownMenuContent>
-                                </DropdownMenu>
-                              </TableCell>
-                            </TableRow>
-                          );
-                        })}
-                      </TableBody>
-                    </Table>
-                  )}
+                                      <FaEdit className="h-4 w-4" />
+                                      Edit
+                                    </DropdownMenuItem>
+                                  )}
+                                  {hasPermission('delete_campaign') && (
+                                    <DropdownMenuItem
+                                      onSelect={() => handleDeleteClick(campaign)}
+                                      className="flex items-center gap-2 text-red-600 focus:text-red-600"
+                                    >
+                                      <FaTrashAlt className="h-4 w-4" />
+                                      Delete
+                                    </DropdownMenuItem>
+                                  )}
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            </div>
 
-                </>
-              ) : (
-                <div className="text-center py-8 text-gray-500 p-6">
-                  <Ghost className="mx-auto h-12 w-12 text-gray-400 mb-3" />
-                  <p className="text-lg font-medium mb-2">No Campaigns Found</p>
-                  <p className="text-sm mb-4">No campaigns have been added to your organization yet.</p>
-                </div>
-              )}
-              {(filteredAndSortedCampaigns.length > 0 || canGoPrev) && (
-                <div className="border-t border-gray-100 px-4">
-                  <PaginationControls
-                    pageNumber={pageNumber}
-                    pageSize={pageSize}
-                    totalOnPage={filteredAndSortedCampaigns.length}
-                    canGoNext={canGoNext}
-                    canGoPrev={canGoPrev}
-                    onNext={goNext}
-                    onPrev={goPrev}
-                    loading={fetching}
-                  />
-                </div>
-              )}
-            </CardContent>
+                            <div className="mt-3 flex flex-wrap items-center gap-2">
+                              <Badge
+                                className={`text-xs px-2 py-1 rounded-full inline-flex items-center gap-1 ${getStatusColor(
+                                  campaign.status ?? 'unknown',
+                                )}`}
+                              >
+                                <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                                {campaign.status ?? 'Unknown'}
+                              </Badge>
+                              {campaign.category && (
+                                <Badge
+                                  variant="secondary"
+                                  className="text-xs uppercase tracking-wide"
+                                >
+                                  {campaign.category}
+                                </Badge>
+                              )}
+                            </div>
+
+                            <div className="mt-4">
+                              <div className="flex items-center justify-between text-xs text-gray-500">
+                                <span>
+                                  {formatCurrency(raisedAmount)} /{' '}
+                                  {formatCurrencyFromMajor(goalAmount)}
+                                </span>
+                                <span>{progress.toFixed(0)}%</span>
+                              </div>
+                              <div className="mt-2 h-2 w-full rounded-full bg-gray-100 overflow-hidden">
+                                <div
+                                  className={`h-full ${getProgressColor(progress)} transition-all duration-300`}
+                                  style={{ width: `${progress}%` }}
+                                />
+                              </div>
+                            </div>
+
+                            <div className="mt-4 flex items-center justify-between text-xs text-gray-500">
+                              <span>Donors</span>
+                              <span className="text-sm font-semibold text-gray-900">
+                                {donationCount.toLocaleString()}
+                              </span>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+
+                    {/* Desktop Table View */}
+                    {viewMode === 'table' && (
+                      <Table className="hidden md:table w-full">
+                        <TableHeader>
+                          <TableRow className="bg-gray-100 border-b-2 border-gray-200 text-gray-700 grid grid-cols-[1.3fr_0.7fr_1fr_1.1fr_0.5fr] items-center">
+                            <SortableTableHeader
+                              sortKey="title"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="px-4 py-3 text-xs font-semibold text-gray-700 uppercase tracking-wide"
+                            >
+                              Campaign Details
+                            </SortableTableHeader>
+                            <SortableTableHeader
+                              sortKey="status"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="px-4 py-3 pl-6 text-xs font-semibold text-gray-700 uppercase tracking-wide"
+                            >
+                              Status
+                            </SortableTableHeader>
+                            <SortableTableHeader
+                              sortKey="category"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="px-4 py-3 text-xs font-semibold text-gray-700 uppercase tracking-wide"
+                            >
+                              Category
+                            </SortableTableHeader>
+                            <SortableTableHeader
+                              sortable={false}
+                              sortKey="progress"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="px-4 py-3 text-xs font-semibold text-gray-700 uppercase tracking-wide"
+                            >
+                              Progress
+                            </SortableTableHeader>
+                            <SortableTableHeader
+                              sortable={false}
+                              sortKey="actions"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="px-4 py-3 text-xs font-semibold text-gray-700 uppercase tracking-wide text-right"
+                            >
+                              Actions
+                            </SortableTableHeader>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {filteredAndSortedCampaigns.map((campaign: any) => {
+                            const raisedAmount = Number(campaign.raised) || 0;
+                            const goalAmount = Number(campaign.goal) || 0;
+                            const progress =
+                              goalAmount > 0
+                                ? Math.min((raisedAmount / 100 / goalAmount) * 100, 100)
+                                : 0;
+                            const status = (campaign.status ?? 'inactive').toString();
+                            const statusTone = status.toLowerCase();
+                            const statusClass =
+                              statusTone === 'active'
+                                ? 'bg-green-100 text-green-800'
+                                : statusTone === 'paused'
+                                  ? 'bg-yellow-100 text-yellow-800'
+                                  : statusTone === 'completed'
+                                    ? 'bg-blue-100 text-blue-800'
+                                    : 'bg-gray-100 text-gray-700';
+
+                            return (
+                              <TableRow
+                                key={campaign.id ?? campaign.title}
+                                className="border border-gray-100 hover:bg-gray-50 grid grid-cols-[1.3fr_0.7fr_1fr_1.1fr_0.5fr] items-center"
+                              >
+                                <TableCell
+                                  className="px-4 py-3 whitespace-normal cursor-pointer"
+                                  onClick={() => handleOpenOverview(campaign as Campaign)}
+                                  role="button"
+                                  tabIndex={0}
+                                  onKeyDown={(event) => {
+                                    if (event.key === 'Enter' || event.key === ' ') {
+                                      event.preventDefault();
+                                      handleOpenOverview(campaign as Campaign);
+                                    }
+                                  }}
+                                >
+                                  <div className="flex items-center gap-2">
+                                    <ImageWithFallback
+                                      src={campaign.coverImageUrl}
+                                      alt={campaign.title}
+                                      className="w-10 h-10 object-cover rounded-lg border border-gray-200 shrink-0 bg-gray-100"
+                                      fallbackSrc="/campaign-fallback.svg"
+                                    />
+                                    <div className="min-w-0">
+                                      <p className="font-medium text-gray-900 text-sm whitespace-normal break-normal">
+                                        {campaign.title}
+                                      </p>
+                                    </div>
+                                  </div>
+                                </TableCell>
+                                <TableCell className="px-4 py-3 pl-6">
+                                  <span
+                                    className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${statusClass}`}
+                                  >
+                                    {status}
+                                  </span>
+                                </TableCell>
+                                <TableCell className="px-4 py-3 whitespace-normal">
+                                  {campaign.category ? (
+                                    <Badge
+                                      variant="secondary"
+                                      className="text-xs uppercase tracking-wide whitespace-normal break-normal text-left"
+                                    >
+                                      {campaign.category}
+                                    </Badge>
+                                  ) : (
+                                    <span className="text-xs text-gray-400">--</span>
+                                  )}
+                                </TableCell>
+                                <TableCell className="px-4 py-3">
+                                  <div className="w-[220px] max-w-full">
+                                    <div className="flex items-center justify-between text-xs text-gray-500">
+                                      <span>
+                                        {formatCurrency(raisedAmount)} /{' '}
+                                        {formatCurrencyFromMajor(goalAmount)}
+                                      </span>
+                                      <span>{progress.toFixed(0)}%</span>
+                                    </div>
+                                    <div className="mt-2 h-2 w-full rounded-full bg-gray-100 overflow-hidden">
+                                      <div
+                                        className={`h-full ${getProgressColor(progress)} transition-all duration-300`}
+                                        style={{ width: `${progress}%` }}
+                                      />
+                                    </div>
+                                  </div>
+                                </TableCell>
+                                <TableCell className="px-4 py-3 text-right">
+                                  <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-gray-500 hover:bg-gray-100"
+                                        aria-label="Campaign actions"
+                                        disabled={
+                                          !hasPermission('edit_campaign') &&
+                                          !hasPermission('delete_campaign')
+                                        }
+                                      >
+                                        <MoreVertical className="h-4 w-4" />
+                                      </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent align="end">
+                                      {hasPermission('edit_campaign') && (
+                                        <DropdownMenuItem
+                                          onSelect={() => handleEditClick(campaign)}
+                                          className="flex items-center gap-2"
+                                        >
+                                          <FaEdit className="h-4 w-4" />
+                                          Edit
+                                        </DropdownMenuItem>
+                                      )}
+                                      {hasPermission('delete_campaign') && (
+                                        <DropdownMenuItem
+                                          onSelect={() => handleDeleteClick(campaign)}
+                                          className="flex items-center gap-2 text-red-600 focus:text-red-600"
+                                        >
+                                          <FaTrashAlt className="h-4 w-4" />
+                                          Delete
+                                        </DropdownMenuItem>
+                                      )}
+                                    </DropdownMenuContent>
+                                  </DropdownMenu>
+                                </TableCell>
+                              </TableRow>
+                            );
+                          })}
+                        </TableBody>
+                      </Table>
+                    )}
+                  </>
+                ) : (
+                  <div className="text-center py-8 text-gray-500 p-6">
+                    <Ghost className="mx-auto h-12 w-12 text-gray-400 mb-3" />
+                    <p className="text-lg font-medium mb-2">No Campaigns Found</p>
+                    <p className="text-sm mb-4">
+                      No campaigns have been added to your organization yet.
+                    </p>
+                  </div>
+                )}
+                {(filteredAndSortedCampaigns.length > 0 || canGoPrev) && (
+                  <div className="border-t border-gray-100 px-4">
+                    <PaginationControls
+                      pageNumber={pageNumber}
+                      pageSize={pageSize}
+                      totalOnPage={filteredAndSortedCampaigns.length}
+                      canGoNext={canGoNext}
+                      canGoPrev={canGoPrev}
+                      onNext={goNext}
+                      onPrev={goPrev}
+                      loading={fetching}
+                    />
+                  </div>
+                )}
+              </CardContent>
             </Card>
           </div>
         </main>
@@ -2777,20 +2917,25 @@ const CampaignManagement = ({
         <>
           <div
             className={`fixed inset-0 bg-black/50 z-40 transition-opacity duration-500 ${
-              isOverviewOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+              isOverviewOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
             }`}
             onClick={closeOverview}
           />
 
           <div
             className={`fixed right-0 top-0 h-full w-full sm:max-w-md md:max-w-lg shadow-2xl z-50 transform transition-all duration-500 ease-in-out overflow-hidden bg-[#F3F1EA] ${
-              isOverviewOpen ? "translate-x-0" : "translate-x-full"
+              isOverviewOpen ? 'translate-x-0' : 'translate-x-full'
             }`}
           >
             <div className="flex h-full flex-col">
               <div className="border-b border-gray-100 px-6 py-4 shadow-sm flex items-center justify-between">
                 <h2 className="text-lg font-semibold text-gray-900">Campaign Overview</h2>
-                <Button variant="ghost" size="icon" onClick={closeOverview} aria-label="Close overview">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={closeOverview}
+                  aria-label="Close overview"
+                >
                   <X className="h-5 w-5" />
                 </Button>
               </div>
@@ -2799,7 +2944,7 @@ const CampaignManagement = ({
                 <div className="rounded-2xl border border-gray-100 bg-gray-50/60 p-3">
                   <ImageWithFallback
                     src={selectedCampaign?.coverImageUrl}
-                    alt={selectedCampaign?.title || "Campaign cover"}
+                    alt={selectedCampaign?.title || 'Campaign cover'}
                     className="h-52 w-full rounded-xl object-cover bg-gray-100"
                     fallbackSrc="/campaign-fallback.svg"
                   />
@@ -2808,24 +2953,24 @@ const CampaignManagement = ({
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge
                     className={`text-xs px-2 py-1 rounded-full inline-flex items-center gap-1 ${getStatusColor(
-                      selectedCampaign?.status ?? "inactive"
+                      selectedCampaign?.status ?? 'inactive',
                     )}`}
                   >
                     <span className="h-1.5 w-1.5 rounded-full bg-current" />
-                    {selectedCampaign?.status ?? "Inactive"}
+                    {selectedCampaign?.status ?? 'Inactive'}
                   </Badge>
                   <Badge variant="secondary" className="text-xs uppercase tracking-wide">
-                    {selectedCampaign?.category || "Uncategorized"}
+                    {selectedCampaign?.category || 'Uncategorized'}
                   </Badge>
                 </div>
 
                 <div>
                   <h3 className="text-xl font-semibold text-gray-900">
-                    {selectedCampaign?.title || "Untitled campaign"}
+                    {selectedCampaign?.title || 'Untitled campaign'}
                   </h3>
                   <p className="mt-2 text-sm text-gray-600 leading-relaxed">
                     {selectedCampaign?.description ||
-                      "No description available for this campaign yet."}
+                      'No description available for this campaign yet.'}
                   </p>
                 </div>
               </div>
@@ -2837,10 +2982,11 @@ const CampaignManagement = ({
                     <span>
                       {selectedCampaign?.goal
                         ? Math.min(
-                            ((Number(selectedCampaign?.raised || 0) / 100) /
+                            (Number(selectedCampaign?.raised || 0) /
+                              100 /
                               Number(selectedCampaign.goal)) *
                               100,
-                            100
+                            100,
                           ).toFixed(0)
                         : 0}
                       %
@@ -2851,21 +2997,23 @@ const CampaignManagement = ({
                       className={`h-full ${getProgressColor(
                         selectedCampaign?.goal
                           ? Math.min(
-                              ((Number(selectedCampaign?.raised || 0) / 100) /
+                              (Number(selectedCampaign?.raised || 0) /
+                                100 /
                                 Number(selectedCampaign.goal)) *
                                 100,
-                              100
+                              100,
                             )
-                          : 0
+                          : 0,
                       )}`}
                       style={{
                         width: `${
                           selectedCampaign?.goal
                             ? Math.min(
-                                ((Number(selectedCampaign?.raised || 0) / 100) /
+                                (Number(selectedCampaign?.raised || 0) /
+                                  100 /
                                   Number(selectedCampaign.goal)) *
                                   100,
-                                100
+                                100,
                               )
                             : 0
                         }%`,
@@ -2889,7 +3037,7 @@ const CampaignManagement = ({
                 </div>
 
                 <div className="text-xs text-gray-500">
-                  Donors:{" "}
+                  Donors:{' '}
                   <span className="font-semibold text-gray-900">
                     {Number(selectedCampaign?.donationCount || 0).toLocaleString()}
                   </span>
@@ -2910,21 +3058,21 @@ const CampaignManagement = ({
                         Edit Details
                       </Button>
                       {(() => {
-                        const status = (selectedCampaign?.status ?? "").toString().toLowerCase();
-                        const isCompleted = status === "completed";
-                        const isPaused = status === "paused";
+                        const status = (selectedCampaign?.status ?? '').toString().toLowerCase();
+                        const isCompleted = status === 'completed';
+                        const isPaused = status === 'paused';
 
                         return (
                           <Button
                             className={`h-11 rounded-full text-white ${
                               isPaused
-                                ? "bg-emerald-700 hover:bg-emerald-800"
-                                : "bg-red-500 hover:bg-red-600"
+                                ? 'bg-emerald-700 hover:bg-emerald-800'
+                                : 'bg-red-500 hover:bg-red-600'
                             }`}
                             onClick={isPaused ? handleResumeCampaign : handlePauseCampaign}
                             disabled={!selectedCampaign || isCompleted}
                           >
-                            {isPaused ? "Continue Donations" : "Pause Donations"}
+                            {isPaused ? 'Continue Donations' : 'Pause Donations'}
                           </Button>
                         );
                       })()}
@@ -2937,21 +3085,30 @@ const CampaignManagement = ({
         </>
       )}
       {/* Dialogs remain after main content */}
-      <CampaignDialog open={isEditDialogOpen} onOpenChange={open => { setIsEditDialogOpen(open); if(!open) setEditingCampaign(null); }} campaign={editingCampaign} organizationId={userSession.user.organizationId || ""} onSave={handleSave} />
-      <CampaignDialog 
-        key={addDialogKey} 
-        open={isAddDialogOpen} 
-        onOpenChange={open => { 
-          setIsAddDialogOpen(open); 
+      <CampaignDialog
+        open={isEditDialogOpen}
+        onOpenChange={(open) => {
+          setIsEditDialogOpen(open);
+          if (!open) setEditingCampaign(null);
+        }}
+        campaign={editingCampaign}
+        organizationId={userSession.user.organizationId || ''}
+        onSave={handleSave}
+      />
+      <CampaignDialog
+        key={addDialogKey}
+        open={isAddDialogOpen}
+        onOpenChange={(open) => {
+          setIsAddDialogOpen(open);
           if (open) {
             // Increment key to force remount and clear all state
-            setAddDialogKey(prev => prev + 1);
+            setAddDialogKey((prev) => prev + 1);
           }
-        }} 
-        organizationId={userSession.user.organizationId || ""} 
-        onSave={(data, isNew) => handleSave(data, isNew, undefined)} 
+        }}
+        organizationId={userSession.user.organizationId || ''}
+        onSave={(data, isNew) => handleSave(data, isNew, undefined)}
       />
-      
+
       {/* New CampaignForm Component */}
       <CampaignForm
         open={isNewCampaignFormOpen}
@@ -2993,7 +3150,7 @@ const CampaignManagement = ({
         dateError={editCampaignDateError}
         onDateErrorClear={() => setEditCampaignDateError(false)}
       />
-      
+
       {/* Delete Confirmation Dialog */}
       <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
         <DialogContent className="sm:max-w-[400px] p-0 border-0 shadow-2xl">
@@ -3012,29 +3169,28 @@ const CampaignManagement = ({
                 </div>
               </div>
             </div>
-            
+
             {/* Title */}
-            <h2 className="text-xl font-semibold text-gray-900 mb-3">
-              Delete campaign
-            </h2>
-            
+            <h2 className="text-xl font-semibold text-gray-900 mb-3">Delete campaign</h2>
+
             {/* Description */}
             <p className="text-gray-600 mb-8 leading-relaxed">
-              Are you sure you want to delete this campaign?<br />
+              Are you sure you want to delete this campaign?
+              <br />
               This action cannot be undone.
             </p>
-            
+
             {/* Action Buttons */}
             <div className="flex gap-3">
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 onClick={() => setIsDeleteDialogOpen(false)}
                 disabled={isDeleting}
                 className="flex-1 h-11 border-gray-300 text-gray-700 hover:bg-gray-50"
               >
                 Cancel
               </Button>
-              <Button 
+              <Button
                 onClick={handleConfirmDelete}
                 disabled={isDeleting}
                 className="flex-1 h-11 bg-red-500 hover:bg-red-600 text-white border-0"


### PR DESCRIPTION
## Summary
Closes #642 by moving Campaign export from client-side CSV generation to a server-side Cloud Function so exports are complete, permissioned, and independent of UI pagination/filter state.

 ## Changes
- Added backend handler: backend/functions/handlers/campaignsExport.js
- Registered function: backend/functions/index.js (exports.exportCampaigns)
- Added frontend API:
      - src/entities/campaign/api/campaignExportApi.ts
      - src/entities/campaign/api/index.ts
- Added function URL mapping:
      - src/shared/config/functions.ts (FUNCTION_URLS.exportCampaigns)
- Replaced client CSV export in CampaignManagement with backend call + loading/toast UX:
      - src/views/admin/CampaignManagement.tsx


https://github.com/user-attachments/assets/4644bbdc-3e06-4852-a3cd-c28cba2efc20

## Backend behavior
- Method: `POST`
- Auth: Firebase ID token required
- Authorization:
      - Allowed: `view_campaigns` or `system_admin`
      - Non-system-admin users are org-scoped
- Exports full org campaign dataset from Firestore
- Returns CSV as attachment
- Filename format: `campaigns-{organizationId}-{YYYYMMDD-HHMMSSZ}.csv`
- CSV formula-injection hardening included (`=`, `+`, `-`, `@`)

## Acceptance Criteria Mapping
- Export button downloads full org campaign CSV from backend: ✅
- Export not affected by client pagination: ✅
- Unauthorised users receive 403: ✅
- Errors surfaced with a clear toast message: ✅
- CSV filename includes context/timestamp: ✅

## Validation
- `npm.cmd --prefix backend/functions run lint -- handlers/campaignsExport.js` ✅
- `npx.cmd eslint src/entities/campaign/api/campaignExportApi.ts` ✅
- Note: `CampaignManagement.tsx` has pre-existing lint issues unrelated to this scope.

## Deployment
- `firebase deploy --only functions:exportCampaigns`
