### PR TITLE
feat(org branding): SVG logo upload + portrait idle crop

### DIFF
--- a/docs/ORGANIZATION_SETTINGS_IMPLEMENTATION_FLOW.md
+++ b/docs/ORGANIZATION_SETTINGS_IMPLEMENTATION_FLOW.md
@@ -131,7 +131,7 @@ How:
 1. User picks file from hidden input.
 2. Crop dialog opens (`SquareImageCropDialog`) with aspect ratio:
    - logo: `1:1`
-   - idle image: `16:9`
+   - idle image: `9:16` (portrait)
 3. On confirm, cropped file is validated and uploaded to Storage.
 4. Upload response returns URL + dimensions + metadata.
 5. UI stores asset as pending (`pendingLogo` / `pendingIdleImage`) and previews it.
@@ -337,7 +337,8 @@ flowchart TD
 Notes:
 
 - `logo` requires square validation (`requireSquare: true`)
-- `idleImage` is cropped at `16:9` in dialog and uploaded without square requirement
+- `logo` upload accepts `PNG`, `JPG/JPEG`, `WEBP`, `GIF`, and `SVG` input types
+- `idleImage` is cropped at `9:16` (portrait) in dialog and uploaded without square requirement
 
 ## 8.2 Remove Asset
 

--- a/src/entities/organization/api/organizationApi.ts
+++ b/src/entities/organization/api/organizationApi.ts
@@ -11,6 +11,7 @@ import {
   updateDoc,
 } from 'firebase/firestore';
 import { FUNCTION_URLS } from '@/shared/config/functions';
+import { FILE_UPLOAD_LIMITS } from '@/shared/config/constants';
 import { uploadImageAsset, type UploadedImageAsset } from '@/shared/lib/imageUpload';
 import { db } from '../../../shared/lib/firebase';
 import { type Organization, type OrganizationSettings } from '../model';
@@ -71,14 +72,17 @@ const normalizeNullableString = (value: string | null | undefined): string | nul
 };
 
 const getFileExtension = (fileName: string, fileType: string) => {
+  if (fileType === 'image/svg+xml') return 'svg';
+  if (fileType === 'image/png') return 'png';
+  if (fileType === 'image/jpeg') return 'jpg';
+  if (fileType === 'image/webp') return 'webp';
+  if (fileType === 'image/gif') return 'gif';
+
   const dotIndex = fileName.lastIndexOf('.');
   if (dotIndex > -1 && dotIndex < fileName.length - 1) {
     return fileName.slice(dotIndex + 1).toLowerCase();
   }
 
-  if (fileType === 'image/png') return 'png';
-  if (fileType === 'image/webp') return 'webp';
-  if (fileType === 'image/gif') return 'gif';
   return 'jpg';
 };
 
@@ -178,7 +182,13 @@ export const organizationApi = {
     }
 
     const storagePath = buildOrganizationSettingsAssetPath(trimmedOrganizationId, assetType, file);
+    const allowedTypes =
+      assetType === 'logo'
+        ? [...FILE_UPLOAD_LIMITS.image.allowedTypes, 'image/svg+xml']
+        : FILE_UPLOAD_LIMITS.image.allowedTypes;
+
     return uploadImageAsset(file, storagePath, {
+      allowedTypes,
       requireSquare: assetType === 'logo',
     });
   },

--- a/src/views/admin/OrganizationSettings.tsx
+++ b/src/views/admin/OrganizationSettings.tsx
@@ -682,7 +682,7 @@ export function OrganizationSettings({
                   <input
                     ref={logoInputRef}
                     type="file"
-                    accept="image/png,image/jpeg,image/webp,image/gif"
+                    accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
                     className="hidden"
                     onChange={handleLogoFileChange}
                   />
@@ -703,7 +703,8 @@ export function OrganizationSettings({
                     </p>
                   )}
                   <p className="text-xs text-gray-500">
-                    After selecting a logo, you can drag and zoom it in a square grid before upload.
+                    After selecting a logo (PNG, JPG, WEBP, GIF, or SVG), you can drag and zoom it
+                    in a square grid before upload.
                   </p>
                 </div>
 
@@ -792,8 +793,8 @@ export function OrganizationSettings({
         }}
         file={idleImageFileToCrop}
         title="Adjust idle screensaver image"
-        description="Position the cover image exactly as you want for kiosk screens."
-        aspectRatio={16 / 9}
+        description="Position the portrait cover image exactly as you want for kiosk screens."
+        aspectRatio={9 / 16}
         onConfirm={async (croppedFile) => {
           await handleUploadImage(croppedFile, 'idleImage');
           setIdleImageFileToCrop(null);

--- a/src/views/admin/OrganizationSettings.tsx
+++ b/src/views/admin/OrganizationSettings.tsx
@@ -261,9 +261,15 @@ export function OrganizationSettings({
   const handleLogoFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
+    event.target.value = '';
+
+    if (file.type === 'image/svg+xml') {
+      await handleUploadImage(file, 'logo');
+      return;
+    }
+
     setLogoFileToCrop(file);
     setIsLogoCropDialogOpen(true);
-    event.target.value = '';
   };
 
   const handleIdleImageFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -703,8 +709,8 @@ export function OrganizationSettings({
                     </p>
                   )}
                   <p className="text-xs text-gray-500">
-                    After selecting a logo (PNG, JPG, WEBP, GIF, or SVG), you can drag and zoom it
-                    in a square grid before upload.
+                    Raster logos can be adjusted in a square crop before upload. SVG logos are
+                    uploaded directly to preserve the vector asset.
                   </p>
                 </div>
 


### PR DESCRIPTION
## Summary
- allow SVG files in Organisation Settings logo upload flow
- extend organisation logo upload validation to accept `image/svg+xml`
- improve file extension resolution for logo assets using MIME type
- switch idle screensaver crop ratio from `16:9` to portrait `9:16`
- update organisation settings implementation docs for new branding behaviour

## Why
- enables SVG logo uploads
- makes idle image cropping portrait-oriented for kiosk screens

## Files Changed
- src/entities/organization/api/organizationApi.ts
- src/views/admin/OrganizationSettings.tsx
- docs/ORGANIZATION_SETTINGS_IMPLEMENTATION_FLOW.md

## Docs
- Updated `docs/ORGANIZATION_SETTINGS_IMPLEMENTATION_FLOW.md`:
  - idle image crop ratio now `9:16` (portrait)
  - logo upload types include `SVG` alongside PNG/JPG/WEBP/GIF

## Manual Test
1. Go to Admin -> Organization Settings -> Branding.
2. Upload an .svg as Organisation Logo, crop, save branding, refresh and verify persistence.
3. Upload a portrait idle image (e.g. 1080x1920), crop, and save branding.
4. Open the kiosk idle screen and verify portrait framing.

Closes #671
Closes #672
