### PR TITLE
docs: add organisation + export implementation flow docs and align donation/giftaid docs

### DIFF
--- a/docs/CAMPAIGN_EXPORT_FLOW.md
+++ b/docs/CAMPAIGN_EXPORT_FLOW.md
@@ -1,0 +1,196 @@
+# Campaign Export Flow
+
+## 1) Purpose
+
+This document explains the campaign CSV export flow end-to-end:
+
+- export trigger from Admin Campaign Management
+- backend auth/permission and organization checks
+- filter application and CSV generation
+- browser download behavior
+
+---
+
+## 2) Scope
+
+### In Scope
+
+- Admin-triggered campaign export
+- optional filtering by search, status, category, and date range
+- optional targeted export using `campaignIds`
+- backend CSV response as downloadable attachment
+
+### Out of Scope
+
+- campaign creation/editing lifecycle
+- donation and gift aid exports
+- scheduled export jobs
+
+---
+
+## 3) Files and Ownership
+
+### Frontend
+
+- `src/views/admin/CampaignManagement.tsx`
+  - `handleExportCampaigns` request trigger and UI loading/toast handling
+
+- `src/entities/campaign/api/campaignExportApi.ts`
+  - authenticated function call
+  - attachment filename parse + blob download
+
+- `src/shared/config/functions.ts`
+  - `FUNCTION_URLS.exportCampaigns`
+
+### Backend
+
+- `backend/functions/handlers/campaignsExport.js`
+  - auth, permission, org-scope enforcement
+  - filter logic and CSV generation
+
+- `backend/functions/index.js`
+  - function registration: `exports.exportCampaigns`
+
+---
+
+## 4) High-Level Architecture
+
+```mermaid
+flowchart LR
+  A[Campaign Management UI] --> B[campaignExportApi.ts]
+  B --> C[Cloud Function: exportCampaigns]
+  C --> D[(Firestore campaigns)]
+  C --> E[CSV serialization]
+  E --> F[HTTP attachment response]
+  F --> B
+  B --> G[Browser download]
+```
+
+---
+
+## 5) How / Why / Where
+
+## A) UI Trigger
+
+How:
+
+1. Admin clicks Export.
+2. UI checks `export_campaigns` permission and `organizationId`.
+3. UI sends current filter state in request.
+
+Why:
+
+- export should mirror current admin filtering intent.
+
+Where:
+
+- `src/views/admin/CampaignManagement.tsx`
+
+## B) API Bridge
+
+How:
+
+1. Get Firebase ID token.
+2. `POST` request to `FUNCTION_URLS.exportCampaigns`.
+3. On success, parse `content-disposition` filename and trigger blob download.
+
+Why:
+
+- keeps auth and download handling centralized and reusable.
+
+Where:
+
+- `src/entities/campaign/api/campaignExportApi.ts`
+
+## C) Backend Export Logic
+
+How:
+
+1. Verify auth token.
+2. Load caller profile from `users/{uid}`.
+3. Enforce:
+   - `export_campaigns` or `system_admin`
+   - non-system admins can export only own organization
+4. Query campaigns by `organizationId`.
+5. Apply optional `campaignIds` and filters.
+6. Build CSV and return attachment.
+
+Why:
+
+- backend authority guarantees security and complete dataset export.
+
+Where:
+
+- `backend/functions/handlers/campaignsExport.js`
+
+---
+
+## 6) Sequence
+
+```mermaid
+sequenceDiagram
+  actor Admin
+  participant UI as CampaignManagement.tsx
+  participant API as campaignExportApi.ts
+  participant FN as exportCampaigns (CF)
+  participant FS as Firestore campaigns
+
+  Admin->>UI: Click Export
+  UI->>API: exportCampaigns({ organizationId, filters, campaignIds? })
+  API->>FN: POST + Authorization Bearer token
+  FN->>FN: verifyAuth + permission + org scope
+  FN->>FS: query campaigns by organizationId
+  FS-->>FN: campaign docs
+  FN->>FN: apply filters + build CSV
+  FN-->>API: 200 attachment response
+  API->>Admin: Trigger browser download
+```
+
+---
+
+## 7) Request Contract
+
+- `organizationId: string` (required)
+- `campaignIds?: string[]`
+- `filters?:`
+  - `searchTerm?: string`
+  - `status?: string`
+  - `category?: string`
+  - `dateRange?: "all" | "last30" | "last90" | "last365"`
+
+---
+
+## 8) Security and Validation
+
+- method must be `POST`
+- caller profile must exist
+- permission must include `export_campaigns` or `system_admin`
+- organization scope enforced for non-system admins
+- CSV formula sanitization is applied for string fields
+
+---
+
+## 9) Response Contract
+
+Success:
+
+- status `200`
+- `Content-Type: text/csv; charset=utf-8`
+- `Content-Disposition: attachment; filename="campaigns-{orgId}-{timestamp}.csv"`
+
+Failures:
+
+- `400` invalid payload
+- `403` permission/org-scope violation
+- `405` method not allowed
+- `500` unexpected backend error
+
+---
+
+## 10) Testing Checklist
+
+1. Export succeeds with valid permission and organization.
+2. Cross-organization export blocked for non-system-admin.
+3. `campaignIds` restrict exported rows correctly.
+4. Filters produce expected subset.
+5. Download filename and CSV content are correct.

--- a/docs/DONATION_EXPORT_FLOW.md
+++ b/docs/DONATION_EXPORT_FLOW.md
@@ -19,6 +19,7 @@ This flow replaces client-side CSV generation with a backend function so exports
 
 - Admin-triggered donation CSV export
 - Date range filtering (`current_month`, `past_month`, `custom`)
+- Server-side filter support (`searchTerm`, `status`, `campaignId`, `recurring`, `date`)
 - Backend permission and organization checks
 - CSV generation and download response
 
@@ -87,11 +88,12 @@ sequenceDiagram
 
   Admin->>UI: Click Export
   UI->>UI: Validate custom dates (if selected)
-  UI->>API: exportDonations({ organizationId, range, startDate?, endDate? })
+  UI->>API: exportDonations({ organizationId, range, startDate?, endDate?, filters? })
   API->>API: get Firebase ID token
   API->>FN: POST + Authorization: Bearer <token>
   FN->>FN: verifyAuth + permission + org scope
   FN->>FN: resolveDateRange(range, startDate, endDate)
+  FN->>FN: normalize and apply export filters
   FN->>FS: Query donations by organizationId
   FS-->>FN: Donation docs
   FN->>FN: Filter by effective timestamp
@@ -136,6 +138,13 @@ Conditional:
 
 - `startDate: "YYYY-MM-DD"` (required for `custom`)
 - `endDate: "YYYY-MM-DD"` (required for `custom`)
+- `filters?: {`
+  - `searchTerm?: string`
+  - `status?: string`
+  - `campaignId?: string`
+  - `recurring?: "all" | "recurring" | "one_time" | string`
+  - `date?: "YYYY-MM-DD"`
+- `}`
 
 Error behavior:
 
@@ -211,6 +220,12 @@ Filter:
   1. `paymentCompletedAt` (primary)
   2. `timestamp` (fallback)
   3. `createdAt` (fallback)
+- After date-range filtering, additional server-side export filters are applied:
+  - `searchTerm` matches donor name, payment intent id, transaction id, or campaign display name
+  - `status` matches `paymentStatus`
+  - `campaignId` matches donation campaign
+  - `recurring` maps to recurring vs one-time donations
+  - `date` matches effective timestamp date (`YYYY-MM-DD`)
 
 Records without a parseable effective timestamp are excluded.
 

--- a/docs/KIOSK_EXPORT_FLOW.md
+++ b/docs/KIOSK_EXPORT_FLOW.md
@@ -1,0 +1,198 @@
+# Kiosk Export Flow
+
+## 1) Purpose
+
+This document explains the kiosk CSV export flow end-to-end:
+
+- export trigger from Admin Kiosk Management
+- backend permission and organization checks
+- kiosk + donation aggregation for performance columns
+- downloadable CSV response
+
+---
+
+## 2) Scope
+
+### In Scope
+
+- Admin-triggered kiosk export
+- filter support for search and kiosk status
+- computed performance fields (`totalRaised`, `totalDonations`)
+
+### Out of Scope
+
+- kiosk CRUD and assignment management
+- campaign and subscription export logic
+- scheduled exports
+
+---
+
+## 3) Files and Ownership
+
+### Frontend
+
+- `src/views/admin/KioskManagement.tsx`
+  - `handleExportKiosks`
+
+- `src/entities/kiosk/api/kioskExportApi.ts`
+  - authenticated function call + browser download
+
+- `src/shared/config/functions.ts`
+  - `FUNCTION_URLS.exportKiosks`
+
+### Backend
+
+- `backend/functions/handlers/kiosksExport.js`
+  - authorization + org guardrails
+  - filtering + aggregation + CSV generation
+
+- `backend/functions/index.js`
+  - function registration: `exports.exportKiosks`
+
+---
+
+## 4) High-Level Architecture
+
+```mermaid
+flowchart LR
+  A[Kiosk Management UI] --> B[kioskExportApi.ts]
+  B --> C[Cloud Function: exportKiosks]
+  C --> D[(Firestore kiosks)]
+  C --> E[(Firestore donations)]
+  D --> F[Filter + combine]
+  E --> F
+  F --> G[CSV serialization]
+  G --> H[HTTP attachment response]
+  H --> B
+  B --> I[Browser download]
+```
+
+---
+
+## 5) How / Why / Where
+
+## A) UI Trigger
+
+How:
+
+1. Admin clicks Export.
+2. UI checks `export_kiosks` permission and `organizationId`.
+3. UI sends `organizationId` and current filters.
+
+Why:
+
+- ensure export is scoped to active organization and visible filter intent.
+
+Where:
+
+- `src/views/admin/KioskManagement.tsx`
+
+## B) API Bridge
+
+How:
+
+1. Retrieve current Firebase ID token.
+2. `POST` to `FUNCTION_URLS.exportKiosks`.
+3. Parse returned filename and download blob.
+
+Why:
+
+- centralizes auth, error handling, and download behavior.
+
+Where:
+
+- `src/entities/kiosk/api/kioskExportApi.ts`
+
+## C) Backend Export Logic
+
+How:
+
+1. Verify auth and permissions (`export_kiosks` or `system_admin`).
+2. Enforce same-org export for non-system-admin callers.
+3. Query kiosks by organization (and optional status).
+4. Query donations for same organization.
+5. Build per-kiosk performance map:
+   - `totalRaised`: sum of donation amounts by kiosk
+   - `totalDonations`: unique donor count by kiosk
+6. Emit fixed CSV schema and response attachment.
+
+Why:
+
+- combines operational kiosk state with donation outcomes in one export.
+
+Where:
+
+- `backend/functions/handlers/kiosksExport.js`
+
+---
+
+## 6) Sequence
+
+```mermaid
+sequenceDiagram
+  actor Admin
+  participant UI as KioskManagement.tsx
+  participant API as kioskExportApi.ts
+  participant FN as exportKiosks (CF)
+  participant K as Firestore kiosks
+  participant D as Firestore donations
+
+  Admin->>UI: Click Export
+  UI->>API: exportKiosks({ organizationId, filters })
+  API->>FN: POST + Bearer token
+  FN->>FN: verifyAuth + permission + org scope
+  FN->>K: query kiosks by organizationId
+  FN->>D: query donations by organizationId
+  K-->>FN: kiosk docs
+  D-->>FN: donation docs
+  FN->>FN: derive performance and build CSV
+  FN-->>API: 200 attachment response
+  API->>Admin: Trigger file download
+```
+
+---
+
+## 7) Request Contract
+
+- `organizationId: string` (required)
+- `filters?:`
+  - `searchTerm?: string`
+  - `status?: "all" | "online" | "offline" | "maintenance"`
+
+---
+
+## 8) CSV Contract
+
+Header order is fixed:
+
+1. `name`
+2. `location`
+3. `status`
+4. `kioskId`
+5. `totalRaised`
+6. `totalDonations`
+7. `assignedCampaigns`
+8. `lastActive`
+
+Filename:
+
+- `kiosks-{organizationId}-{YYYYMMDD-HHMMSSZ}.csv`
+
+---
+
+## 9) Security and Validation
+
+- `POST` only
+- caller must have kiosk export permission
+- non-system-admin cross-org request is rejected
+- CSV formula sanitization is applied
+
+---
+
+## 10) Testing Checklist
+
+1. Export works for valid org and permission.
+2. Search and status filters affect row set correctly.
+3. `totalRaised` and `totalDonations` aggregation correctness.
+4. Cross-org export blocked for non-system-admin.
+5. CSV headers and filename format are stable.

--- a/docs/ORGANIZATION_SETTINGS_IMPLEMENTATION_FLOW.md
+++ b/docs/ORGANIZATION_SETTINGS_IMPLEMENTATION_FLOW.md
@@ -1,0 +1,554 @@
+# Organization Settings Implementation Flow
+
+## 1) Purpose
+
+This document explains the Organization Settings page implementation end-to-end for:
+
+- identity updates (display name, thank-you message)
+- branding updates (accent color, logo, idle image)
+- organization switching for super admins
+- upload/remove/change behavior and validation gates
+- production-scale design guidance
+
+---
+
+## 2) Scope
+
+### In Scope
+
+- Admin UI behavior in `OrganizationSettings.tsx`
+- Client API bridge for uploads and secure settings persistence
+- Cloud Function validation + authorization
+- Firestore and Storage interactions
+- Security and scaling considerations
+
+### Out of Scope
+
+- Stripe onboarding and bank details
+- campaign/kiosk rendering internals consuming branding
+- organization creation/deletion workflows
+
+---
+
+## 3) Files and Ownership
+
+### Frontend UI
+
+- `src/views/admin/OrganizationSettings.tsx`
+  - form state, permission gating, crop dialog orchestration
+  - section-based saves (`identity`, `branding`)
+  - upload/remove actions and previews
+
+- `src/views/admin/OrganizationSwitcher.tsx`
+  - super-admin organization selector with search
+
+- `src/shared/ui/SquareImageCropDialog.tsx`
+  - client-side crop, zoom, drag, output file generation
+
+### Frontend Data/API
+
+- `src/shared/lib/hooks/useOrganization.ts`
+  - real-time org data via Firestore `onSnapshot`
+  - local cache hydration for better perceived performance
+
+- `src/entities/organization/api/organizationApi.ts`
+  - storage upload path generation
+  - image upload entrypoint
+  - secure function call for settings update
+
+- `src/shared/lib/imageUpload.ts`
+  - file type/size/aspect validation
+  - Firebase Storage upload + download URL retrieval
+
+- `src/shared/config/functions.ts`
+  - function URL mapping (`updateOrganizationSettings`)
+
+### Backend
+
+- `backend/functions/handlers/organizationSettings.js`
+  - payload validation and normalization
+  - auth + permission + org-boundary enforcement
+  - storage URL ownership verification
+  - section guardrails (`identity` vs `branding`)
+  - Firestore merge update with audit fields
+
+- `backend/functions/index.js`
+  - Cloud Function export registration (`updateOrganizationSettings`)
+
+- `backend/storage.rules`
+  - storage read/write permissions for org settings assets
+
+---
+
+## 4) High-Level Architecture
+
+```mermaid
+flowchart LR
+  A[Admin Organization Settings UI] --> B[organizationApi.ts]
+  B --> C[imageUpload.ts]
+  C --> D[(Firebase Storage)]
+
+  B --> E[Cloud Function: updateOrganizationSettings]
+  E --> F[(users collection)]
+  E --> G[(organizations collection)]
+  E --> D
+
+  H[useOrganization hook] --> G
+  G --> A
+```
+
+---
+
+## 4.1) How / Why / Where (Implementation Narrative)
+
+This section is the direct implementation flow in `how -> why -> where` format.
+
+## A) Page Load and Initial Data Hydration
+
+How:
+
+1. Admin opens Organization Settings screen.
+2. Page resolves `organizationId` from `userSession`.
+3. `useOrganization(organizationId)` subscribes to Firestore org doc.
+4. Form state is initialized from `organization.settings` (or fallback values).
+5. Permission flags are derived (`canEditIdentity`, `canEditBranding`, `canSwitchOrganization`).
+
+Why:
+
+- Real-time subscription keeps admin UI consistent with latest saved org settings.
+- Local form state allows edit buffering before save.
+- Early permission derivation keeps UI and action buttons safe by default.
+
+Where:
+
+- `src/views/admin/OrganizationSettings.tsx`
+- `src/shared/lib/hooks/useOrganization.ts`
+
+## B) Upload Logo / Idle Image (Pre-Save Stage)
+
+How:
+
+1. User picks file from hidden input.
+2. Crop dialog opens (`SquareImageCropDialog`) with aspect ratio:
+   - logo: `1:1`
+   - idle image: `16:9`
+3. On confirm, cropped file is validated and uploaded to Storage.
+4. Upload response returns URL + dimensions + metadata.
+5. UI stores asset as pending (`pendingLogo` / `pendingIdleImage`) and previews it.
+6. No Firestore settings write happens yet.
+
+Why:
+
+- Crop-before-upload gives deterministic kiosk-ready media.
+- Two-phase commit behavior (upload first, save settings later) avoids partial settings writes.
+- Pending state allows users to review changes before persisting.
+
+Where:
+
+- `src/views/admin/OrganizationSettings.tsx` (`handleLogoFileChange`, `handleIdleImageFileChange`, `handleUploadImage`)
+- `src/shared/ui/SquareImageCropDialog.tsx`
+- `src/entities/organization/api/organizationApi.ts` (`uploadOrganizationSettingsImage`)
+- `src/shared/lib/imageUpload.ts`
+
+## C) Save Identity Section
+
+How:
+
+1. User clicks `Save Identity`.
+2. Client verifies identity permission and dirty-state.
+3. Client validates `displayName`, `thankYouMessage`, color format baseline.
+4. API sends payload with `section: "identity"` and normalized values.
+5. Function validates payload + auth + org scope + identity permission.
+6. Function rejects if branding fields changed in identity section.
+7. Function merges `settings` in Firestore and sets `updatedAt`, `updatedBy`.
+
+Why:
+
+- Section-scoped saves allow delegated permissions per concern.
+- Backend re-validation prevents client bypass and maintains authoritative constraints.
+
+Where:
+
+- `src/views/admin/OrganizationSettings.tsx` (`handleSaveSection`)
+- `src/entities/organization/api/organizationApi.ts` (`saveOrganizationSettings`, `updateOrganizationSettings`)
+- `backend/functions/handlers/organizationSettings.js`
+
+## D) Save Branding Section
+
+How:
+
+1. User clicks `Save Branding`.
+2. Client verifies branding permission and dirty-state.
+3. Client ensures accent color is valid and logo dimensions are available.
+4. API sends payload with `section: "branding"` including URLs and logo dimensions.
+5. Function verifies asset URLs belong to the same org path and allowed bucket.
+6. Function rejects if identity fields changed in branding section.
+7. Function writes merged settings + audit metadata to Firestore.
+
+Why:
+
+- URL ownership checks block cross-org asset reference attacks.
+- Logo dimension checks enforce the 1:1 brand asset contract.
+
+Where:
+
+- `src/views/admin/OrganizationSettings.tsx` (`handleSaveSection`, `loadImageDimensionsFromUrl`)
+- `src/entities/organization/api/organizationApi.ts`
+- `backend/functions/handlers/organizationSettings.js` (`assertAssetBelongsToOrganization`)
+- `backend/storage.rules`
+
+## E) Remove / Replace Asset
+
+How:
+
+1. Remove action clears local URL + pending metadata in UI.
+2. Save Branding persists `null` URL values to settings.
+3. Replace action uploads a new asset and overwrites URL on next Save Branding.
+
+Why:
+
+- Keeping remove as a local staged change matches same save semantics as other fields.
+- Prevents accidental destructive storage operations from UI-only clicks.
+
+Where:
+
+- `src/views/admin/OrganizationSettings.tsx` (`handleRemoveLogo`, `handleRemoveIdleImage`)
+- `backend/functions/handlers/organizationSettings.js`
+
+## F) Switch Organization (Privileged Only)
+
+How:
+
+1. Super admin opens switcher popover.
+2. Selector fetches organizations and filters by search query.
+3. Selected org id is passed to parent via `onOrganizationChange`.
+4. Page rerenders with new org context; hook resubscribes to target org doc.
+
+Why:
+
+- Allows centralized support and operations without direct DB editing.
+- Keeps same settings page workflow reusable across organizations.
+
+Where:
+
+- `src/views/admin/OrganizationSwitcher.tsx`
+- `src/views/admin/OrganizationSettings.tsx`
+- `src/shared/lib/hooks/useOrganization.ts`
+
+---
+
+## 5) Runtime Data Model
+
+Organization settings are persisted under:
+
+- `organizations/{organizationId}.settings.displayName`
+- `organizations/{organizationId}.settings.thankYouMessage`
+- `organizations/{organizationId}.settings.accentColorHex`
+- `organizations/{organizationId}.settings.logoUrl`
+- `organizations/{organizationId}.settings.idleImageUrl`
+- `organizations/{organizationId}.settings.updatedAt`
+- `organizations/{organizationId}.settings.updatedBy`
+
+Uploaded assets are stored under:
+
+- `organizations/{organizationId}/settings/logo/{timestamp}-{sanitizedName}.{ext}`
+- `organizations/{organizationId}/settings/idleImage/{timestamp}-{sanitizedName}.{ext}`
+
+---
+
+## 6) Permissions and Access Model
+
+### UI-Level Gating
+
+Page uses:
+
+- role checks (`admin`, `super_admin`)
+- explicit permissions:
+  - `change_org_identity`
+  - `change_org_branding`
+
+Super-admin org switching requires:
+
+- role `super_admin`
+- permission `system_admin`
+
+### Backend Enforcement
+
+Function accepts update only if:
+
+- caller is authenticated
+- caller has org settings write access:
+  - section-specific permission, or
+  - `system_admin`
+- non-privileged callers can only update their own `organizationId`
+
+### Storage Enforcement
+
+From `backend/storage.rules`:
+
+- public read is allowed only for `logo` and `idleImage` asset paths
+- write is allowed only for admin-like users in the same organization path
+
+---
+
+## 7) Save Flow (Identity and Branding)
+
+```mermaid
+sequenceDiagram
+  actor Admin
+  participant UI as OrganizationSettings.tsx
+  participant API as organizationApi.saveOrganizationSettings
+  participant FN as updateOrganizationSettings (CF)
+  participant FS as Firestore organizations
+
+  Admin->>UI: Click Save Identity/Branding
+  UI->>UI: Validate fields + section changes
+  UI->>API: Build payload + include section
+  API->>API: get Firebase ID token
+  API->>FN: POST with Bearer token
+  FN->>FN: Validate payload and section constraints
+  FN->>FN: Verify caller permission + org scope
+  FN->>FS: Merge settings + updatedAt/updatedBy
+  FS-->>FN: Write success
+  FN-->>API: 200 success payload
+  API-->>UI: Resolve promise
+  UI->>Admin: Toast + state cleanup
+```
+
+---
+
+## 8) Upload, Remove, and Change Asset Flows
+
+## 8.1 Upload (Logo / Idle Image)
+
+```mermaid
+flowchart TD
+  A[User chooses file] --> B[Open crop dialog]
+  B --> C[Crop/zoom/position]
+  C --> D[Confirm cropped file]
+  D --> E[uploadOrganizationSettingsImage]
+  E --> F[Validate type/size/aspect in imageUpload.ts]
+  F --> G[Upload to Storage path under org/settings/assetType]
+  G --> H[Receive download URL + width + height]
+  H --> I[Set pending asset + preview URL in UI state]
+  I --> J[Persist only when Save Branding is clicked]
+```
+
+Notes:
+
+- `logo` requires square validation (`requireSquare: true`)
+- `idleImage` is cropped at `16:9` in dialog and uploaded without square requirement
+
+## 8.2 Remove Asset
+
+- Remove buttons clear local state (`logoUrl`, `idleImageUrl`, pending metadata)
+- no storage delete is performed during remove action
+- deletion is persisted only after clicking Save Branding (URL set to `null`)
+
+Operational implication:
+
+- old files remain in Storage unless cleanup tooling/lifecycle policy is added
+
+## 8.3 Change Asset
+
+- Uploading a new file updates local preview and pending metadata
+- persisted URL changes only on Save Branding
+- backend verifies URL path belongs to target org and expected asset type
+
+---
+
+## 9) Section Guardrails
+
+The backend enforces strict section boundaries:
+
+- if `section = identity`, branding fields cannot change
+- if `section = branding`, identity fields cannot change
+
+This protects against accidental mixed updates and supports clean permission delegation across teams.
+
+```mermaid
+flowchart TD
+  A[Incoming payload] --> B{section provided?}
+  B -- identity --> C{branding fields changed?}
+  C -- yes --> X[400 reject]
+  C -- no --> D[identity permission check]
+  B -- branding --> E{identity fields changed?}
+  E -- yes --> X
+  E -- no --> F[branding permission check]
+  B -- missing --> G[evaluate both change sets]
+```
+
+---
+
+## 10) Validation Matrix
+
+Client and backend both validate key constraints:
+
+- `displayName` required, max 40 chars
+- `thankYouMessage` max 140 chars
+- `accentColorHex` must match `#RRGGBB`
+- when `logoUrl` is present, `logoWidth` and `logoHeight` must exist and match 1:1 ratio
+- `logoUrl` and `idleImageUrl` must be HTTP(S) or `gs://`
+- asset URL must resolve to:
+  - allowed storage bucket
+  - expected path prefix
+  - same target organization
+
+---
+
+## 11) Organization Switching Behavior
+
+Only privileged super admins get the switcher in Organization Settings.
+
+Workflow:
+
+1. Load organizations for selector.
+2. Search and choose another organization.
+3. Parent updates active org context.
+4. `useOrganization` subscribes to new org document and refreshes form.
+
+This enables centralized support/admin workflows without direct database edits.
+
+---
+
+## 12) Scale-Oriented Design Guidance
+
+## 12.1 Security Hardening
+
+- Keep backend as final authority for:
+  - permission checks
+  - org scope checks
+  - URL ownership checks
+- Never trust client-provided asset metadata alone.
+- Keep Storage rules and function validations aligned to avoid bypass gaps.
+
+## 12.2 Performance and Cost
+
+- `useOrganization` snapshot subscription gives low-latency updates but can increase read volume at scale.
+- If admin sessions grow significantly, consider:
+  - listener lifecycle optimization
+  - per-screen subscription toggles
+  - cache TTL strategy for low-change fields
+
+## 12.3 Storage Lifecycle
+
+Current remove/replace logic leaves old assets in bucket.
+
+Recommended for scale:
+
+- maintain `settingsAssetRefs` metadata with active file path
+- add scheduled cleanup job to remove unreferenced historical files
+- add retention window and soft-delete period to avoid accidental loss
+
+## 12.4 Observability
+
+Add structured logs/metrics for:
+
+- settings update success/fail by section
+- rejection reason counters (permission, invalid payload, URL ownership)
+- upload failure types (size, type, aspect, network)
+
+## 12.5 Auditing and Compliance
+
+Current audit fields (`updatedAt`, `updatedBy`) are good baseline.
+
+For enterprise-grade governance, add:
+
+- immutable settings change history collection
+- before/after diff snapshots
+- actor role and permission snapshot at write time
+
+## 12.6 Concurrency
+
+Current behavior is last-write-wins.
+
+If concurrent editing becomes common:
+
+- include settings version/etag in payload
+- reject stale writes with conflict response (`409`)
+- show conflict resolution UI
+
+---
+
+## 13) Failure Modes and Troubleshooting
+
+Common failures:
+
+- `403`: missing permission or cross-organization attempt
+- `400`: section mismatch, invalid hex, invalid lengths, invalid URL ownership
+- `404`: organization missing
+- function unreachable from frontend (bad URL/env/network)
+
+Quick checks:
+
+1. Confirm caller has correct permission in `users/{uid}.permissions`.
+2. Confirm caller org matches requested org unless `system_admin`.
+3. Confirm uploaded asset URL path starts with:
+   - `organizations/{orgId}/settings/logo/` or
+   - `organizations/{orgId}/settings/idleImage/`
+4. Confirm bucket in URL is one of allowed project buckets.
+
+---
+
+## 14) Recommended Test Matrix
+
+### Unit / Component
+
+- color validation (`#RRGGBB`) and max-length guards
+- crop dialog output dimensions and file generation path
+- section dirty-state detection (`hasIdentityChanges`, `hasBrandingChanges`)
+
+### Integration
+
+- upload -> save branding -> reload page persists values
+- remove image -> save branding -> URL becomes null in Firestore
+- cross-org save blocked for non-privileged user
+- section mismatch payload rejected
+
+### E2E
+
+- super-admin switches organization and edits target org settings
+- admin can edit own org but not cross-org
+- kiosk-facing branding update appears after persistence
+
+---
+
+## 15) Safe Extension Patterns
+
+To add new settings fields safely:
+
+1. Add field in frontend state and form UI.
+2. Add to `saveOrganizationSettings` payload shape.
+3. Add backend validation/normalization.
+4. Add section ownership rules (identity vs branding).
+5. Add tests for permission and invalid payloads.
+6. Add migration/default handling for existing org records.
+
+To support strict asset deletion:
+
+1. Store active asset storage paths in settings.
+2. On successful replace, enqueue deletion of previous path.
+3. Run deletion in backend with retries and idempotency keys.
+
+---
+
+## 16) Quick Reference
+
+### Main UI Entry
+
+- `src/views/admin/OrganizationSettings.tsx`
+
+### Organization Switching
+
+- `src/views/admin/OrganizationSwitcher.tsx`
+
+### Backend Entry
+
+- `backend/functions/handlers/organizationSettings.js`
+- `backend/functions/index.js` (`exports.updateOrganizationSettings`)
+
+### Upload and Validation
+
+- `src/entities/organization/api/organizationApi.ts`
+- `src/shared/lib/imageUpload.ts`
+- `backend/storage.rules`

--- a/docs/SUBSCRIPTION_EXPORT_FLOW.md
+++ b/docs/SUBSCRIPTION_EXPORT_FLOW.md
@@ -1,0 +1,222 @@
+# Subscription Export Flow
+
+## 1) Purpose
+
+This document explains the subscription CSV export flow end-to-end:
+
+- export trigger from Admin Subscription Management
+- date-range and filter handling
+- backend permission + organization checks
+- CSV generation and download response
+
+---
+
+## 2) Scope
+
+### In Scope
+
+- Admin-triggered subscription export
+- range handling (`current_month`, `past_month`, `custom`)
+- search/status/interval filters
+- backend CSV attachment response
+
+### Out of Scope
+
+- subscription lifecycle mutations (cancel/update payment method)
+- donation and gift aid export internals
+- recurring analytics dashboards
+
+---
+
+## 3) Files and Ownership
+
+### Frontend
+
+- `src/views/admin/SubscriptionManagement.tsx`
+  - `handleExport` and range/date validation in UI
+
+- `src/entities/subscription/api/subscriptionExportApi.ts`
+  - authenticated function call and blob download handling
+
+- `src/shared/config/functions.ts`
+  - `FUNCTION_URLS.exportSubscriptions`
+
+### Backend
+
+- `backend/functions/handlers/subscriptionsExport.js`
+  - date-range resolution
+  - permission + org checks
+  - filter application and CSV output
+
+- `backend/functions/index.js`
+  - function registration: `exports.exportSubscriptions`
+
+---
+
+## 4) High-Level Architecture
+
+```mermaid
+flowchart LR
+  A[Subscription Management UI] --> B[subscriptionExportApi.ts]
+  B --> C[Cloud Function: exportSubscriptions]
+  C --> D[(Firestore subscriptions)]
+  C --> E[Date-range + filter processing]
+  E --> F[CSV serialization]
+  F --> G[HTTP attachment response]
+  G --> B
+  B --> H[Browser download]
+```
+
+---
+
+## 5) How / Why / Where
+
+## A) UI Trigger and Validation
+
+How:
+
+1. Admin selects export range.
+2. For `custom`, UI requires both `startDate` and `endDate`.
+3. UI triggers export with organization, range, and filters.
+
+Why:
+
+- catches missing custom dates before network call.
+
+Where:
+
+- `src/views/admin/SubscriptionManagement.tsx`
+
+## B) API Bridge
+
+How:
+
+1. Fetch current user ID token.
+2. `POST` to `FUNCTION_URLS.exportSubscriptions`.
+3. Parse file name from `content-disposition` and download CSV blob.
+
+Why:
+
+- keeps auth and download behavior consistent with other exports.
+
+Where:
+
+- `src/entities/subscription/api/subscriptionExportApi.ts`
+
+## C) Backend Export Processing
+
+How:
+
+1. Verify auth and caller profile.
+2. Enforce permission (`export_subscriptions` or `system_admin`).
+3. Enforce org-scope for non-system-admin users.
+4. Resolve UTC date window:
+   - current month
+   - past month
+   - custom start/end
+5. Query subscriptions by `organizationId`.
+6. Keep rows with `createdAt` in range.
+7. Apply filters (`searchTerm`, `status`, `interval`).
+8. Build fixed CSV schema and return attachment.
+
+Why:
+
+- server-side date and filter logic ensures reliable, auditable exports.
+
+Where:
+
+- `backend/functions/handlers/subscriptionsExport.js`
+
+---
+
+## 6) Sequence
+
+```mermaid
+sequenceDiagram
+  actor Admin
+  participant UI as SubscriptionManagement.tsx
+  participant API as subscriptionExportApi.ts
+  participant FN as exportSubscriptions (CF)
+  participant FS as Firestore subscriptions
+
+  Admin->>UI: Select range and click Export
+  UI->>UI: Validate custom dates
+  UI->>API: exportSubscriptions(request)
+  API->>FN: POST + Authorization Bearer token
+  FN->>FN: verifyAuth + permission + org scope
+  FN->>FN: resolveDateRange(range, startDate, endDate)
+  FN->>FS: query subscriptions by organizationId
+  FS-->>FN: subscription docs
+  FN->>FN: date+filter match and CSV generation
+  FN-->>API: 200 attachment response
+  API->>Admin: Trigger browser download
+```
+
+---
+
+## 7) Request Contract
+
+- `organizationId: string` (required)
+- `range: "current_month" | "past_month" | "custom"` (required)
+- `startDate?: "YYYY-MM-DD"` (required for `custom`)
+- `endDate?: "YYYY-MM-DD"` (required for `custom`)
+- `filters?:`
+  - `searchTerm?: string`
+  - `status?: string`
+  - `interval?: string`
+
+---
+
+## 8) CSV Contract
+
+Header order is fixed:
+
+1. `donorName`
+2. `donorEmail`
+3. `stripeSubscriptionId`
+4. `status`
+5. `amountMinor`
+6. `amountDisplay`
+7. `interval`
+8. `nextPayment`
+9. `startedAt`
+10. `createdAt`
+11. `canceledAt`
+12. `cancelReason`
+
+Filename format:
+
+- `subscriptions-{range}-{YYYYMMDD}-{YYYYMMDD}.csv`
+
+---
+
+## 9) Security and Validation
+
+- `POST` only
+- auth token required
+- permission: `export_subscriptions` or `system_admin`
+- cross-org export blocked for non-system-admin callers
+- strict custom date parsing (`YYYY-MM-DD`)
+- rejects end date before start date
+- CSV formula sanitization is applied
+
+---
+
+## 10) Error Behavior
+
+- `400`: invalid range/dates or missing required fields
+- `403`: permission denied or cross-org attempt
+- `405`: method not allowed
+- `500`: unexpected backend failure
+
+Frontend surfaces backend error messages in toast notifications.
+
+---
+
+## 11) Testing Checklist
+
+1. Export succeeds for each supported range.
+2. Custom range validation blocks missing/invalid dates.
+3. Interval/status/search filters work as expected.
+4. Non-system-admin cross-org export is rejected.
+5. CSV headers and filename format are correct.


### PR DESCRIPTION
## Summary
This PR adds and updates documentation for admin organisation settings and export flows.
Closes #658 

## What Changed
- Added detailed Organisation Settings implementation flow doc:
  - `docs/ORGANIZATION_SETTINGS_IMPLEMENTATION_FLOW.md`
- Added separate export flow docs:
  - `docs/CAMPAIGN_EXPORT_FLOW.md`
  - `docs/KIOSK_EXPORT_FLOW.md`
  - `docs/SUBSCRIPTION_EXPORT_FLOW.md`
- Updated donation export doc to include current filter-based server-side flow:
  - `docs/DONATION_EXPORT_FLOW.md`
- Cleaned quote/encoding artefacts in Gift Aid export doc:
  - `docs/GIFTAID_EXPORT_FLOW.md`

## Why
- Keep implementation docs aligned with current code behaviour.
- Improve maintainability by having one doc per export flow (same style as existing docs).
- Make onboarding/debugging easier with clear How/Why/Where sections and diagrams.

## Validation
- Verified docs against current frontend API + backend handler implementations for:
  - Campaign export
  - Kiosk export
  - Subscription export
  - Donation export (including filters)
  - Gift Aid export

## Notes
- Documentation-only PR (no runtime code logic changes).
