### PR TITLE
refactor: use tokenHash as document ID for O(1) magic link lookup

### DIFF
--- a/backend/functions/entities/magicLink.js
+++ b/backend/functions/entities/magicLink.js
@@ -90,29 +90,33 @@ const generateMagicLinkToken = async ({
     };
   }
 
-  // References
-  const tokenRef = db.collection('magicLinkTokens').doc(paymentIntentId);
-  const ephemeralRef = db.collection('magicLinkEphemeral').doc(paymentIntentId);
-  const donationRef = db.collection('donations').doc(donationId);
+  // References - Check idempotency FIRST using paymentIntentId
+  // We use a separate collection for idempotency to keep magicLinkTokens clean
+  const idempotencyRef = db.collection('magicLinkTokenByPaymentIntent').doc(paymentIntentId);
 
   console.log('🔵 [Magic Link] Starting transaction', { paymentIntentId });
 
   // Execute SINGLE TRANSACTION for full atomicity and idempotency
   try {
     const result = await db.runTransaction(async (transaction) => {
-      console.log('🔵 [Magic Link] Transaction: Checking if token exists', { paymentIntentId });
+      console.log('🔵 [Magic Link] Transaction: Checking idempotency', {
+        paymentIntentId,
+      });
 
-      // 1. CHECK IF TOKEN ALREADY EXISTS (idempotency)
-      const existingToken = await transaction.get(tokenRef);
+      // 1. CHECK IDEMPOTENCY using paymentIntentId (stable key)
+      const existingIdempotency = await transaction.get(idempotencyRef);
 
-      if (existingToken.exists) {
+      if (existingIdempotency.exists) {
+        const existingData = existingIdempotency.data();
         console.log('✅ [Magic Link] Token already exists (idempotent)', {
           paymentIntentId,
           donationId,
           purpose,
+          tokenHash: existingData.tokenHash,
         });
         return {
-          id: paymentIntentId,
+          id: existingData.tokenHash,
+          paymentIntentId: paymentIntentId,
           alreadyExists: true,
         };
       }
@@ -127,6 +131,7 @@ const generateMagicLinkToken = async ({
 
       console.log('🔵 [Magic Link] Transaction: Token generated and hashed', {
         paymentIntentId,
+        tokenHash,
         tokenLength: plainToken.length,
         hashLength: tokenHash.length,
       });
@@ -140,16 +145,22 @@ const generateMagicLinkToken = async ({
 
       console.log('🔵 [Magic Link] Transaction: Expiry set', {
         paymentIntentId,
+        tokenHash,
         expiresAt: expiresAt.toDate().toISOString(),
         ephemeralExpiresAt: ephemeralExpiresAt.toDate().toISOString(),
       });
 
-      // 4. CREATE CONSENT EVENT REFERENCE (auto-generated ID)
+      // 4. CREATE REFERENCES
+      const tokenRef = db.collection('magicLinkTokens').doc(tokenHash);
+      const ephemeralRef = db.collection('magicLinkEphemeral').doc(paymentIntentId);
+      const donationRef = db.collection('donations').doc(donationId);
       const consentRef = donationRef.collection('ConsentEvents').doc();
 
-      console.log('🔵 [Magic Link] Transaction: Writing 4 documents atomically', {
+      console.log('🔵 [Magic Link] Transaction: Writing 5 documents atomically', {
         paymentIntentId,
-        tokenDocId: paymentIntentId,
+        tokenHash,
+        idempotencyDocId: paymentIntentId,
+        tokenDocId: tokenHash,
         ephemeralDocId: paymentIntentId,
         consentEventId: consentRef.id,
         donationId,
@@ -157,9 +168,20 @@ const generateMagicLinkToken = async ({
 
       // 5. ATOMIC WRITES - ALL IN ONE TRANSACTION
 
-      // 5a. Create secure token document (backend only)
+      // 5a. Create idempotency pointer (separate collection for clean schema)
+      transaction.set(idempotencyRef, {
+        tokenHash: tokenHash,
+        transactionId: paymentIntentId,
+        paymentIntentId: paymentIntentId,
+        donationId: donationId,
+        purpose: purpose,
+        createdAt: now,
+      });
+
+      // 5b. Create secure token document (keyed by tokenHash for O(1) lookup)
       transaction.set(tokenRef, {
         tokenHash: tokenHash,
+        transactionId: paymentIntentId,
         paymentIntentId: paymentIntentId,
         donationId: donationId,
         amount: amount,
@@ -179,14 +201,14 @@ const generateMagicLinkToken = async ({
         lastAttemptIp: null,
       });
 
-      // 5b. Create ephemeral document (public, time-restricted)
+      // 5c. Create ephemeral document (public, time-restricted)
       transaction.set(ephemeralRef, {
         plainToken: plainToken,
         expiresAt: ephemeralExpiresAt,
         createdAt: now,
       });
 
-      // 5c. Create consent event (implicit consent from kiosk T&Cs)
+      // 5d. Create consent event (implicit consent from kiosk T&Cs)
       transaction.set(consentRef, {
         id: consentRef.id,
         type: 'implicit',
@@ -200,11 +222,11 @@ const generateMagicLinkToken = async ({
         userAgent: 'kiosk',
       });
 
-      // 5d. Update donation document (merge to prevent failure if doesn't exist)
+      // 5e. Update donation document (merge to prevent failure if doesn't exist)
       transaction.set(
         donationRef,
         {
-          magicLinkTokenId: paymentIntentId,
+          magicLinkTokenId: tokenHash, // Store tokenHash instead of paymentIntentId
           magicLinkPurpose: purpose,
           magicLinkExpiresAt: expiresAt,
           hasConsentEvents: true,
@@ -215,13 +237,15 @@ const generateMagicLinkToken = async ({
       // 6. RETURN RESULT (transaction will commit all writes atomically)
       console.log('✅ [Magic Link] Transaction: All writes prepared, committing', {
         paymentIntentId,
+        tokenHash,
         donationId,
         purpose,
       });
 
       // Note: Plain token is returned here but NEVER stored in database or logged
       return {
-        id: paymentIntentId,
+        id: tokenHash, // Return tokenHash as the ID
+        paymentIntentId: paymentIntentId,
         plainToken: plainToken,
         donationId: donationId,
         purpose: purpose,
@@ -231,7 +255,8 @@ const generateMagicLinkToken = async ({
     });
 
     console.log('✅ [Magic Link] Token created successfully', {
-      paymentIntentId: result.id,
+      tokenHash: result.id,
+      paymentIntentId: result.paymentIntentId,
       donationId: result.donationId,
       purpose: result.purpose,
       expiresAt: result.expiresAt?.toDate().toISOString(),

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -209,13 +209,12 @@ exports.validateMagicLinkToken = functions.https.onRequest(async (req, res) => {
     const db = admin.firestore();
 
     const result = await db.runTransaction(async (transaction) => {
-      // Look up token by hash
-      const tokensQuery = await transaction.get(
-        db.collection('magicLinkTokens').where('tokenHash', '==', tokenHash).limit(1),
-      );
+      // Direct document lookup using tokenHash as document ID (O(1) lookup)
+      const tokenRef = db.collection('magicLinkTokens').doc(tokenHash);
+      const tokenDoc = await transaction.get(tokenRef);
 
       // Check if token exists
-      if (tokensQuery.empty) {
+      if (!tokenDoc.exists) {
         console.warn('⚠️ [Validate Token] Token not found');
         return {
           status: 404,
@@ -226,10 +225,8 @@ exports.validateMagicLinkToken = functions.https.onRequest(async (req, res) => {
         };
       }
 
-      const tokenDoc = tokensQuery.docs[0];
       const tokenData = tokenDoc.data();
       const tokenId = tokenDoc.id;
-      const tokenRef = db.collection('magicLinkTokens').doc(tokenId);
 
       console.log('🔵 [Validate Token] Token found:', {
         tokenId,


### PR DESCRIPTION
## Summary
Refactor magic link token storage to use `tokenHash` as Firestore document ID for O(1) lookup performance, enabling transaction-safe Gift Aid flow implementation.

## Changes
- **Token Generation**: Generate token inside transaction after idempotency check (prevents duplicate tokens on webhook retries)
- **Three-Collection Architecture**:
  - `magicLinkTokens/{tokenHash}` - Full token records (O(1) validation lookup)
  - `magicLinkTokenByPaymentIntent/{paymentIntentId}` - Idempotency pointers (O(1) retry safety)
  - `magicLinkEphemeral/{paymentIntentId}` - Temporary plain tokens (unchanged)
- **Data Model**: Added `transactionId` field, donations now store `magicLinkTokenId` as `tokenHash`
- **Validation**: Updated `validateMagicLinkToken` to use direct document lookup instead of query

## Testing
- [x] `npm run build` - Passed
- [x] `npm run lint` - Passed
- [x] Manual verification completed

**Verified**:
- Token generation creates three documents atomically
- Webhook retries return existing token (idempotent)
- Token validation uses direct O(1) lookup
- No duplicate tokens or consent events on retries

## Risks

 **Breaking Change: Token Validation**
- Validation now uses `doc(tokenHash)` exclusively for O(1) lookups
- Tokens created under the previous `magicLinkTokens/{paymentIntentId}` structure will return `TOKEN_NOT_FOUND` after deployment.
- **Impact Window**: Limited to active, unconsumed tokens. 

## Deployment Notes
- No environment variables or migrations required
- Critical dependency for upcoming `completeGiftAidFlow` endpoint

## Checklist
- [x] I reviewed my own changes
- [x] I updated documentation when needed
- [ ] I added or updated tests where appropriate (deferred to separate task)
- [x] I confirmed no secrets were introduced

## Closes
Closes #662 