### PR TITLE
ix(org-settings): section-scoped saves without losing opposite-section drafts (fix #673)

### DIFF
--- a/backend/functions/handlers/organizationSettings.js
+++ b/backend/functions/handlers/organizationSettings.js
@@ -308,6 +308,41 @@ const resolveSettingsForDiff = (organizationData) => {
   return organizationData.settings;
 };
 
+const buildSectionScopedSettings = ({
+  section,
+  incomingSettings,
+  organizationData,
+  currentSettings,
+}) => {
+  if (section !== 'identity' && section !== 'branding') {
+    return incomingSettings;
+  }
+
+  const currentDisplayName = resolveOrganizationDisplayName(organizationData);
+  const currentThankYouMessage = normalizeOptionalString(currentSettings.thankYouMessage);
+  const currentAccentColorHex = normalizeHexColor(currentSettings.accentColorHex);
+  const currentLogoUrl = normalizeOptionalString(currentSettings.logoUrl);
+  const currentIdleImageUrl = normalizeOptionalString(currentSettings.idleImageUrl);
+
+  if (section === 'identity') {
+    return {
+      displayName: incomingSettings.displayName,
+      thankYouMessage: incomingSettings.thankYouMessage,
+      accentColorHex: currentAccentColorHex,
+      logoUrl: currentLogoUrl,
+      idleImageUrl: currentIdleImageUrl,
+    };
+  }
+
+  return {
+    displayName: currentDisplayName,
+    thankYouMessage: currentThankYouMessage,
+    accentColorHex: incomingSettings.accentColorHex,
+    logoUrl: incomingSettings.logoUrl,
+    idleImageUrl: incomingSettings.idleImageUrl,
+  };
+};
+
 const updateOrganizationSettings = (req, res) => {
   cors(req, res, async () => {
     try {
@@ -317,18 +352,6 @@ const updateOrganizationSettings = (req, res) => {
 
       const auth = await verifyAuth(req);
       const { organizationId, section, settings } = validateAndNormalizeSettingsPayload(req.body);
-      assertAssetBelongsToOrganization(
-        settings.logoUrl,
-        organizationId,
-        LOGO_STORAGE_PATH_REGEX,
-        'logoUrl',
-      );
-      assertAssetBelongsToOrganization(
-        settings.idleImageUrl,
-        organizationId,
-        IDLE_IMAGE_STORAGE_PATH_REGEX,
-        'idleImageUrl',
-      );
       const callerData = await getCallerProfile(auth.uid);
 
       if (!hasAnyOrgSettingsWriteAccess(callerData)) {
@@ -358,29 +381,38 @@ const updateOrganizationSettings = (req, res) => {
 
       const currentOrganizationData = orgSnapshot.data() || {};
       const currentSettings = resolveSettingsForDiff(currentOrganizationData);
+      const sectionScopedSettings = buildSectionScopedSettings({
+        section,
+        incomingSettings: settings,
+        organizationData: currentOrganizationData,
+        currentSettings,
+      });
       const identityChanged =
-        normalizeIdentityField(settings.displayName) !==
+        normalizeIdentityField(sectionScopedSettings.displayName) !==
           normalizeIdentityField(resolveOrganizationDisplayName(currentOrganizationData)) ||
-        normalizeIdentityField(settings.thankYouMessage) !==
+        normalizeIdentityField(sectionScopedSettings.thankYouMessage) !==
           normalizeIdentityField(currentSettings.thankYouMessage);
       const brandingChanged =
-        normalizeHexColor(settings.accentColorHex) !==
+        normalizeHexColor(sectionScopedSettings.accentColorHex) !==
           normalizeHexColor(currentSettings.accentColorHex) ||
-        normalizeOptionalString(settings.logoUrl) !==
+        normalizeOptionalString(sectionScopedSettings.logoUrl) !==
           normalizeOptionalString(currentSettings.logoUrl) ||
-        normalizeOptionalString(settings.idleImageUrl) !==
+        normalizeOptionalString(sectionScopedSettings.idleImageUrl) !==
           normalizeOptionalString(currentSettings.idleImageUrl);
 
-      if (section === 'identity' && brandingChanged) {
-        return res.status(400).send({
-          error: 'Branding fields cannot be changed when section is identity',
-        });
-      }
-
-      if (section === 'branding' && identityChanged) {
-        return res.status(400).send({
-          error: 'Identity fields cannot be changed when section is branding',
-        });
+      if (brandingChanged) {
+        assertAssetBelongsToOrganization(
+          sectionScopedSettings.logoUrl,
+          organizationId,
+          LOGO_STORAGE_PATH_REGEX,
+          'logoUrl',
+        );
+        assertAssetBelongsToOrganization(
+          sectionScopedSettings.idleImageUrl,
+          organizationId,
+          IDLE_IMAGE_STORAGE_PATH_REGEX,
+          'idleImageUrl',
+        );
       }
 
       if (
@@ -405,7 +437,7 @@ const updateOrganizationSettings = (req, res) => {
       await orgRef.set(
         {
           settings: {
-            ...settings,
+            ...sectionScopedSettings,
             updatedAt,
             updatedBy: auth.uid,
           },
@@ -417,7 +449,7 @@ const updateOrganizationSettings = (req, res) => {
         success: true,
         organizationId,
         settings: {
-          ...settings,
+          ...sectionScopedSettings,
           updatedAt,
           updatedBy: auth.uid,
         },

--- a/backend/functions/handlers/organizationSettings.test.js
+++ b/backend/functions/handlers/organizationSettings.test.js
@@ -220,4 +220,83 @@ describe('updateOrganizationSettings', () => {
       }),
     });
   });
+
+  it('ignores branding deltas in identity section payloads', async () => {
+    await seedOrganization('org-1', {
+      settings: {
+        displayName: 'Org One',
+        logoUrl: null,
+        idleImageUrl: null,
+        accentColorHex: '#0E8F5A',
+        thankYouMessage: null,
+      },
+    });
+    await seedUser('user-1', {
+      role: 'admin',
+      permissions: ['change_org_identity'],
+    });
+
+    const req = createRequest({
+      organizationId: 'org-1',
+      section: 'identity',
+      settings: {
+        displayName: 'Org One Updated',
+        accentColorHex: '#123ABC',
+        logoUrl: null,
+        idleImageUrl: null,
+        thankYouMessage: 'Thanks!',
+      },
+    });
+    const res = await invokeHandler(req);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      organizationId: 'org-1',
+      settings: expect.objectContaining({
+        displayName: 'Org One Updated',
+        accentColorHex: '#0E8F5A',
+      }),
+    });
+  });
+
+  it('ignores identity deltas in branding section payloads', async () => {
+    await seedOrganization('org-1', {
+      settings: {
+        displayName: 'Org One',
+        logoUrl: null,
+        idleImageUrl: null,
+        accentColorHex: '#0E8F5A',
+        thankYouMessage: 'Thanks',
+      },
+    });
+    await seedUser('user-1', {
+      role: 'admin',
+      permissions: ['change_org_branding'],
+    });
+
+    const req = createRequest({
+      organizationId: 'org-1',
+      section: 'branding',
+      settings: {
+        displayName: 'Unauthorized Identity Change',
+        accentColorHex: '#123ABC',
+        logoUrl: null,
+        idleImageUrl: null,
+        thankYouMessage: 'Should be ignored',
+      },
+    });
+    const res = await invokeHandler(req);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      organizationId: 'org-1',
+      settings: expect.objectContaining({
+        displayName: 'Org One',
+        accentColorHex: '#123ABC',
+        thankYouMessage: 'Thanks',
+      }),
+    });
+  });
 });

--- a/src/views/admin/OrganizationSettings.tsx
+++ b/src/views/admin/OrganizationSettings.tsx
@@ -262,6 +262,12 @@ export function OrganizationSettings({
   };
 
   const handleSaveSection = async (section: 'identity' | 'branding') => {
+    const currentOrganization = organization;
+    if (!currentOrganization) {
+      showToast('Organization record is not available.', 'error');
+      return;
+    }
+
     const hasSectionPermission = section === 'identity' ? canEditIdentity : canEditBranding;
     if (!hasSectionPermission) {
       showToast(
@@ -319,16 +325,31 @@ export function OrganizationSettings({
 
     setSavingSection(section);
     try {
+      const persistedDisplayName = (
+        currentOrganization.settings?.displayName ||
+        currentOrganization.name ||
+        ''
+      ).trim();
+      const persistedThankYouMessage = (currentOrganization.settings?.thankYouMessage || '').trim();
+      const persistedAccentColorHex = (
+        currentOrganization.settings?.accentColorHex || ACCENT_COLOR_FALLBACK
+      ).trim();
+      const persistedLogoUrl = currentOrganization.settings?.logoUrl || null;
+      const persistedIdleImageUrl = currentOrganization.settings?.idleImageUrl || null;
+      const isIdentitySave = section === 'identity';
+
       await organizationApi.saveOrganizationSettings({
         organizationId,
         section,
-        displayName: trimmedDisplayName,
-        accentColorHex: trimmedAccentColorHex,
-        thankYouMessage: trimmedThankYouMessage || null,
-        logoUrl,
-        idleImageUrl,
-        logo: pendingLogo,
-        idleImage: pendingIdleImage,
+        displayName: isIdentitySave ? trimmedDisplayName : persistedDisplayName,
+        accentColorHex: isIdentitySave ? persistedAccentColorHex : trimmedAccentColorHex,
+        thankYouMessage: isIdentitySave
+          ? trimmedThankYouMessage || null
+          : persistedThankYouMessage || null,
+        logoUrl: isIdentitySave ? persistedLogoUrl : logoUrl,
+        idleImageUrl: isIdentitySave ? persistedIdleImageUrl : idleImageUrl,
+        logo: isIdentitySave ? null : pendingLogo,
+        idleImage: isIdentitySave ? null : pendingIdleImage,
         logoDimensions: resolvedLogoDimensions,
       });
 

--- a/src/views/admin/OrganizationSettings.tsx
+++ b/src/views/admin/OrganizationSettings.tsx
@@ -102,12 +102,27 @@ export function OrganizationSettings({
 
   const logoInputRef = useRef<HTMLInputElement | null>(null);
   const idleImageInputRef = useRef<HTMLInputElement | null>(null);
+  const pendingOppositeSectionDraftRef = useRef<{
+    identity?: {
+      displayName: string;
+      thankYouMessage: string;
+    };
+    branding?: {
+      accentColorHex: string;
+      logoUrl: string | null;
+      idleImageUrl: string | null;
+      pendingLogo: OrganizationSettingsUploadResult | null;
+      pendingIdleImage: OrganizationSettingsUploadResult | null;
+      logoDimensions: { width: number; height: number } | null;
+    };
+  } | null>(null);
 
   useEffect(() => {
     if (!organization) {
       return;
     }
 
+    const draftToRestore = pendingOppositeSectionDraftRef.current;
     setDisplayName(organization.settings?.displayName || organization.name || '');
     setAccentColorHex(organization.settings?.accentColorHex || ACCENT_COLOR_FALLBACK);
     setThankYouMessage(organization.settings?.thankYouMessage || '');
@@ -115,6 +130,23 @@ export function OrganizationSettings({
     setIdleImageUrl(organization.settings?.idleImageUrl || null);
     setPendingLogo(null);
     setPendingIdleImage(null);
+    setLogoDimensions(null);
+
+    if (draftToRestore?.identity) {
+      setDisplayName(draftToRestore.identity.displayName);
+      setThankYouMessage(draftToRestore.identity.thankYouMessage);
+    }
+
+    if (draftToRestore?.branding) {
+      setAccentColorHex(draftToRestore.branding.accentColorHex);
+      setLogoUrl(draftToRestore.branding.logoUrl);
+      setIdleImageUrl(draftToRestore.branding.idleImageUrl);
+      setPendingLogo(draftToRestore.branding.pendingLogo);
+      setPendingIdleImage(draftToRestore.branding.pendingIdleImage);
+      setLogoDimensions(draftToRestore.branding.logoDimensions);
+    }
+
+    pendingOppositeSectionDraftRef.current = null;
   }, [organization]);
 
   useEffect(() => {
@@ -325,6 +357,28 @@ export function OrganizationSettings({
 
     setSavingSection(section);
     try {
+      const draftToPreserve =
+        section === 'identity' && hasBrandingChanges
+          ? {
+              branding: {
+                accentColorHex,
+                logoUrl,
+                idleImageUrl,
+                pendingLogo,
+                pendingIdleImage,
+                logoDimensions,
+              },
+            }
+          : section === 'branding' && hasIdentityChanges
+            ? {
+                identity: {
+                  displayName,
+                  thankYouMessage,
+                },
+              }
+            : null;
+      pendingOppositeSectionDraftRef.current = draftToPreserve;
+
       const persistedDisplayName = (
         currentOrganization.settings?.displayName ||
         currentOrganization.name ||
@@ -353,8 +407,10 @@ export function OrganizationSettings({
         logoDimensions: resolvedLogoDimensions,
       });
 
-      setPendingLogo(null);
-      setPendingIdleImage(null);
+      if (section === 'branding') {
+        setPendingLogo(null);
+        setPendingIdleImage(null);
+      }
       onOrganizationSwitch?.(organizationId, trimmedDisplayName);
       showToast(
         section === 'identity'
@@ -363,6 +419,7 @@ export function OrganizationSettings({
         'success',
       );
     } catch (saveError) {
+      pendingOppositeSectionDraftRef.current = null;
       const message =
         saveError instanceof Error ? saveError.message : 'Failed to update organization settings.';
       showToast(message, 'error');


### PR DESCRIPTION

  ## Summary
  Fixes issue #673 and follow-up UX regression in Organisation Settings:
  - Removed cross-section save errors (`identity` vs `branding`)
  - Prevented unsaved opposite-section inputs from being wiped after save
  
  





  ## Root Cause
  - Backend previously rejected mixed-section payloads.
  - Frontend save flow rehydrated from backend response and unintentionally resets in-progress edits in the non-saved section.

  ## Changes


https://github.com/user-attachments/assets/b961b3cb-80c6-4921-84eb-56799bfbffc4

  ### Backend
  - Updated `updateOrganizationSettings` to apply changes in a section-scoped way:
    - `identity`: updates only `displayName`, `thankYouMessage`
    - `branding`: updates only `accentColorHex`, `logoUrl`, `idleImageUrl`
  - Removed hard cross-section rejection logic that caused deadlock when both sections were dirty.
  - Kept asset ownership validation on branding changes only.

  ### Frontend
  - Updated section save payload shaping in Organisation Settings so each save represents section intent.
  - Added opposite-section draft preservation during save/rehydrate cycle:
    - Saving `identity` preserves unsaved branding inputs (including pending logo/idle image uploads and logo dimensions).
    - Saving `branding` preserves unsaved identity inputs.
  - Cleared pending branding uploads only when branding is actually saved (not on identity save).
  - Added null guard for `organisation` in save handler to satisfy strict TypeScript checks.

  ### Tests
  - Added backend regression tests for mixed payload behaviour:
    - identity save ignores branding deltas
    - branding save ignores identity deltas

  ## Files Changed
  - backend/functions/handlers/organizationSettings.js
  - backend/functions/handlers/organizationSettings.test.js
  - src/views/admin/OrganizationSettings.tsx

  ## Verification
  - `npm.cmd test -- organizationSettings.test.js` (run in `backend/functions`) ✅
  - `npx.cmd tsc --noEmit` (repo root) ✅
  - `next build` reaches post-TypeScript stage; remaining `spawn EPERM` is environment-specific and unrelated to this fix.

  ## User Impact
  - Admins can save identity and branding independently without cross-section errors.
  - In-progress inputs/uploads in the other section are retained after save and do not need to be re-entered or re-uploaded.

  ## Issue
  Closes #673

  ## Deployment Notes
  - Deploy backend functions to ship handler behaviour.
  - Deploy frontend app to ship draft-preservation UX fix.
