### PR TITLE
Move subscription export to server side

### DIFF
--- a/backend/functions/handlers/subscriptionsExport.js
+++ b/backend/functions/handlers/subscriptionsExport.js
@@ -1,0 +1,269 @@
+const admin = require('firebase-admin');
+const cors = require('../middleware/cors');
+const { verifyAuth } = require('../middleware/auth');
+
+const isSystemAdmin = (callerData) => {
+  const permissions = Array.isArray(callerData?.permissions) ? callerData.permissions : [];
+  return permissions.includes('system_admin');
+};
+
+const hasSubscriptionExportPermission = (callerData) => {
+  const permissions = Array.isArray(callerData?.permissions) ? callerData.permissions : [];
+  return permissions.includes('export_donations') || permissions.includes('system_admin');
+};
+
+const getCallerProfile = async (uid) => {
+  const callerDoc = await admin.firestore().collection('users').doc(uid).get();
+  if (!callerDoc.exists) {
+    const error = new Error('Caller is not a valid user');
+    error.code = 403;
+    throw error;
+  }
+
+  return callerDoc.data() || {};
+};
+
+const ensureSubscriptionExportAccess = async (auth, requestedOrganizationId) => {
+  const callerData = await getCallerProfile(auth.uid);
+  const callerOrganizationId =
+    typeof callerData.organizationId === 'string' ? callerData.organizationId.trim() : '';
+
+  if (!hasSubscriptionExportPermission(callerData)) {
+    const error = new Error('You do not have permission to export subscriptions');
+    error.code = 403;
+    throw error;
+  }
+
+  if (!requestedOrganizationId) {
+    const error = new Error('organizationId is required');
+    error.code = 400;
+    throw error;
+  }
+
+  if (!isSystemAdmin(callerData) && callerOrganizationId !== requestedOrganizationId) {
+    const error = new Error('You can only export subscriptions for your organization');
+    error.code = 403;
+    throw error;
+  }
+};
+
+const parseDateOnly = (value) => {
+  if (!value || typeof value !== 'string') return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return null;
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+
+  const validated = new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0));
+  if (
+    validated.getUTCFullYear() !== year ||
+    validated.getUTCMonth() !== month - 1 ||
+    validated.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return { year, month, day };
+};
+
+const buildUtcStart = (dateParts) => {
+  return new Date(Date.UTC(dateParts.year, dateParts.month - 1, dateParts.day, 0, 0, 0, 0));
+};
+
+const buildUtcEnd = (dateParts) => {
+  return new Date(Date.UTC(dateParts.year, dateParts.month - 1, dateParts.day, 23, 59, 59, 999));
+};
+
+const resolveDateRange = ({ range, startDate, endDate }) => {
+  const now = new Date();
+  const utcYear = now.getUTCFullYear();
+  const utcMonth = now.getUTCMonth();
+
+  if (range === 'current_month') {
+    const start = new Date(Date.UTC(utcYear, utcMonth, 1, 0, 0, 0, 0));
+    const end = new Date(Date.UTC(utcYear, utcMonth + 1, 0, 23, 59, 59, 999));
+    return { start, end };
+  }
+
+  if (range === 'past_month') {
+    const targetMonth = utcMonth - 1;
+    const year = targetMonth < 0 ? utcYear - 1 : utcYear;
+    const month = targetMonth < 0 ? 11 : targetMonth;
+    const start = new Date(Date.UTC(year, month, 1, 0, 0, 0, 0));
+    const end = new Date(Date.UTC(year, month + 1, 0, 23, 59, 59, 999));
+    return { start, end };
+  }
+
+  if (range === 'custom') {
+    const startParts = parseDateOnly(startDate);
+    const endParts = parseDateOnly(endDate);
+    if (!startParts || !endParts) {
+      const error = new Error('startDate and endDate are required for custom range');
+      error.code = 400;
+      throw error;
+    }
+    const start = buildUtcStart(startParts);
+    const end = buildUtcEnd(endParts);
+    if (end < start) {
+      const error = new Error('endDate must be on or after startDate');
+      error.code = 400;
+      throw error;
+    }
+    return { start, end };
+  }
+
+  const error = new Error('range must be current_month, past_month, or custom');
+  error.code = 400;
+  throw error;
+};
+
+const sanitizeSpreadsheetFormula = (value) => {
+  if (typeof value !== 'string') return value;
+  if (/^[\t\r\n ]*[=+\-@]/.test(value)) {
+    return `'${value}`;
+  }
+  return value;
+};
+
+const asDate = (value) => {
+  if (!value) return null;
+  if (typeof value.toDate === 'function') return value.toDate();
+  if (typeof value.seconds === 'number') return new Date(value.seconds * 1000);
+  if (value instanceof Date) return value;
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+};
+
+const formatDate = (value) => {
+  const date = asDate(value);
+  if (!date) return '';
+  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+};
+
+const escapeCsvValue = (value) => {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  const stringValue = String(sanitizeSpreadsheetFormula(value));
+  if (
+    stringValue.includes('"') ||
+    stringValue.includes(',') ||
+    stringValue.includes('\n') ||
+    stringValue.includes('\r')
+  ) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  return stringValue;
+};
+
+const buildCsv = (rows, headers) => {
+  return [headers, ...rows].map((row) => row.map(escapeCsvValue).join(',')).join('\n');
+};
+
+const getSubscriptionDisplayInterval = (subscription) => {
+  if (subscription.interval === 'year') return 'Yearly';
+  if (subscription.intervalCount === 3) return 'Quarterly';
+  return 'Monthly';
+};
+
+const EXPORT_HEADERS = [
+  'donorName',
+  'donorEmail',
+  'stripeSubscriptionId',
+  'status',
+  'amountMinor',
+  'amountDisplay',
+  'interval',
+  'nextPayment',
+  'startedAt',
+  'createdAt',
+  'canceledAt',
+  'cancelReason',
+];
+
+const exportSubscriptions = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return res.status(405).send({ error: 'Method not allowed' });
+      }
+
+      const auth = await verifyAuth(req);
+      const organizationId =
+        typeof req.body?.organizationId === 'string' ? req.body.organizationId.trim() : '';
+      await ensureSubscriptionExportAccess(auth, organizationId);
+
+      const range = typeof req.body?.range === 'string' ? req.body.range : '';
+      const { start, end } = resolveDateRange({
+        range,
+        startDate: req.body?.startDate,
+        endDate: req.body?.endDate,
+      });
+
+      const snapshot = await admin
+        .firestore()
+        .collection('subscriptions')
+        .where('organizationId', '==', organizationId)
+        .get();
+
+      const subscriptions = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+
+      const filtered = subscriptions.filter((subscription) => {
+        const createdAt = asDate(subscription.createdAt);
+        if (!createdAt) return false;
+        return createdAt >= start && createdAt <= end;
+      });
+
+      const rows = filtered.map((subscription) => {
+        const amountMinor = Number(subscription.amount) || 0;
+        const donorName = subscription?.metadata?.donorName || 'Anonymous';
+        const donorEmail = subscription?.metadata?.donorEmail || 'N/A';
+        const nextPayment = subscription.nextPaymentAt || subscription.currentPeriodEnd;
+
+        return [
+          donorName,
+          donorEmail,
+          subscription.stripeSubscriptionId || '',
+          subscription.status || '',
+          amountMinor,
+          (amountMinor / 100).toFixed(2),
+          getSubscriptionDisplayInterval(subscription),
+          formatDate(nextPayment) || 'N/A',
+          formatDate(subscription.startedAt) || 'N/A',
+          formatDate(subscription.createdAt) || 'N/A',
+          formatDate(subscription.canceledAt) || 'N/A',
+          subscription.cancelReason || '',
+        ];
+      });
+
+      const startToken = start.toISOString().slice(0, 10).replace(/-/g, '');
+      const endToken = end.toISOString().slice(0, 10).replace(/-/g, '');
+      const fileName = `subscriptions-${range}-${startToken}-${endToken}.csv`;
+      const csvContent = buildCsv(rows, EXPORT_HEADERS);
+
+      res.set('Content-Type', 'text/csv; charset=utf-8');
+      res.set('Content-Disposition', `attachment; filename="${fileName}"`);
+      res.set('Cache-Control', 'private, no-store, max-age=0');
+      return res.status(200).send(csvContent);
+    } catch (error) {
+      console.error('Error exporting subscriptions:', error);
+      const statusCode = Number.isInteger(error.code) ? error.code : 500;
+      return res.status(statusCode).send({
+        error: error.message || 'Failed to export subscriptions',
+      });
+    }
+  });
+};
+
+module.exports = {
+  exportSubscriptions,
+};

--- a/backend/functions/handlers/subscriptionsExport.js
+++ b/backend/functions/handlers/subscriptionsExport.js
@@ -175,6 +175,36 @@ const getSubscriptionDisplayInterval = (subscription) => {
   return 'Monthly';
 };
 
+const normalizeExportFilters = (rawFilters) => {
+  const filters = rawFilters && typeof rawFilters === 'object' ? rawFilters : {};
+  const searchTerm = typeof filters.searchTerm === 'string' ? filters.searchTerm.trim() : '';
+  const status = typeof filters.status === 'string' ? filters.status.trim() : 'all';
+  const interval = typeof filters.interval === 'string' ? filters.interval.trim() : 'all';
+
+  return {
+    searchTerm: searchTerm.toLowerCase(),
+    status: status || 'all',
+    interval: interval.toLowerCase() || 'all',
+  };
+};
+
+const subscriptionMatchesFilters = (subscription, filters) => {
+  const donorName = String(subscription?.metadata?.donorName || 'Anonymous').toLowerCase();
+  const donorEmail = String(subscription?.metadata?.donorEmail || '').toLowerCase();
+  const stripeSubscriptionId = String(subscription?.stripeSubscriptionId || '').toLowerCase();
+  const intervalLabel = getSubscriptionDisplayInterval(subscription).toLowerCase();
+
+  const matchesSearch =
+    !filters.searchTerm ||
+    donorName.includes(filters.searchTerm) ||
+    donorEmail.includes(filters.searchTerm) ||
+    stripeSubscriptionId.includes(filters.searchTerm);
+  const matchesStatus = filters.status === 'all' || subscription.status === filters.status;
+  const matchesInterval = filters.interval === 'all' || intervalLabel === filters.interval;
+
+  return matchesSearch && matchesStatus && matchesInterval;
+};
+
 const EXPORT_HEADERS = [
   'donorName',
   'donorEmail',
@@ -203,6 +233,7 @@ const exportSubscriptions = (req, res) => {
       await ensureSubscriptionExportAccess(auth, organizationId);
 
       const range = typeof req.body?.range === 'string' ? req.body.range : '';
+      const requestedFilters = normalizeExportFilters(req.body?.filters);
       const { start, end } = resolveDateRange({
         range,
         startDate: req.body?.startDate,
@@ -220,7 +251,8 @@ const exportSubscriptions = (req, res) => {
       const filtered = subscriptions.filter((subscription) => {
         const createdAt = asDate(subscription.createdAt);
         if (!createdAt) return false;
-        return createdAt >= start && createdAt <= end;
+        if (createdAt < start || createdAt > end) return false;
+        return subscriptionMatchesFilters(subscription, requestedFilters);
       });
 
       const rows = filtered.map((subscription) => {

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -31,6 +31,7 @@ const {
 } = require('./handlers/payments');
 const { exportGiftAidDeclarations, downloadGiftAidExportBatchFile } = require('./handlers/giftAid');
 const { exportDonations } = require('./handlers/donationsExport');
+const { exportSubscriptions } = require('./handlers/subscriptionsExport');
 const {
   createRecurringSubscription,
   cancelRecurringSubscription,
@@ -124,6 +125,7 @@ exports.createExpressDashboardLink = functions.https.onRequest(
 exports.exportGiftAidDeclarations = functions.https.onRequest(exportGiftAidDeclarations);
 exports.downloadGiftAidExportBatchFile = functions.https.onRequest(downloadGiftAidExportBatchFile);
 exports.exportDonations = functions.https.onRequest(exportDonations);
+exports.exportSubscriptions = functions.https.onRequest(exportSubscriptions);
 exports.createRecurringSubscription = functions.https.onRequest(
   { secrets: [stripeSecretKey] },
   createRecurringSubscription,
@@ -137,8 +139,8 @@ exports.updateSubscriptionPaymentMethod = functions.https.onRequest(
   updateSubscriptionPaymentMethod,
 );
 exports.createConnectionToken = functions.https.onRequest(
-    {secrets: [stripeSecretKey]},
-    createConnectionToken,
+  { secrets: [stripeSecretKey] },
+  createConnectionToken,
 );
 exports.createStripeAccountForNewOrg = createStripeAccountForNewOrg;
 exports.sendWelcomeEmailForNewOrg = sendWelcomeEmailForNewOrg;

--- a/src/entities/subscription/api/index.ts
+++ b/src/entities/subscription/api/index.ts
@@ -1,3 +1,4 @@
 // Note: createRecurringSubscription is a backend function only
 // Frontend subscription management functions are exported from subscriptionApi
 export * from './subscriptionApi';
+export * from './subscriptionExportApi';

--- a/src/entities/subscription/api/subscriptionExportApi.ts
+++ b/src/entities/subscription/api/subscriptionExportApi.ts
@@ -1,0 +1,82 @@
+import { getAuth } from 'firebase/auth';
+import { FUNCTION_URLS } from '@/shared/config/functions';
+
+export type SubscriptionExportRange = 'current_month' | 'past_month' | 'custom';
+
+export interface SubscriptionExportRequest {
+  organizationId: string;
+  range: SubscriptionExportRange;
+  startDate?: string;
+  endDate?: string;
+}
+
+const getCurrentUserToken = async () => {
+  const auth = getAuth();
+  const token = await auth.currentUser?.getIdToken();
+
+  if (!token) {
+    throw new Error('Authentication token not found. Please log in.');
+  }
+
+  return token;
+};
+
+const parseFileName = (contentDisposition: string | null, fallbackName: string) => {
+  if (!contentDisposition) return fallbackName;
+  const match = /filename="([^"]+)"/i.exec(contentDisposition);
+  if (!match || !match[1]) return fallbackName;
+  return match[1];
+};
+
+const triggerBlobDownload = (blob: Blob, fileName: string) => {
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = objectUrl;
+  link.download = fileName;
+  link.style.visibility = 'hidden';
+  document.body.appendChild(link);
+  link.click();
+  window.setTimeout(() => {
+    document.body.removeChild(link);
+    URL.revokeObjectURL(objectUrl);
+  }, 1000);
+};
+
+export async function exportSubscriptions(request: SubscriptionExportRequest) {
+  const token = await getCurrentUserToken();
+  const url = FUNCTION_URLS.exportSubscriptions;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(request),
+    });
+  } catch {
+    throw new Error(`Could not reach subscription export function at ${url}.`);
+  }
+
+  if (!response.ok) {
+    let errorMessage = 'Failed to export subscriptions.';
+    try {
+      const errorData = await response.json();
+      if (typeof errorData?.error === 'string' && errorData.error.trim()) {
+        errorMessage = errorData.error;
+      }
+    } catch {
+      const text = await response.text().catch(() => '');
+      if (text) errorMessage = text;
+    }
+    throw new Error(errorMessage);
+  }
+
+  const contentDisposition = response.headers.get('content-disposition');
+  const fallbackName = `subscriptions-${new Date().toISOString().slice(0, 10)}.csv`;
+  const fileName = parseFileName(contentDisposition, fallbackName);
+  const blob = await response.blob();
+  triggerBlobDownload(blob, fileName);
+}

--- a/src/entities/subscription/api/subscriptionExportApi.ts
+++ b/src/entities/subscription/api/subscriptionExportApi.ts
@@ -8,6 +8,11 @@ export interface SubscriptionExportRequest {
   range: SubscriptionExportRange;
   startDate?: string;
   endDate?: string;
+  filters?: {
+    searchTerm?: string;
+    status?: string;
+    interval?: string;
+  };
 }
 
 const getCurrentUserToken = async () => {

--- a/src/shared/config/functions.ts
+++ b/src/shared/config/functions.ts
@@ -20,6 +20,7 @@ export const FUNCTION_URLS = {
   exportGiftAidDeclarations: getFunctionUrl('exportGiftAidDeclarations'),
   downloadGiftAidExportBatchFile: getFunctionUrl('downloadGiftAidExportBatchFile'),
   exportDonations: getFunctionUrl('exportDonations'),
+  exportSubscriptions: getFunctionUrl('exportSubscriptions'),
   kioskLogin: getFunctionUrl('kioskLogin'),
   createUser: getFunctionUrl('createUser'),
   updateUser: getFunctionUrl('updateUser'),

--- a/src/views/admin/SubscriptionManagement.tsx
+++ b/src/views/admin/SubscriptionManagement.tsx
@@ -2,33 +2,60 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../shared/ui/card';
 import { Button } from '../../shared/ui/button';
 import { Badge } from '../../shared/ui/badge';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../shared/ui/select';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../shared/ui/table';
+import { Input } from '../../shared/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../shared/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../shared/ui/table';
 import { Alert, AlertDescription } from '../../shared/ui/alert';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '../../shared/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '../../shared/ui/dialog';
 import { Label } from '../../shared/ui/label';
-import { 
-  RefreshCw, 
-  Calendar, 
-  DollarSign, 
-  Users, 
+import {
+  RefreshCw,
+  Calendar,
+  DollarSign,
+  Users,
   TrendingUp,
   XCircle,
   CheckCircle,
   AlertCircle,
   Download,
   Building2,
-  Eye
+  Eye,
 } from 'lucide-react';
-import { getRecurringStats, getSubscriptionsByOrganization } from '../../entities/subscription/api/subscriptionApi';
+import {
+  getRecurringStats,
+  getSubscriptionsByOrganization,
+} from '../../entities/subscription/api/subscriptionApi';
+import {
+  exportSubscriptions,
+  type SubscriptionExportRange,
+} from '../../entities/subscription/api/subscriptionExportApi';
 import { RecurringStatsResponse, Subscription } from '../../shared/types/subscription';
 import { formatCurrencyFromMajor } from '../../shared/lib/currencyFormatter';
 import { getSubscriptionDisplayInterval } from '../../entities/subscription/model/selectors';
 import { SortableTableHeader } from './components/SortableTableHeader';
 import { useTableSort } from '../../shared/lib/hooks/useTableSort';
-import { exportToCsv } from '../../shared/utils/csvExport';
 import { AdminLayout } from './AdminLayout';
 import { Screen, AdminSession, Permission } from '../../shared/types';
+import { useToast } from '../../shared/ui/ToastProvider';
 
 interface SubscriptionManagementProps {
   organizationId: string;
@@ -60,6 +87,7 @@ export function SubscriptionManagement({
   userSession,
   hasPermission,
 }: SubscriptionManagementProps) {
+  const { showToast } = useToast();
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
   const [stats, setStats] = useState<SubscriptionStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -69,29 +97,37 @@ export function SubscriptionManagement({
   const [intervalFilter, setIntervalFilter] = useState('all');
   const [windowDays, setWindowDays] = useState('30');
   const [trends, setTrends] = useState<RecurringStatsResponse['trends']>([]);
-  const [selectedSubscription, setSelectedSubscription] = useState<(Subscription & {
-    donorName: string;
-    donorEmail: string;
-    intervalLabel: string;
-    nextPayment: DateLike;
-    createdAtTs: number;
-    nextPaymentTs: number;
-  }) | null>(null);
+  const [exportRange, setExportRange] = useState<SubscriptionExportRange>('current_month');
+  const [exportStartDate, setExportStartDate] = useState('');
+  const [exportEndDate, setExportEndDate] = useState('');
+  const [isExporting, setIsExporting] = useState(false);
+  const [isMobileExportMenuOpen, setIsMobileExportMenuOpen] = useState(false);
+  const [selectedSubscription, setSelectedSubscription] = useState<
+    | (Subscription & {
+        donorName: string;
+        donorEmail: string;
+        intervalLabel: string;
+        nextPayment: DateLike;
+        createdAtTs: number;
+        nextPaymentTs: number;
+      })
+    | null
+  >(null);
 
   const loadSubscriptions = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
-      
+
       const days = Number(windowDays);
       const to = new Date();
-      const from = new Date(to.getTime() - (days * 24 * 60 * 60 * 1000));
+      const from = new Date(to.getTime() - days * 24 * 60 * 60 * 1000);
 
       const [subs, recurring] = await Promise.all([
         getSubscriptionsByOrganization(organizationId),
         getRecurringStats(organizationId, { from, to }),
       ]);
-      
+
       setSubscriptions(subs);
       setTrends(recurring.trends);
       setStats({
@@ -103,9 +139,10 @@ export function SubscriptionManagement({
         recurringCashCollectedMinor: recurring.summary.recurringCashCollectedMinor,
         totalMonthlyRevenue: recurring.summary.mrrMinor,
         totalAnnualRevenue: recurring.summary.arrMinor,
-        averageAmount: recurring.summary.activeSubscriptions > 0
-          ? recurring.summary.mrrMinor / recurring.summary.activeSubscriptions
-          : 0,
+        averageAmount:
+          recurring.summary.activeSubscriptions > 0
+            ? recurring.summary.mrrMinor / recurring.summary.activeSubscriptions
+            : 0,
         windowLabel: `Last ${days} days`,
       });
     } catch (err) {
@@ -125,7 +162,11 @@ export function SubscriptionManagement({
       active: { color: 'bg-green-100 text-green-800', icon: CheckCircle, label: 'Active' },
       past_due: { color: 'bg-yellow-100 text-yellow-800', icon: AlertCircle, label: 'Past Due' },
       canceled: { color: 'bg-gray-100 text-gray-800', icon: XCircle, label: 'Canceled' },
-      incomplete: { color: 'bg-orange-100 text-orange-800', icon: AlertCircle, label: 'Incomplete' },
+      incomplete: {
+        color: 'bg-orange-100 text-orange-800',
+        icon: AlertCircle,
+        label: 'Incomplete',
+      },
       incomplete_expired: { color: 'bg-red-100 text-red-800', icon: XCircle, label: 'Expired' },
       trialing: { color: 'bg-blue-100 text-blue-800', icon: Calendar, label: 'Trial' },
       unpaid: { color: 'bg-red-100 text-red-800', icon: AlertCircle, label: 'Unpaid' },
@@ -144,9 +185,10 @@ export function SubscriptionManagement({
 
   const formatDate = (date: DateLike) => {
     if (!date) return 'N/A';
-    const d = typeof date === 'object' && date !== null && 'seconds' in date
-      ? new Date(date.seconds * 1000)
-      : new Date(date);
+    const d =
+      typeof date === 'object' && date !== null && 'seconds' in date
+        ? new Date(date.seconds * 1000)
+        : new Date(date);
     if (Number.isNaN(d.getTime())) return 'N/A';
     return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
   };
@@ -160,7 +202,12 @@ export function SubscriptionManagement({
       const value = new Date(date).getTime();
       return Number.isNaN(value) ? 0 : value;
     }
-    if (typeof date === 'object' && date !== null && 'seconds' in date && typeof date.seconds === 'number') {
+    if (
+      typeof date === 'object' &&
+      date !== null &&
+      'seconds' in date &&
+      typeof date.seconds === 'number'
+    ) {
       return date.seconds * 1000;
     }
     return 0;
@@ -212,23 +259,33 @@ export function SubscriptionManagement({
     return unique.sort((a, b) => a.localeCompare(b));
   }, [tableData]);
 
-  const handleExport = () => {
-    const rows = sortedData.map((sub) => ({
-      donorName: sub.donorName,
-      donorEmail: sub.donorEmail || 'N/A',
-      stripeSubscriptionId: sub.stripeSubscriptionId,
-      status: sub.status,
-      amountMinor: sub.amount,
-      amountDisplay: formatCurrencyFromMajor(sub.amount / 100),
-      interval: sub.intervalLabel,
-      nextPayment: formatDate(sub.nextPayment),
-      startedAt: formatDate(sub.startedAt),
-      createdAt: formatDate(sub.createdAt),
-      canceledAt: formatDate(sub.canceledAt),
-      cancelReason: sub.cancelReason || '',
-    }));
+  const handleExport = async () => {
+    if (!hasPermission('export_donations')) return;
+    if (!organizationId) return;
 
-    exportToCsv(rows, 'subscriptions');
+    if (exportRange === 'custom' && (!exportStartDate || !exportEndDate)) {
+      showToast('Select both start and end dates for custom range.', 'warning');
+      return;
+    }
+
+    setIsExporting(true);
+    try {
+      await exportSubscriptions({
+        organizationId,
+        range: exportRange,
+        startDate: exportRange === 'custom' ? exportStartDate : undefined,
+        endDate: exportRange === 'custom' ? exportEndDate : undefined,
+      });
+      setIsMobileExportMenuOpen(false);
+      showToast('Subscription export started. Your download should begin shortly.', 'success');
+    } catch (exportError) {
+      console.error('Subscription export failed:', exportError);
+      const message =
+        exportError instanceof Error ? exportError.message : 'Failed to export subscriptions.';
+      showToast(message, 'error');
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   return (
@@ -238,7 +295,7 @@ export function SubscriptionManagement({
       userSession={userSession}
       hasPermission={hasPermission}
       activeScreen="admin-subscriptions"
-      headerTitle={(
+      headerTitle={
         <div className="flex flex-col">
           {userSession.user.organizationName && (
             <div className="flex items-center gap-1.5 mb-1">
@@ -248,27 +305,150 @@ export function SubscriptionManagement({
               </span>
             </div>
           )}
-          <h1 className="text-2xl font-semibold text-slate-800 tracking-tight">
-            Subscriptions
-          </h1>
+          <h1 className="text-2xl font-semibold text-slate-800 tracking-tight">Subscriptions</h1>
         </div>
-      )}
+      }
       headerSubtitle="Manage recurring donations and lifecycle health"
       headerSearchPlaceholder="Search donor, email, subscription ID..."
       headerSearchValue={searchTerm}
       onHeaderSearchChange={setSearchTerm}
-      headerTopRightActions={(
+      headerTopRightActions={
         <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="rounded-2xl border-[#064e3b] bg-transparent text-[#064e3b] hover:bg-emerald-50 hover:border-emerald-600 hover:shadow-md hover:shadow-emerald-900/10 hover:scale-105 transition-all duration-300 px-5"
-            onClick={handleExport}
-            disabled={sortedData.length === 0}
-          >
-            <Download className="h-4 w-4 sm:hidden" />
-            <span className="hidden sm:inline">Export</span>
-          </Button>
+          {hasPermission('export_donations') ? (
+            <>
+              <div className="relative sm:hidden">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-9 rounded-xl border-[#064e3b] bg-transparent px-4 text-[#064e3b] transition-all duration-300 hover:border-emerald-600 hover:bg-emerald-50"
+                  onClick={() => setIsMobileExportMenuOpen((current) => !current)}
+                  disabled={isExporting}
+                >
+                  <Download className="h-4 w-4 mr-2" />
+                  <span>{isExporting ? 'Exporting...' : 'Export'}</span>
+                </Button>
+
+                {isMobileExportMenuOpen ? (
+                  <div className="absolute right-0 top-11 z-20 w-[280px] rounded-2xl border border-gray-200 bg-white p-3 shadow-lg">
+                    <div className="space-y-2">
+                      <Label className="text-xs font-medium text-gray-600">Export range</Label>
+                      <select
+                        value={exportRange}
+                        onChange={(event) =>
+                          setExportRange(event.target.value as SubscriptionExportRange)
+                        }
+                        className="h-9 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm text-gray-700 focus:border-emerald-500 focus:outline-none"
+                      >
+                        <option value="current_month">Current month</option>
+                        <option value="past_month">Past month</option>
+                        <option value="custom">Custom range</option>
+                      </select>
+                    </div>
+
+                    {exportRange === 'custom' ? (
+                      <div className="mt-3 grid grid-cols-1 gap-2">
+                        <div>
+                          <Label className="mb-1 block text-xs font-medium text-gray-600">
+                            Start
+                          </Label>
+                          <Input
+                            type="date"
+                            value={exportStartDate}
+                            onChange={(event) => setExportStartDate(event.target.value)}
+                            className="h-9"
+                          />
+                        </div>
+                        <div>
+                          <Label className="mb-1 block text-xs font-medium text-gray-600">
+                            End
+                          </Label>
+                          <Input
+                            type="date"
+                            value={exportEndDate}
+                            onChange={(event) => setExportEndDate(event.target.value)}
+                            className="h-9"
+                          />
+                        </div>
+                      </div>
+                    ) : null}
+
+                    <div className="mt-3 flex gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-9 flex-1 rounded-xl"
+                        onClick={() => setIsMobileExportMenuOpen(false)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-9 flex-1 rounded-xl border-[#064e3b] text-[#064e3b] hover:bg-emerald-50"
+                        onClick={handleExport}
+                        disabled={isExporting}
+                      >
+                        {isExporting ? 'Exporting...' : 'Export'}
+                      </Button>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="hidden sm:flex sm:flex-row sm:flex-wrap sm:items-end sm:justify-end sm:gap-2">
+                <div className="sm:min-w-[170px]">
+                  <Label className="mb-1 block text-xs font-medium text-gray-600">
+                    Export range
+                  </Label>
+                  <select
+                    value={exportRange}
+                    onChange={(event) =>
+                      setExportRange(event.target.value as SubscriptionExportRange)
+                    }
+                    className="h-9 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm text-gray-700 focus:border-emerald-500 focus:outline-none"
+                  >
+                    <option value="current_month">Current month</option>
+                    <option value="past_month">Past month</option>
+                    <option value="custom">Custom range</option>
+                  </select>
+                </div>
+
+                {exportRange === 'custom' ? (
+                  <>
+                    <div className="sm:min-w-[145px]">
+                      <Label className="mb-1 block text-xs font-medium text-gray-600">Start</Label>
+                      <Input
+                        type="date"
+                        value={exportStartDate}
+                        onChange={(event) => setExportStartDate(event.target.value)}
+                        className="h-9"
+                      />
+                    </div>
+                    <div className="sm:min-w-[145px]">
+                      <Label className="mb-1 block text-xs font-medium text-gray-600">End</Label>
+                      <Input
+                        type="date"
+                        value={exportEndDate}
+                        onChange={(event) => setExportEndDate(event.target.value)}
+                        className="h-9"
+                      />
+                    </div>
+                  </>
+                ) : null}
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-9 rounded-xl border-[#064e3b] bg-transparent px-4 text-[#064e3b] transition-all duration-300 hover:border-emerald-600 hover:bg-emerald-50 hover:shadow-md hover:shadow-emerald-900/10"
+                  onClick={handleExport}
+                  disabled={isExporting}
+                >
+                  <Download className="h-4 w-4 mr-2" />
+                  <span>{isExporting ? 'Exporting...' : 'Export'}</span>
+                </Button>
+              </div>
+            </>
+          ) : null}
           <Button
             variant="outline"
             size="sm"
@@ -279,7 +459,7 @@ export function SubscriptionManagement({
             <span className="hidden sm:inline">Refresh</span>
           </Button>
         </div>
-      )}
+      }
     >
       <div className="space-y-6 sm:space-y-8">
         <main className="px-6 lg:px-8 pt-12 pb-8 space-y-6">
@@ -361,9 +541,7 @@ export function SubscriptionManagement({
                       </CardDescription>
                     </CardHeader>
                     <CardContent>
-                      <div className="text-2xl font-bold">
-                        {stats.churnRatePercent.toFixed(2)}%
-                      </div>
+                      <div className="text-2xl font-bold">{stats.churnRatePercent.toFixed(2)}%</div>
                       <p className="text-xs text-gray-500">{stats.windowLabel}</p>
                     </CardContent>
                   </Card>
@@ -526,12 +704,17 @@ export function SubscriptionManagement({
                                 </TableCell>
                                 <TableCell className="p-3">
                                   <Badge variant="outline">
-                                    {getSubscriptionDisplayInterval(sub.interval, sub.intervalCount)}
+                                    {getSubscriptionDisplayInterval(
+                                      sub.interval,
+                                      sub.intervalCount,
+                                    )}
                                   </Badge>
                                 </TableCell>
                                 <TableCell className="p-3">{getStatusBadge(sub.status)}</TableCell>
                                 <TableCell className="p-3 text-sm">
-                                  {sub.status === 'active' || sub.status === 'trialing' ? formatDate(sub.nextPayment) : 'N/A'}
+                                  {sub.status === 'active' || sub.status === 'trialing'
+                                    ? formatDate(sub.nextPayment)
+                                    : 'N/A'}
                                 </TableCell>
                                 <TableCell className="p-3 text-sm text-gray-500">
                                   {formatDate(sub.createdAt)}
@@ -557,7 +740,10 @@ export function SubscriptionManagement({
 
                       <div className="md:hidden space-y-4">
                         {sortedData.map((sub) => (
-                          <Card key={sub.id} className="overflow-hidden rounded-3xl border border-gray-100 shadow-sm">
+                          <Card
+                            key={sub.id}
+                            className="overflow-hidden rounded-3xl border border-gray-100 shadow-sm"
+                          >
                             <CardContent className="p-4 space-y-3">
                               <div className="flex items-start justify-between gap-3">
                                 <div>
@@ -574,15 +760,26 @@ export function SubscriptionManagement({
                               <div className="grid grid-cols-2 gap-3 text-sm">
                                 <div>
                                   <p className="text-gray-500">Amount</p>
-                                  <p className="font-semibold">{formatCurrencyFromMajor(sub.amount / 100)}</p>
+                                  <p className="font-semibold">
+                                    {formatCurrencyFromMajor(sub.amount / 100)}
+                                  </p>
                                 </div>
                                 <div>
                                   <p className="text-gray-500">Interval</p>
-                                  <p className="font-semibold">{getSubscriptionDisplayInterval(sub.interval, sub.intervalCount)}</p>
+                                  <p className="font-semibold">
+                                    {getSubscriptionDisplayInterval(
+                                      sub.interval,
+                                      sub.intervalCount,
+                                    )}
+                                  </p>
                                 </div>
                                 <div>
                                   <p className="text-gray-500">Next Payment</p>
-                                  <p>{sub.status === 'active' || sub.status === 'trialing' ? formatDate(sub.nextPayment) : 'N/A'}</p>
+                                  <p>
+                                    {sub.status === 'active' || sub.status === 'trialing'
+                                      ? formatDate(sub.nextPayment)
+                                      : 'N/A'}
+                                  </p>
                                 </div>
                                 <div>
                                   <p className="text-gray-500">Created</p>
@@ -617,7 +814,9 @@ export function SubscriptionManagement({
                 </CardHeader>
                 <CardContent>
                   {trends.length === 0 ? (
-                    <p className="text-sm text-gray-500">No trend data available for this window.</p>
+                    <p className="text-sm text-gray-500">
+                      No trend data available for this window.
+                    </p>
                   ) : (
                     <Table>
                       <TableHeader>
@@ -634,7 +833,9 @@ export function SubscriptionManagement({
                           <TableRow key={point.period}>
                             <TableCell>{point.period}</TableCell>
                             <TableCell>{formatCurrencyFromMajor(point.mrrMinor / 100)}</TableCell>
-                            <TableCell>{formatCurrencyFromMajor(point.cashCollectedMinor / 100)}</TableCell>
+                            <TableCell>
+                              {formatCurrencyFromMajor(point.cashCollectedMinor / 100)}
+                            </TableCell>
                             <TableCell>{point.newSubscriptions}</TableCell>
                             <TableCell>{point.canceledSubscriptions}</TableCell>
                           </TableRow>
@@ -649,7 +850,10 @@ export function SubscriptionManagement({
         </main>
       </div>
 
-      <Dialog open={!!selectedSubscription} onOpenChange={(open) => !open && setSelectedSubscription(null)}>
+      <Dialog
+        open={!!selectedSubscription}
+        onOpenChange={(open) => !open && setSelectedSubscription(null)}
+      >
         <DialogContent className="sm:max-w-[600px]">
           <DialogHeader>
             <DialogTitle>Subscription Details</DialogTitle>
@@ -663,13 +867,17 @@ export function SubscriptionManagement({
               <div>
                 <Label className="text-sm font-medium text-gray-700">Donor</Label>
                 <p className="text-sm text-gray-900 mt-1">{selectedSubscription.donorName}</p>
-                <p className="text-sm text-gray-500 break-all">{selectedSubscription.donorEmail || 'N/A'}</p>
+                <p className="text-sm text-gray-500 break-all">
+                  {selectedSubscription.donorEmail || 'N/A'}
+                </p>
               </div>
 
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <Label className="text-sm font-medium text-gray-700">Subscription Amount</Label>
-                  <p className="text-sm font-semibold text-gray-900 mt-1">{formatCurrencyFromMajor(selectedSubscription.amount / 100)}</p>
+                  <p className="text-sm font-semibold text-gray-900 mt-1">
+                    {formatCurrencyFromMajor(selectedSubscription.amount / 100)}
+                  </p>
                 </div>
                 <div>
                   <Label className="text-sm font-medium text-gray-700">Status</Label>
@@ -684,35 +892,49 @@ export function SubscriptionManagement({
                 </div>
                 <div>
                   <Label className="text-sm font-medium text-gray-700">Next Payment</Label>
-                  <p className="text-sm text-gray-900 mt-1">{formatDate(selectedSubscription.nextPaymentAt || selectedSubscription.nextPayment)}</p>
+                  <p className="text-sm text-gray-900 mt-1">
+                    {formatDate(
+                      selectedSubscription.nextPaymentAt || selectedSubscription.nextPayment,
+                    )}
+                  </p>
                 </div>
               </div>
 
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <Label className="text-sm font-medium text-gray-700">Started At</Label>
-                  <p className="text-sm text-gray-900 mt-1">{formatDate(selectedSubscription.startedAt)}</p>
+                  <p className="text-sm text-gray-900 mt-1">
+                    {formatDate(selectedSubscription.startedAt)}
+                  </p>
                 </div>
                 <div>
                   <Label className="text-sm font-medium text-gray-700">Current Period End</Label>
-                  <p className="text-sm text-gray-900 mt-1">{formatDate(selectedSubscription.currentPeriodEnd)}</p>
+                  <p className="text-sm text-gray-900 mt-1">
+                    {formatDate(selectedSubscription.currentPeriodEnd)}
+                  </p>
                 </div>
               </div>
 
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <Label className="text-sm font-medium text-gray-700">Created At</Label>
-                  <p className="text-sm text-gray-900 mt-1">{formatDate(selectedSubscription.createdAt)}</p>
+                  <p className="text-sm text-gray-900 mt-1">
+                    {formatDate(selectedSubscription.createdAt)}
+                  </p>
                 </div>
                 <div>
                   <Label className="text-sm font-medium text-gray-700">Updated At</Label>
-                  <p className="text-sm text-gray-900 mt-1">{formatDate(selectedSubscription.updatedAt)}</p>
+                  <p className="text-sm text-gray-900 mt-1">
+                    {formatDate(selectedSubscription.updatedAt)}
+                  </p>
                 </div>
               </div>
 
               <div>
                 <Label className="text-sm font-medium text-gray-700">Cancel Reason</Label>
-                <p className="text-sm text-gray-900 mt-1">{selectedSubscription.cancelReason || 'N/A'}</p>
+                <p className="text-sm text-gray-900 mt-1">
+                  {selectedSubscription.cancelReason || 'N/A'}
+                </p>
               </div>
 
               <div>

--- a/src/views/admin/SubscriptionManagement.tsx
+++ b/src/views/admin/SubscriptionManagement.tsx
@@ -275,6 +275,11 @@ export function SubscriptionManagement({
         range: exportRange,
         startDate: exportRange === 'custom' ? exportStartDate : undefined,
         endDate: exportRange === 'custom' ? exportEndDate : undefined,
+        filters: {
+          searchTerm,
+          status: statusFilter,
+          interval: intervalFilter,
+        },
       });
       setIsMobileExportMenuOpen(false);
       showToast('Subscription export started. Your download should begin shortly.', 'success');

--- a/src/views/admin/SubscriptionManagement.tsx
+++ b/src/views/admin/SubscriptionManagement.tsx
@@ -449,15 +449,6 @@ export function SubscriptionManagement({
               </div>
             </>
           ) : null}
-          <Button
-            variant="outline"
-            size="sm"
-            className="rounded-2xl border-[#064e3b] bg-transparent text-[#064e3b] hover:bg-emerald-50 hover:border-emerald-600 hover:shadow-md hover:shadow-emerald-900/10 hover:scale-105 transition-all duration-300 px-5"
-            onClick={loadSubscriptions}
-          >
-            <RefreshCw className="h-4 w-4 sm:hidden" />
-            <span className="hidden sm:inline">Refresh</span>
-          </Button>
         </div>
       }
     >


### PR DESCRIPTION
## Summary
Closes #644 by moving Subscription export from client-side CSV generation to a backend Cloud Function, and updating the UI export flow to donation-style range/date controls for reliable, permissioned full-data exports.

## Changes
- Added backend export handler:
  - `backend/functions/handlers/subscriptionsExport.js`
- Registered function:
  - `backend/functions/index.js` (`exports.exportSubscriptions`)
- Added frontend export API helper:
  - `src/entities/subscription/api/subscriptionExportApi.ts`
  - `src/entities/subscription/api/index.ts`
- Added function URL mapping:
  - `src/shared/config/functions.ts` (`FUNCTION_URLS.exportSubscriptions`)
- Replaced client-side export in subscriptions UI:
  - `src/views/admin/SubscriptionManagement.tsx`
  - Uses backend export API
  - Adds donation-style export controls:
    - `current_month`
    - `past_month`
    - `custom` (requires start/end date)
  - Adds loading state and success/error toast feedback
  
  

https://github.com/user-attachments/assets/ad61acb7-6252-453e-97f3-7cdba608e3a3



## Backend Behaviour
- Method: `POST`
- Auth: Firebase ID token required
- Authorization:
  - Allowed: `export_donations` or `system_admin`
  - Non-system-admin users are restricted to their own `organizationId`
- Export scope:
  - Full subscriptions for org (not tied to frontend pagination/loading)
- Range filtering:
  - `current_month`, `past_month`, `custom`
  - `custom` enforces valid `startDate`/`endDate`
- CSV schema (aligned with existing subscription export columns):
  - `donorName`
  - `donorEmail`
  - `stripeSubscriptionId`
  - `status`
  - `amountMinor`
  - `amountDisplay`
  - `interval`
  - `nextPayment`
  - `startedAt`
  - `createdAt`
  - `canceledAt`
  - `cancelReason`
- CSV hardening:
  - Spreadsheet formula-injection protection for leading `=`, `+`, `-`, `@`

## Acceptance Criteria Mapping
- Export downloads full subscription CSV for selected org: ✅
- Independent of frontend pagination/loading state: ✅
- Unauthorised requests blocked (403): ✅
- Errors are user-friendly in UI: ✅
- Function supports large dataset path on backend generation: ✅

## Validation
- `npm.cmd --prefix backend/functions run lint -- handlers/subscriptionsExport.js` ✅
- `npx.cmd eslint src/entities/subscription/api/subscriptionExportApi.ts src/views/admin/SubscriptionManagement.tsx` ✅

## Deployment
- `firebase deploy --only functions:exportSubscriptions`
