### PR TITLE
chore(github-actions): temporarily disable stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Stale Issues and PRs
 
 on:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: '0 2 * * *'
   workflow_dispatch:
 
 permissions:
@@ -12,6 +12,8 @@ permissions:
 jobs:
   stale:
     name: Mark and close stale items
+    # Temporarily disabled: prevents marking/closing until this guard is removed.
+    if: ${{ false }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### What
Temporarily disables the stale automation workflow so issues/PRs are not marked stale and stale-marked items are not auto-closed.

### Why
We want to pause stale enforcement while we review the ticket backlog and avoid unintended closures.

### Changes
- Updated `.github/workflows/stale.yml`
- Added job-level guard:
  - `if: ${{ false }}`
- Kept all existing stale settings intact for quick re-enablement later

### Impact
- No new stale labels/comments will be applied by automation
- No stale-based auto-closing will occur
- Existing `stale` labels remain unchanged

### Rollback
Remove `if: ${{ false }}` from the `stale` job to re-enable the workflow.

### Testing
- Verified workflow file parses correctly
- Verified stale job is explicitly disabled via job condition
