### PR TITLE
Harden Gift Aid Validation to Prevent Phantom Declarations

### DIFF
--- a/backend/functions/handlers/subscriptions.js
+++ b/backend/functions/handlers/subscriptions.js
@@ -29,6 +29,27 @@ const getTaxYear = (dateValue) => {
   return `${startYear}-${endYearShort}`;
 };
 
+const writeGiftAidReconciliationIssue = async ({
+  paymentIntentId,
+  declarationId,
+  organizationId,
+  reason,
+  metadata,
+}) => {
+  await admin
+    .firestore()
+    .collection('giftAidReconciliationIssues')
+    .add({
+      paymentIntentId: paymentIntentId || null,
+      declarationId: declarationId || null,
+      organizationId: organizationId || null,
+      reason,
+      metadata: metadata || {},
+      resolved: false,
+      createdAt: admin.firestore.Timestamp.now(),
+    });
+};
+
 const createGiftAidDeclarationFromMetadata = async ({
   donationId,
   amountMinor,
@@ -38,7 +59,6 @@ const createGiftAidDeclarationFromMetadata = async ({
   organizationId,
   donationDateIso,
 }) => {
-
   // Strict Guard: Only process if isGiftAid is explicitly true
   const isGiftAid = toBoolean(metadata.isGiftAid);
   if (!isGiftAid) {
@@ -83,12 +103,26 @@ const createGiftAidDeclarationFromMetadata = async ({
     if (declarationSnap.exists) {
       const existingDonationId = toStringOrNull(declarationSnap.data()?.donationId);
       if (existingDonationId && existingDonationId !== donationId) {
-        console.warn(
-          'Gift Aid declaration already linked to a different donation; skipping relink:',
+        // Track conflict in reconciliation issues (matches one-time behavior)
+        await writeGiftAidReconciliationIssue({
+          paymentIntentId: donationId,
+          declarationId,
+          organizationId: organizationId || null,
+          reason: 'declaration_already_linked_to_other_donation',
+          metadata: {
+            existingDonationId,
+            incomingDonationId: donationId,
+            source: 'recurring_subscription',
+          },
+        });
+        console.error('[Gift Aid Recurring] Declaration already linked to different donation:', {
           declarationId,
           existingDonationId,
-          donationId,
-        );
+          incomingDonationId: donationId,
+          campaignId: campaignId || 'unknown',
+        });
+        // Note: We return instead of throw to avoid breaking subscription flow,
+        // but we DO track the issue for visibility (deliberate divergence from one-time path)
         return;
       }
 

--- a/backend/functions/handlers/subscriptions.js
+++ b/backend/functions/handlers/subscriptions.js
@@ -38,7 +38,38 @@ const createGiftAidDeclarationFromMetadata = async ({
   organizationId,
   donationDateIso,
 }) => {
-  if (!toBoolean(metadata.isGiftAid)) return;
+
+  // Strict Guard: Only process if isGiftAid is explicitly true
+  const isGiftAid = toBoolean(metadata.isGiftAid);
+  if (!isGiftAid) {
+    return; // Exit immediately - not a Gift Aid donation
+  }
+
+  // Consent Validation: Verify required consent fields are present
+  const giftAidConsent = toBoolean(metadata.giftAidConsent);
+  const ukTaxpayerConfirmation = toBoolean(metadata.giftAidTaxpayer);
+
+  if (!giftAidConsent || !ukTaxpayerConfirmation) {
+    console.warn('[Gift Aid Recurring] Skipping declaration: missing required consent', {
+      donationId,
+      campaignId: campaignId || 'unknown',
+      // Raw metadata values (for debugging string vs boolean issues)
+      raw: {
+        isGiftAid: metadata.isGiftAid,
+        giftAidConsent: metadata.giftAidConsent,
+        giftAidTaxpayer: metadata.giftAidTaxpayer,
+      },
+      // Parsed boolean values
+      parsed: {
+        isGiftAid,
+        giftAidConsent,
+        ukTaxpayerConfirmation,
+      },
+      // Validation failure reason
+      reason: !giftAidConsent ? 'missing_gift_aid_consent' : 'missing_uk_taxpayer_confirmation',
+    });
+    return; // Exit immediately - consent not provided
+  }
 
   const declarationId =
     toStringOrNull(metadata.giftAidDeclarationId) || toStringOrNull(metadata.declarationId);

--- a/backend/functions/handlers/webhooks.js
+++ b/backend/functions/handlers/webhooks.js
@@ -120,8 +120,40 @@ const createGiftAidDeclarationIfNeeded = async ({
   campaignTitleSnapshot,
   organizationId,
 }) => {
+ 
+  // Strict Guard: Only process if isGiftAid is explicitly true
   const isGiftAid = toBoolean(metadata.isGiftAid);
-  if (!isGiftAid) return;
+  if (!isGiftAid) {
+    return; // Exit immediately - not a Gift Aid donation
+  }
+
+  // Consent Validation: Verify required consent fields are present
+  const giftAidConsent = toBoolean(metadata.giftAidConsent);
+  const ukTaxpayerConfirmation = toBoolean(metadata.giftAidTaxpayer);
+
+  if (!giftAidConsent || !ukTaxpayerConfirmation) {
+    console.warn('[Gift Aid] Skipping declaration: missing required consent', {
+      paymentIntentId: paymentIntent.id,
+      campaignId: campaignId || 'unknown',
+      platform: metadata.platform || 'unknown',
+      // Raw metadata values (for debugging string vs boolean issues)
+      raw: {
+        isGiftAid: metadata.isGiftAid,
+        giftAidConsent: metadata.giftAidConsent,
+        giftAidTaxpayer: metadata.giftAidTaxpayer,
+      },
+      // Parsed boolean values
+      parsed: {
+        isGiftAid,
+        giftAidConsent,
+        ukTaxpayerConfirmation,
+      },
+      // Validation failure reason
+      reason: !giftAidConsent ? 'missing_gift_aid_consent' : 'missing_uk_taxpayer_confirmation',
+    });
+    return; // Exit immediately - consent not provided
+  }
+
   if (!Number.isInteger(paymentIntent.amount) || paymentIntent.amount <= 0) {
     throw new Error(`Invalid payment amount for Gift Aid declaration: ${paymentIntent.amount}`);
   }


### PR DESCRIPTION
## Summary
This PR addresses a critical data integrity issue where Gift Aid declarations were being created for donations even when donors did not complete the Gift Aid consent form. The fix adds strict validation guards and consent verification so declarations are only created when explicitly intended by the donor.

## Changes

**Core Validation Logic (Applied to both one-time and recurring declaration paths):**

1. **Strict `isGiftAid` Guard**
   - Added an explicit boolean check at function entry that exits immediately if Gift Aid is not enabled
   - Prevents accidental execution due to bad metadata or fallback logic
   - Uses `toBoolean()` to correctly handle string/boolean conversion

2. **Consent Field Validation**
   - Validates both required consent flags before proceeding:
     - `giftAidConsent` - donor consent to Gift Aid
     - `ukTaxpayerConfirmation` - confirmation of UK taxpayer status
   - Both must be explicitly `true` before a declaration can be created

3. **Enhanced Logging**
   - Added warning logs when validation fails, including:
     - Raw metadata values for debugging string vs boolean issues
     - Parsed boolean values
     - Specific validation failure reason codes
     - Payment/donation identifiers for traceability

4. **Improved Conflict Tracking**
   - Recurring donation conflicts are now written to `giftAidReconciliationIssues`
   - Improves observability for recurring declaration-linking issues
   - Deliberate divergence from one-time flow: recurring path returns instead of throwing to preserve subscription processing

**Files Modified:**
- `backend/functions/handlers/webhooks.js` - hardened `createGiftAidDeclarationIfNeeded()` for one-time donations
- `backend/functions/handlers/subscriptions.js` - hardened `createGiftAidDeclarationFromMetadata()` for recurring donations and added conflict tracking

**Key Code Pattern:**
```javascript
// Strict guard
const isGiftAid = toBoolean(metadata.isGiftAid);
if (!isGiftAid) return;

// Consent validation
const giftAidConsent = toBoolean(metadata.giftAidConsent);
const ukTaxpayerConfirmation = toBoolean(metadata.giftAidTaxpayer);

if (!giftAidConsent || !ukTaxpayerConfirmation) {
  console.warn('[Gift Aid] Skipping declaration: missing required consent', {...});
  return;
}

// Conflict tracking (recurring donations)
if (existingDonationId && existingDonationId !== donationId) {
  await writeGiftAidReconciliationIssue({...});
  return; // Don't throw - preserve subscription flow
}
```

## Testing
- `npm run build` - build passed successfully
- `npm test -- giftAid.validation.test.js` - passed successfully
- Manual verification completed locally
- Verified `toBoolean()` handles string and boolean values correctly
- Confirmed early-exit guards prevent downstream declaration creation when consent is missing

**Test Scenarios Covered:**
- Donation with `isGiftAid = false` -> no declaration created ✅
- Donation with `isGiftAid = true` but missing consent -> no declaration created ✅
- Donation with `giftAidConsent = false` or `giftAidTaxpayer = false` -> no declaration created ✅
- Donation with valid consent + details -> declaration created ✅
- Donation with valid consent but partial donor metadata -> declaration created with fallback values ✅
- Metadata with `"false"` / `"true"` / `"1"` values -> parsed correctly ✅
- Recurring conflict tracking -> reconciliation issue logged ✅

## Screenshots Or Recordings
N/A - backend validation logic only

## Risks

**Low Risk:**
- Changes are defensive in nature and prevent unwanted behavior
- Early exits ensure no side effects when validation fails
- Existing valid Gift Aid donations continue to work as expected

**Potential Edge Cases:**
- If Android sends metadata as strings instead of booleans, `toBoolean()` handles this safely
- Orphaned declarations with `donationId: null` are a separate issue and are not addressed by this PR

**Known Limitation:**
- Legacy `createPaymentIntent` endpoint, if still in use, may be affected by the stricter metadata requirements
- That compatibility work is deferred to the planned frontend / flow rewrite

## Deployment Notes

**Deployment Steps:**
- Build functions: `npm run build` (from `SwiftCause_Web/`)
- Deploy functions: `firebase deploy --only functions` (from `SwiftCause_Web/backend/`)

**No environment changes required:**
- No environment variable changes
- No database migrations

**Post-Deploy Checks:**
- Monitor Cloud Functions logs for `[Gift Aid] Skipping declaration` warnings
- Review `giftAidReconciliationIssues` for any new recurring conflict entries
- Verify legitimate Gift Aid donations are not being blocked

**Rollback Plan:**
- Revert the PR commits and redeploy functions
- No data cleanup required, since this change only prevents unwanted creation

## Checklist
- [x] I reviewed my own changes
- [x] I updated documentation when needed
- [x] I confirmed no secrets were introduced
- [x] Backend validation does not rely on frontend correctness
- [x] Logs clearly show why a declaration was skipped
- [x] Addressed review feedback on recurring conflict observability

## Closes
closes #650 