### PR TITLE
fix(admin-kiosks): align kiosks page background with AdminLayout

### DIFF
--- a/src/views/admin/KioskManagement.tsx
+++ b/src/views/admin/KioskManagement.tsx
@@ -515,7 +515,7 @@ export function KioskManagement({
         hasPermission={hasPermission}
         activeScreen="admin-kiosks"
       >
-        <div className="min-h-screen bg-gray-50">
+        <div className="space-y-6 sm:space-y-8">
           <div className="text-center py-12">
             <div className="animate-pulse">
               <div className="w-12 h-12 bg-gray-300 rounded-full mx-auto mb-3"></div>
@@ -580,7 +580,7 @@ export function KioskManagement({
         ) : null
       }
     >
-      <div className="min-h-screen bg-gray-50">
+      <div className="space-y-6 sm:space-y-8">
         <main className="px-6 lg:px-8 pt-12 pb-8">
           {/* Stat Cards Section */}
           <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6 mb-12">


### PR DESCRIPTION
## Summary
Fixes visual inconsistency on `/admin/kiosks` where page-level wrappers in `KioskManagement` were overriding the shared admin background.
<img width="1919" height="865" alt="Screenshot 2026-04-27 205324" src="https://github.com/user-attachments/assets/a99dc82d-6de4-44c6-a69d-44e0911fe259" />

Closes #684

## What Changed
- Updated `src/views/admin/KioskManagement.tsx`:
  - Replaced page wrappers using `min-h-screen bg-gray-50`
  - With neutral spacing wrappers: `space-y-6 sm:space-y-8`
- Kept all existing layout/content behavior and logic unchanged.

## Why
`AdminLayout` already provides the standard admin background (`bg-[#F3F1EA]`).  
The kiosks page had local `bg-gray-50` wrappers, causing a mismatch with other admin pages.

## Validation
- Verified diff is style-only and scoped to the two wrapper class changes.
- No functional logic touched (loading, header, table rendering, actions unchanged).

## Files Changed
- `src/views/admin/KioskManagement.tsx`
