### PR TITLE
refactor(admin): centralize admin refresh/loading UX and align cursor pagination patterns

### DIFF
--- a/docs/ADMIN_FLOW.md
+++ b/docs/ADMIN_FLOW.md
@@ -60,8 +60,35 @@ Admin users manage campaigns, users, kiosks, subscriptions, donations, and Gift 
 - view account status
 - access express dashboard links where supported
 
+## Standardized Admin List UX
+
+Admin data-heavy pages (campaigns, users, kiosks, donations, subscriptions, and Gift Aid) now follow a shared composition:
+
+- `AdminStatsGrid` + `AdminStatsGridLoading` for KPI card rows
+- `AdminDataSection` + `AdminDataSectionLoading` for filter/table sections
+- `AdminSearchFilterHeader` for standardized filter controls and actions
+- `AdminRefreshButton` for consistent manual refresh behavior
+- `AdminPageStatus` for initial page loading and error states
+
+Reference: `docs/ADMIN_UI_CONVENTIONS.md`
+
+## Filters, Pagination, And Data Fetching
+
+- Filters are centralized through shared admin filter header components.
+- List pages use backend-driven filtering and cursor-based pagination hooks.
+- Pagination control UI is standardized (`Previous`, `Page N`, `Next`) for desktop and mobile.
+- Default admin page size is `20` (via shared pagination hook), with per-screen overrides where required.
+- Gift Aid export history uses cursor pagination with page size `2`.
+
+## Mobile Behavior Standards
+
+- Refresh actions in admin list sections are shown in the section header top-right on small screens.
+- The same refresh action stays near filters/actions on desktop.
+- Stats cards and table/list sections use shared responsive layouts so behavior is consistent across pages.
+
 ## Important Contributor Notes
 
 - Many admin screens aggregate data from multiple features and shared hooks.
 - Changes in admin flows often affect both UI composition and backend data assumptions.
 - Authorization-sensitive changes should be reviewed carefully, especially around Stripe onboarding and organization scoping.
+- New admin list screens should follow the shared component and pagination conventions instead of introducing page-specific patterns.

--- a/docs/ADMIN_UI_CONVENTIONS.md
+++ b/docs/ADMIN_UI_CONVENTIONS.md
@@ -1,0 +1,89 @@
+# Admin UI Conventions
+
+This document defines the shared conventions for admin list pages.
+
+## 1) Purpose
+
+Use shared components and shared data-loading patterns so admin pages behave consistently across:
+
+- desktop and mobile layouts
+- refresh interactions
+- filtering and pagination
+- loading and error states
+
+## 2) Shared UI Primitives
+
+Core components:
+
+- `src/views/admin/components/AdminStatsGrid.tsx`
+- `src/views/admin/components/AdminStatsGridLoading.tsx`
+- `src/views/admin/components/AdminDataSection.tsx`
+- `src/views/admin/components/AdminDataSectionLoading.tsx`
+- `src/views/admin/components/AdminSearchFilterHeader.tsx`
+- `src/views/admin/components/AdminRefreshButton.tsx`
+- `src/views/admin/components/AdminPageStatus.tsx`
+
+Typical composition:
+
+1. top-level page wraps in `AdminLayout`
+2. initial states use `AdminPageLoader` / `AdminPageError`
+3. KPI cards render in `AdminStatsGrid`
+4. list/filter area renders in `AdminDataSection`
+5. list-loading skeleton uses `AdminDataSectionLoading`
+
+## 3) Refresh Behavior
+
+Centralized refresh behavior is provided by `AdminDataSection` + `AdminRefreshButton`.
+
+- Desktop: refresh appears with section actions near filters.
+- Mobile: refresh appears in the section header top-right.
+- Manual refresh uses the same visual treatment (light overlay + "Refreshing data...") across sections.
+
+Do not implement custom per-page refresh buttons unless a page has a unique product requirement.
+
+## 4) Filters And Pagination Contract
+
+Filter controls are centralized with `AdminSearchFilterHeader`.
+
+Pagination behavior:
+
+- Cursor-based pagination is managed with `usePagination`.
+- UI controls are standardized: `Previous`, `Page N`, `Next`.
+- Pagination state resets when organization or filter state changes.
+- Query keys should use stable primitive segments (`string`/`number`), not raw objects.
+
+Page sizes:
+
+- Standard admin list page size: `20` (`PAGE_SIZE` in `usePagination`).
+- Gift Aid export history page size: `2` (`useGiftAidExportBatches` override).
+
+## 5) Backend-Driven Filtering
+
+For admin list pages:
+
+- filter state should be applied in paginated backend/Firestore queries
+- list pagination should not be done by client-side slicing
+- refresh should invalidate query cache for that section key
+
+If backend indexes are not available yet, temporary fallback logic is acceptable but should be documented and removed once indexes are deployed.
+
+## 6) Firestore Index Notes
+
+Gift Aid export history pagination uses:
+
+- `where('organizationId', '==', ...)`
+- `orderBy('createdAt', 'desc')`
+- `orderBy('__name__', 'desc')`
+
+This requires a composite index for `giftAidExportBatches`.
+
+## 7) New Admin Page Checklist
+
+Before merging a new admin list page:
+
+1. Uses `AdminDataSection` for filters + list container.
+2. Uses shared refresh behavior (no duplicate mobile refresh placements).
+3. Uses `usePagination`-based cursor flow.
+4. Uses standardized pagination control UI.
+5. Uses shared loading/error components.
+6. Confirms required Firestore indexes for query shape.

--- a/docs/GIFTAID_EXPORT_FLOW.md
+++ b/docs/GIFTAID_EXPORT_FLOW.md
@@ -65,7 +65,8 @@ This is the **export** flow for Gift Aid declarations, not the donor capture flo
 - `src/views/admin/GiftAidManagement.tsx`
   - “Export and track” action
   - export history table/cards
-  - pagination (history)
+  - cursor-based history pagination (page size `2`)
+  - standardized Previous/Page/Next controls
   - role/permission-based UI behavior
 
 ---

--- a/docs/GIFTAID_EXPORT_FLOW.md
+++ b/docs/GIFTAID_EXPORT_FLOW.md
@@ -293,13 +293,16 @@ This supports recovery if local copies are missing.
 - Export button triggers backend export and tracking flow
 - Immediately attempts both file downloads after successful export
 - Shows clear warning if secondary file download fails while export succeeded
-- Loads and paginates export history
+- Loads export history with cursor-based pagination
+- Uses a fixed export history page size of `2` batches per page
+- Uses the same admin pagination controls (`Previous`, `Page N`, `Next`) on desktop and mobile
 - Disables buttons based on permission + file availability + in-flight state
 
 History source:
 
 - `giftAidExportBatches` collection filtered by org
-- sorted by batch timestamps
+- primary query order: `createdAt desc`, then `__name__ desc`
+- if Firestore composite index is missing, client falls back to org-filtered fetch and in-memory sort/pagination until index is created
 
 ---
 

--- a/docs/PROJECT_WORKFLOW.md
+++ b/docs/PROJECT_WORKFLOW.md
@@ -1,6 +1,7 @@
 # SwiftCause - Project Workflow Documentation
 
 ## 📋 Table of Contents
+
 1. [Project Overview](#project-overview)
 2. [Architecture](#architecture)
 3. [User Flows](#user-flows)
@@ -15,6 +16,7 @@
 ## 🎯 Project Overview
 
 **SwiftCause** is a donation management platform that enables organizations to:
+
 - Create and manage fundraising campaigns
 - Deploy donation kiosks (physical or virtual)
 - Process payments securely via Stripe
@@ -22,6 +24,7 @@
 - Manage users with role-based permissions
 
 ### Core Concept
+
 Organizations create campaigns → Assign campaigns to kiosks → Donors use kiosks to donate → Admins track everything via dashboard
 
 ---
@@ -29,6 +32,7 @@ Organizations create campaigns → Assign campaigns to kiosks → Donors use kio
 ## 🏗️ Architecture
 
 ### Frontend Architecture
+
 ```
 Next.js 14 (App Router)
 ├── /app                    # Next.js pages
@@ -48,6 +52,7 @@ Next.js 14 (App Router)
 ```
 
 ### Backend Architecture
+
 ```
 Firebase
 ├── Firestore              # NoSQL Database
@@ -62,6 +67,7 @@ Firebase
 ## 👥 User Flows
 
 ### 1. Organization Setup Flow
+
 ```
 1. Super Admin creates Organization
 2. Organization connects Stripe account
@@ -70,6 +76,7 @@ Firebase
 ```
 
 ### 2. Campaign Creation Flow
+
 ```
 Admin Dashboard
     ↓
@@ -88,6 +95,7 @@ Campaign goes Live
 ```
 
 ### 3. Kiosk Setup Flow
+
 ```
 Admin Dashboard
     ↓
@@ -105,6 +113,7 @@ Kiosk is Active
 ```
 
 ### 4. Donation Flow
+
 ```
 Donor visits Kiosk URL
     ↓
@@ -124,6 +133,7 @@ Dashboard updates in real-time
 ```
 
 ### 5. Admin Monitoring Flow
+
 ```
 Admin logs in
     ↓
@@ -146,15 +156,17 @@ Admin can:
 ## 🛠️ Technical Stack
 
 ### Frontend
+
 - **Framework:** Next.js 14 (React 18)
 - **Language:** TypeScript
 - **Styling:** Tailwind CSS
 - **UI Components:** Shadcn/ui (Radix UI)
 - **Charts:** Recharts
 - **Forms:** React Hook Form
-- **State Management:** React Hooks + Context
+- **State Management:** React Hooks + Context + TanStack Query (admin data queries)
 
 ### Backend
+
 - **Database:** Firebase Firestore (NoSQL)
 - **Authentication:** Firebase Auth
 - **Storage:** Firebase Storage
@@ -162,6 +174,7 @@ Admin can:
 - **Payments:** Stripe API
 
 ### DevOps
+
 - **Hosting:** Firebase Hosting / Vercel
 - **Version Control:** Git
 - **Package Manager:** npm
@@ -171,6 +184,7 @@ Admin can:
 ## ✨ Key Features
 
 ### 1. Campaign Management
+
 - **CRUD Operations:** Create, Read, Update, Delete campaigns
 - **Rich Configuration:**
   - Custom donation amounts
@@ -182,6 +196,7 @@ Admin can:
 - **Progress Tracking:** Real-time goal completion percentage
 
 ### 2. Kiosk System
+
 - **Multi-Device Support:** iOS, Android, Windows, ChromeOS
 - **Access Control:** QR codes and secure access codes
 - **Campaign Assignment:** Multiple campaigns per kiosk
@@ -189,6 +204,7 @@ Admin can:
 - **Location-Based Analytics:** Track donations by location
 
 ### 3. Payment Processing
+
 - **Stripe Integration:**
   - Secure payment processing
   - PCI compliance
@@ -198,6 +214,7 @@ Admin can:
 - **Payout Management:** Automatic transfers to organization accounts
 
 ### 4. Analytics Dashboard
+
 - **Real-Time Metrics:**
   - Total raised across all campaigns
   - Total donation count
@@ -211,6 +228,7 @@ Admin can:
 - **Alerts:** System notifications (offline kiosks, etc.)
 
 ### 5. User Management
+
 - **Role-Based Access Control (RBAC):**
   - Super Admin (system-wide access)
   - Admin (organization-level access)
@@ -223,6 +241,7 @@ Admin can:
   - system_admin (super admin only)
 
 ### 6. Data Export
+
 - **CSV Export:** Campaign data, donations, analytics
 - **Filtering:** By status, category, date range
 - **Sorting:** By title, goal, end date, created date
@@ -232,6 +251,7 @@ Admin can:
 ## 🔄 Data Flow
 
 ### Campaign Creation Flow
+
 ```
 Admin UI (CampaignManagement.tsx)
     ↓
@@ -247,6 +267,7 @@ UI updates with new campaign
 ```
 
 ### Donation Processing Flow
+
 ```
 Donor submits payment
     ↓
@@ -263,6 +284,7 @@ Dashboard refreshes automatically
 ```
 
 ### Dashboard Data Loading Flow
+
 ```
 AdminDashboard mounts
     ↓
@@ -279,6 +301,24 @@ Data aggregation & calculations
 State updates → UI renders
 ```
 
+### Admin List Data Loading Flow (Standardized)
+
+```
+Admin list page mounts (campaigns/users/kiosks/donations/subscriptions/gift aid)
+    ↓
+Shared filter state updates
+    ↓
+usePagination cursor state (page number + current cursor)
+    ↓
+TanStack Query with stable primitive query key
+    ↓
+Backend/Firestore paginated query (PAGE_SIZE + 1)
+    ↓
+updatePage(lastDoc, hasNextPage)
+    ↓
+Unified Previous / Page N / Next controls
+```
+
 ---
 
 ## 🔒 Security & Performance
@@ -286,16 +326,19 @@ State updates → UI renders
 ### Security Measures
 
 #### 1. Authentication
+
 - Firebase Authentication with email/password
 - Session management with secure tokens
 - Protected routes (admin-only pages)
 
 #### 2. Authorization
+
 - Role-based access control (RBAC)
 - Permission checks before every action
 - Organization-level data isolation
 
 #### 3. Firestore Security Rules
+
 ```javascript
 rules_version = '2';
 service cloud.firestore {
@@ -304,10 +347,10 @@ service cloud.firestore {
     match /users/{userId} {
       allow read: if request.auth.uid == userId;
     }
-    
+
     // Organization members can access org data
     match /campaigns/{campaignId} {
-      allow read: if request.auth != null && 
+      allow read: if request.auth != null &&
         get(/databases/$(database)/documents/users/$(request.auth.uid))
         .data.organizationId == resource.data.organizationId;
     }
@@ -316,38 +359,45 @@ service cloud.firestore {
 ```
 
 #### 4. Data Validation
+
 - Input sanitization on client-side
 - Server-side validation in Cloud Functions
 - Type safety with TypeScript
 
 #### 5. PII Protection
+
 ⚠️ **Current Issue:** Donation data with PII (email, phone, name) is exposed to client
 **Recommendation:** Use Cloud Functions to sanitize sensitive data
 
 ### Performance Optimizations
 
 #### 1. Efficient Queries
+
 - **Before:** Fetching all donations (10,000+ reads)
 - **After:** Using `getCountFromServer()` (6 reads)
 - Parallel queries with `Promise.all()`
 - Indexed queries for fast lookups
 
 #### 2. Code Splitting
+
 - Next.js automatic code splitting
 - Lazy loading of components
 - Dynamic imports for heavy libraries
 
 #### 3. Caching Strategy
+
 - Browser caching for static assets
 - Firebase SDK caching
-- **Recommended:** Add React Query for data caching
+- TanStack Query cache + targeted query invalidation for admin sections
 
 #### 4. Image Optimization
+
 - Next.js Image component
 - Lazy loading images
 - Responsive images with srcset
 
 #### 5. Bundle Optimization
+
 - Tree shaking unused code
 - Minification in production
 - Compression (gzip/brotli)
@@ -359,6 +409,7 @@ service cloud.firestore {
 ### Collections Structure
 
 #### 1. **organizations**
+
 ```typescript
 {
   id: string;
@@ -367,12 +418,13 @@ service cloud.firestore {
     accountId: string;
     chargesEnabled: boolean;
     payoutsEnabled: boolean;
-  };
+  }
   createdAt: Timestamp;
 }
 ```
 
 #### 2. **users**
+
 ```typescript
 {
   id: string;
@@ -386,6 +438,7 @@ service cloud.firestore {
 ```
 
 #### 3. **campaigns**
+
 ```typescript
 {
   id: string;
@@ -405,7 +458,7 @@ service cloud.firestore {
   endDate: Timestamp;
   isGlobal: boolean;
   assignedKiosks: string[];
-  
+
   configuration: {
     predefinedAmounts: number[];
     allowCustomAmount: boolean;
@@ -421,14 +474,14 @@ service cloud.firestore {
     optionalFields: string[];
     enableAnonymousDonations: boolean;
   };
-  
+
   organizationInfo?: {
     name: string;
     description: string;
     website: string;
     logo: string;
   };
-  
+
   impactMetrics?: {
     peopleHelped: number;
     itemsProvided: number;
@@ -438,13 +491,14 @@ service cloud.firestore {
       unit: string;
     };
   };
-  
+
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }
 ```
 
 #### 4. **kiosks**
+
 ```typescript
 {
   id: string;
@@ -457,19 +511,20 @@ service cloud.firestore {
   defaultCampaignId?: string;
   assignedCampaigns: string[];
   totalRaised: number;
-  
+
   deviceInfo: {
     os: string;
     browser: string;
     userAgent: string;
   };
-  
+
   createdAt: Timestamp;
   lastActive: Timestamp;
 }
 ```
 
 #### 5. **donations**
+
 ```typescript
 {
   id: string;
@@ -477,25 +532,25 @@ service cloud.firestore {
   campaignId: string;
   kioskId?: string;
   amount: number;
-  
+
   // Donor information (PII)
   donorName?: string;
   donorEmail?: string;
   donorPhone?: string;
   donorMessage?: string;
   isAnonymous: boolean;
-  
+
   // Payment details
   transactionId: string;
   paymentMethod: string;
-  
+
   // Recurring
   isRecurring: boolean;
   recurringInterval?: 'monthly' | 'quarterly' | 'yearly';
-  
+
   // Tax
   isGiftAid: boolean;
-  
+
   // Metadata
   platform?: string;
   timestamp: Timestamp;
@@ -520,11 +575,15 @@ For optimal query performance, create these composite indexes in Firestore:
 3. **kiosks**
    - `organizationId` (ASC) + `status` (ASC)
 
+4. **giftAidExportBatches**
+   - `organizationId` (ASC) + `createdAt` (DESC) + `__name__` (DESC)
+
 ---
 
 ## 🚀 Deployment Workflow
 
 ### Development
+
 ```bash
 npm install
 npm run dev
@@ -532,12 +591,14 @@ npm run dev
 ```
 
 ### Production Build
+
 ```bash
 npm run build
 npm start
 ```
 
 ### Firebase Deployment
+
 ```bash
 # Deploy functions
 cd backend/functions
@@ -552,6 +613,7 @@ firebase deploy --only hosting
 ## 📊 Key Metrics & KPIs
 
 ### Business Metrics
+
 - Total funds raised
 - Number of active campaigns
 - Average donation amount
@@ -559,6 +621,7 @@ firebase deploy --only hosting
 - Campaign completion rate
 
 ### Technical Metrics
+
 - Page load time (< 3s)
 - API response time (< 500ms)
 - Error rate (< 1%)
@@ -570,6 +633,7 @@ firebase deploy --only hosting
 ## 🔮 Future Enhancements
 
 ### Planned Features
+
 1. **Mobile App:** Native iOS/Android apps
 2. **Email Campaigns:** Automated donor communications
 3. **Advanced Analytics:** Predictive analytics, donor insights
@@ -579,13 +643,15 @@ firebase deploy --only hosting
 7. **White-Label:** Custom branding for organizations
 
 ### Performance Improvements
-1. Implement React Query for caching
+
+1. Expand TanStack Query usage and cache tuning for non-admin flows
 2. Add service workers for offline support
 3. Optimize images with WebP format
 4. Implement virtual scrolling for large lists
 5. Add database connection pooling
 
 ### Security Enhancements
+
 1. Two-factor authentication (2FA)
 2. Audit logging for all actions
 3. Data encryption at rest
@@ -597,17 +663,20 @@ firebase deploy --only hosting
 ## 📞 Support & Maintenance
 
 ### Monitoring
+
 - Firebase Console for real-time metrics
 - Error tracking with Sentry (recommended)
 - Performance monitoring with Lighthouse
 - User analytics with Google Analytics
 
 ### Backup Strategy
+
 - Firestore automatic backups (daily)
 - Manual exports for critical data
 - Version control for code (Git)
 
 ### Update Process
+
 1. Test in development environment
 2. Deploy to staging
 3. Run automated tests
@@ -619,27 +688,35 @@ firebase deploy --only hosting
 ## 📝 Common Questions & Answers
 
 ### Q: How do organizations get paid?
+
 **A:** Organizations connect their Stripe account during onboarding. Donations are processed through Stripe and automatically transferred to the organization's bank account according to their Stripe payout schedule.
 
 ### Q: Can one kiosk show multiple campaigns?
+
 **A:** Yes! Kiosks can be assigned multiple campaigns. Donors can browse and select which campaign to support.
 
 ### Q: How are permissions managed?
+
 **A:** The system uses role-based access control (RBAC). Each user has a role (super_admin, admin, manager, viewer) with specific permissions. Admins can create users and assign roles.
 
 ### Q: Is donor information secure?
+
 **A:** Yes, all payment processing is handled by Stripe (PCI compliant). Donor information is stored in Firestore with security rules. However, we recommend implementing additional PII sanitization for production.
 
 ### Q: Can campaigns be scheduled?
+
 **A:** Yes, campaigns have start and end dates. They can be set to activate/deactivate automatically.
 
 ### Q: How is the donation distribution calculated?
+
 **A:** The system uses Firestore's `getCountFromServer()` to efficiently count donations in different amount ranges without downloading all documents. This is much more efficient than fetching all donations.
 
 ### Q: What happens if a kiosk goes offline?
+
 **A:** The dashboard shows an alert for offline kiosks. Admins are notified and can investigate. Donations cannot be processed while offline.
 
 ### Q: Can donors get receipts?
+
 **A:** Yes, Stripe automatically sends payment receipts. Organizations can also implement custom thank-you emails via Cloud Functions.
 
 ---
@@ -647,6 +724,7 @@ firebase deploy --only hosting
 ## 🎓 Learning Resources
 
 ### For Developers
+
 - [Next.js Documentation](https://nextjs.org/docs)
 - [Firebase Documentation](https://firebase.google.com/docs)
 - [Stripe API Reference](https://stripe.com/docs/api)
@@ -654,12 +732,13 @@ firebase deploy --only hosting
 - [Tailwind CSS](https://tailwindcss.com/docs)
 
 ### For Admins
+
 - User guide (to be created)
 - Video tutorials (to be created)
 - FAQ section (to be created)
 
 ---
 
-**Last Updated:** December 2024
-**Version:** 1.0.0
+**Last Updated:** April 29, 2026
+**Version:** 1.1.0
 **Maintained by:** SwiftCause Development Team

--- a/src/entities/giftAid/api/giftAidExportApi.ts
+++ b/src/entities/giftAid/api/giftAidExportApi.ts
@@ -1,5 +1,15 @@
 import { getAuth } from 'firebase/auth';
-import { collection, getDocs, query, where } from 'firebase/firestore';
+import {
+  collection,
+  DocumentSnapshot,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  QueryDocumentSnapshot,
+  startAfter,
+  where,
+} from 'firebase/firestore';
 import { FUNCTION_URLS } from '@/shared/config/functions';
 import { db } from '@/shared/lib/firebase';
 
@@ -44,6 +54,12 @@ export interface GiftAidExportBatch {
   rowCount: number;
   hmrcFile?: GiftAidExportFile | null;
   internalFile?: GiftAidExportFile | null;
+}
+
+export interface GiftAidExportBatchPage {
+  batches: GiftAidExportBatch[];
+  lastDoc: DocumentSnapshot | null;
+  hasNextPage: boolean;
 }
 
 export type GiftAidExportFileKind = 'hmrc' | 'internal';
@@ -169,6 +185,47 @@ export async function fetchGiftAidExportBatches(
         (Number.isFinite(rightTime) ? rightTime : 0) - (Number.isFinite(leftTime) ? leftTime : 0)
       );
     });
+}
+
+export async function fetchGiftAidExportBatchesPaginated(
+  organizationId: string,
+  cursor: DocumentSnapshot | null,
+  pageSize: number,
+): Promise<GiftAidExportBatchPage> {
+  const constraints: Parameters<typeof query>[1][] = [
+    where('organizationId', '==', organizationId),
+    orderBy('createdAt', 'desc'),
+    orderBy('__name__', 'desc'),
+    limit(pageSize + 1),
+  ];
+
+  if (cursor) {
+    constraints.push(startAfter(cursor));
+  }
+
+  const batchesQuery = query(collection(db, 'giftAidExportBatches'), ...constraints);
+  const snapshot = await getDocs(batchesQuery);
+
+  if (snapshot.empty) {
+    return { batches: [], lastDoc: null, hasNextPage: false };
+  }
+
+  const hasNextPage = snapshot.docs.length > pageSize;
+  const docs: QueryDocumentSnapshot[] = hasNextPage
+    ? snapshot.docs.slice(0, pageSize)
+    : snapshot.docs;
+
+  return {
+    batches: docs.map(
+      (docSnapshot) =>
+        ({
+          id: docSnapshot.id,
+          ...docSnapshot.data(),
+        }) as GiftAidExportBatch,
+    ),
+    lastDoc: docs[docs.length - 1] ?? null,
+    hasNextPage,
+  };
 }
 
 function triggerBlobDownload(blob: Blob, fileName: string) {

--- a/src/entities/giftAid/api/giftAidExportApi.ts
+++ b/src/entities/giftAid/api/giftAidExportApi.ts
@@ -64,6 +64,73 @@ export interface GiftAidExportBatchPage {
 
 export type GiftAidExportFileKind = 'hmrc' | 'internal';
 
+interface GiftAidBatchTimestampFields {
+  createdAt?: unknown;
+  completedAt?: unknown;
+  failedAt?: unknown;
+}
+
+function normalizeTimestampToMillis(value: unknown): number {
+  if (!value) return 0;
+
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isFinite(time) ? time : 0;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === 'object') {
+    const maybeTimestamp = value as {
+      toDate?: () => Date;
+      seconds?: number | string;
+      nanoseconds?: number | string;
+    };
+
+    if (typeof maybeTimestamp.toDate === 'function') {
+      const dateValue = maybeTimestamp.toDate();
+      if (dateValue instanceof Date) {
+        const time = dateValue.getTime();
+        if (Number.isFinite(time)) return time;
+      }
+    }
+
+    const secondsRaw = maybeTimestamp.seconds;
+    const seconds =
+      typeof secondsRaw === 'number'
+        ? secondsRaw
+        : typeof secondsRaw === 'string'
+          ? Number(secondsRaw)
+          : NaN;
+
+    if (Number.isFinite(seconds)) {
+      const nanosRaw = maybeTimestamp.nanoseconds;
+      const nanos =
+        typeof nanosRaw === 'number'
+          ? nanosRaw
+          : typeof nanosRaw === 'string'
+            ? Number(nanosRaw)
+            : 0;
+
+      const nanosMillis = Number.isFinite(nanos) ? nanos / 1_000_000 : 0;
+      return seconds * 1000 + nanosMillis;
+    }
+  }
+
+  return 0;
+}
+
+function getBatchSortMillis(batch: GiftAidBatchTimestampFields): number {
+  return normalizeTimestampToMillis(batch.createdAt ?? batch.completedAt ?? batch.failedAt);
+}
+
 const getGiftAidExportFunctionUrl = () => {
   return (
     process.env.NEXT_PUBLIC_EXPORT_GIFTAID_FUNCTION_URL?.trim() ||
@@ -179,11 +246,9 @@ export async function fetchGiftAidExportBatches(
         }) as GiftAidExportBatch,
     )
     .sort((left, right) => {
-      const leftTime = Date.parse(left.createdAt || left.completedAt || left.failedAt || '');
-      const rightTime = Date.parse(right.createdAt || right.completedAt || right.failedAt || '');
-      return (
-        (Number.isFinite(rightTime) ? rightTime : 0) - (Number.isFinite(leftTime) ? leftTime : 0)
-      );
+      const leftTime = getBatchSortMillis(left);
+      const rightTime = getBatchSortMillis(right);
+      return rightTime - leftTime;
     });
 }
 
@@ -220,21 +285,9 @@ export async function fetchGiftAidExportBatchesPaginated(
     );
     const fallbackSnapshot = await getDocs(fallbackQuery);
     const sortedDocs = [...fallbackSnapshot.docs].sort((a, b) => {
-      const aTime = Date.parse(
-        (a.data() as { createdAt?: string; completedAt?: string; failedAt?: string }).createdAt ||
-          (a.data() as { completedAt?: string }).completedAt ||
-          (a.data() as { failedAt?: string }).failedAt ||
-          '',
-      );
-      const bTime = Date.parse(
-        (b.data() as { createdAt?: string; completedAt?: string; failedAt?: string }).createdAt ||
-          (b.data() as { completedAt?: string }).completedAt ||
-          (b.data() as { failedAt?: string }).failedAt ||
-          '',
-      );
-      const safeATime = Number.isFinite(aTime) ? aTime : 0;
-      const safeBTime = Number.isFinite(bTime) ? bTime : 0;
-      if (safeATime !== safeBTime) return safeBTime - safeATime;
+      const aTime = getBatchSortMillis(a.data() as GiftAidBatchTimestampFields);
+      const bTime = getBatchSortMillis(b.data() as GiftAidBatchTimestampFields);
+      if (aTime !== bTime) return bTime - aTime;
       return b.id.localeCompare(a.id);
     });
 

--- a/src/entities/giftAid/api/giftAidExportApi.ts
+++ b/src/entities/giftAid/api/giftAidExportApi.ts
@@ -204,7 +204,56 @@ export async function fetchGiftAidExportBatchesPaginated(
   }
 
   const batchesQuery = query(collection(db, 'giftAidExportBatches'), ...constraints);
-  const snapshot = await getDocs(batchesQuery);
+
+  let snapshot;
+  try {
+    snapshot = await getDocs(batchesQuery);
+  } catch (err: unknown) {
+    const code = (err as { code?: string })?.code;
+    if (code !== 'failed-precondition') throw err;
+
+    // Fallback when composite index is not created yet.
+    // We fetch by organization and apply ordering/pagination in memory.
+    const fallbackQuery = query(
+      collection(db, 'giftAidExportBatches'),
+      where('organizationId', '==', organizationId),
+    );
+    const fallbackSnapshot = await getDocs(fallbackQuery);
+    const sortedDocs = [...fallbackSnapshot.docs].sort((a, b) => {
+      const aTime = Date.parse(
+        (a.data() as { createdAt?: string; completedAt?: string; failedAt?: string }).createdAt ||
+          (a.data() as { completedAt?: string }).completedAt ||
+          (a.data() as { failedAt?: string }).failedAt ||
+          '',
+      );
+      const bTime = Date.parse(
+        (b.data() as { createdAt?: string; completedAt?: string; failedAt?: string }).createdAt ||
+          (b.data() as { completedAt?: string }).completedAt ||
+          (b.data() as { failedAt?: string }).failedAt ||
+          '',
+      );
+      const safeATime = Number.isFinite(aTime) ? aTime : 0;
+      const safeBTime = Number.isFinite(bTime) ? bTime : 0;
+      if (safeATime !== safeBTime) return safeBTime - safeATime;
+      return b.id.localeCompare(a.id);
+    });
+
+    const startIndex = cursor ? sortedDocs.findIndex((docSnap) => docSnap.id === cursor.id) + 1 : 0;
+    const docs = sortedDocs.slice(startIndex, startIndex + pageSize);
+    const hasNextPage = startIndex + pageSize < sortedDocs.length;
+
+    return {
+      batches: docs.map(
+        (docSnapshot) =>
+          ({
+            id: docSnapshot.id,
+            ...docSnapshot.data(),
+          }) as GiftAidExportBatch,
+      ),
+      lastDoc: docs[docs.length - 1] ?? null,
+      hasNextPage,
+    };
+  }
 
   if (snapshot.empty) {
     return { batches: [], lastDoc: null, hasNextPage: false };

--- a/src/shared/lib/hooks/useCampaignsPaginated.ts
+++ b/src/shared/lib/hooks/useCampaignsPaginated.ts
@@ -53,7 +53,7 @@ export function useCampaignsPaginated(organizationId?: string, filters: Campaign
   }
 
   const refresh = useCallback(() => {
-    queryClient.invalidateQueries({
+    return queryClient.invalidateQueries({
       predicate: (q) => q.queryKey[0] === 'campaigns-paginated' && q.queryKey[1] === organizationId,
     });
   }, [queryClient, organizationId]);

--- a/src/shared/lib/hooks/useDonations.ts
+++ b/src/shared/lib/hooks/useDonations.ts
@@ -55,7 +55,7 @@ export function useDonations(organizationId?: string, filters: DonationFilters =
   }
 
   const refresh = useCallback(() => {
-    queryClient.invalidateQueries({
+    return queryClient.invalidateQueries({
       predicate: (q) => q.queryKey[0] === 'donations' && q.queryKey[1] === organizationId,
     });
   }, [queryClient, organizationId]);

--- a/src/shared/lib/hooks/useGiftAid.ts
+++ b/src/shared/lib/hooks/useGiftAid.ts
@@ -54,7 +54,7 @@ export function useGiftAid(organizationId?: string, filters: GiftAidFilters = {}
   }
 
   const refresh = useCallback(() => {
-    queryClient.invalidateQueries({
+    return queryClient.invalidateQueries({
       predicate: (q) => q.queryKey[0] === 'gift-aid' && q.queryKey[1] === organizationId,
     });
   }, [queryClient, organizationId]);

--- a/src/shared/lib/hooks/useGiftAidExportBatches.ts
+++ b/src/shared/lib/hooks/useGiftAidExportBatches.ts
@@ -47,7 +47,7 @@ export function useGiftAidExportBatches(
   }
 
   const refresh = useCallback(() => {
-    queryClient.invalidateQueries({
+    return queryClient.invalidateQueries({
       predicate: (q) =>
         q.queryKey[0] === 'gift-aid-export-batches' && q.queryKey[1] === organizationId,
     });

--- a/src/shared/lib/hooks/useGiftAidExportBatches.ts
+++ b/src/shared/lib/hooks/useGiftAidExportBatches.ts
@@ -1,3 +1,4 @@
+import { useCallback, useEffect } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchGiftAidExportBatchesPaginated } from '../../../entities/giftAid/api';
 import { usePagination } from './usePagination';

--- a/src/shared/lib/hooks/useGiftAidExportBatches.ts
+++ b/src/shared/lib/hooks/useGiftAidExportBatches.ts
@@ -1,0 +1,68 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchGiftAidExportBatchesPaginated } from '../../../entities/giftAid/api';
+import { usePagination } from './usePagination';
+
+const DEFAULT_EXPORT_HISTORY_PAGE_SIZE = 2;
+
+export function useGiftAidExportBatches(
+  organizationId?: string,
+  pageSize = DEFAULT_EXPORT_HISTORY_PAGE_SIZE,
+) {
+  const pagination = usePagination();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    pagination.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [organizationId]);
+
+  const queryKey = [
+    'gift-aid-export-batches',
+    organizationId,
+    pagination.currentCursor?.id ?? 'page-1',
+    pageSize,
+  ] as const;
+
+  const { data, isLoading, isFetching, error } = useQuery({
+    queryKey,
+    queryFn: () => {
+      if (!organizationId) throw new Error('organizationId is required');
+      return fetchGiftAidExportBatchesPaginated(organizationId, pagination.currentCursor, pageSize);
+    },
+    enabled: !!organizationId,
+    placeholderData: (prev) => prev,
+    staleTime: 30_000,
+  });
+
+  useEffect(() => {
+    if (data) {
+      pagination.updatePage({ lastDoc: data.lastDoc, hasNextPage: data.hasNextPage });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  if (process.env.NODE_ENV !== 'production' && error) {
+    console.error('[useGiftAidExportBatches]', error);
+  }
+
+  const refresh = useCallback(() => {
+    queryClient.invalidateQueries({
+      predicate: (q) =>
+        q.queryKey[0] === 'gift-aid-export-batches' && q.queryKey[1] === organizationId,
+    });
+  }, [queryClient, organizationId]);
+
+  return {
+    exportBatches: data?.batches ?? [],
+    loading: isLoading,
+    fetching: isFetching,
+    error: error ? 'Failed to load Gift Aid export history. Please try again.' : null,
+    pageNumber: pagination.pageNumber,
+    canGoNext: pagination.canGoNext,
+    canGoPrev: pagination.canGoPrev,
+    goNext: pagination.goNext,
+    goPrev: pagination.goPrev,
+    pageSize,
+    refresh,
+  };
+}

--- a/src/shared/lib/hooks/useGiftAidExportBatches.ts
+++ b/src/shared/lib/hooks/useGiftAidExportBatches.ts
@@ -53,6 +53,10 @@ export function useGiftAidExportBatches(
     });
   }, [queryClient, organizationId]);
 
+  const goFirst = useCallback(() => {
+    pagination.reset();
+  }, [pagination]);
+
   return {
     exportBatches: data?.batches ?? [],
     loading: isLoading,
@@ -61,6 +65,7 @@ export function useGiftAidExportBatches(
     pageNumber: pagination.pageNumber,
     canGoNext: pagination.canGoNext,
     canGoPrev: pagination.canGoPrev,
+    goFirst,
     goNext: pagination.goNext,
     goPrev: pagination.goPrev,
     pageSize,

--- a/src/shared/lib/hooks/useKiosks.ts
+++ b/src/shared/lib/hooks/useKiosks.ts
@@ -64,7 +64,7 @@ export function useKiosks(organizationId?: string, filters: KioskFilters = {}) {
   // Predicate-based invalidation â€” only invalidates kiosk queries for this org,
   // leaving all other cached queries (campaigns, users, donations) untouched
   const refresh = useCallback(() => {
-    queryClient.invalidateQueries({
+    return queryClient.invalidateQueries({
       predicate: (q) => q.queryKey[0] === 'kiosks' && q.queryKey[1] === organizationId,
     });
   }, [queryClient, organizationId]);

--- a/src/shared/lib/hooks/useUsersPaginated.ts
+++ b/src/shared/lib/hooks/useUsersPaginated.ts
@@ -46,7 +46,7 @@ export function useUsersPaginated(organizationId?: string, filters: UserFilters 
   }
 
   const refresh = useCallback(() => {
-    queryClient.invalidateQueries({
+    return queryClient.invalidateQueries({
       predicate: (q) => q.queryKey[0] === 'users-paginated' && q.queryKey[1] === organizationId,
     });
   }, [queryClient, organizationId]);

--- a/src/views/admin/AdminDashboard.tsx
+++ b/src/views/admin/AdminDashboard.tsx
@@ -79,6 +79,7 @@ import { DonationDistributionDialog } from '../../widgets/donation-distribution'
 import { KioskForm, KioskFormData } from './components/KioskForm';
 import { CampaignForm, CampaignFormData } from './components/CampaignForm';
 import { KpiCard } from './components/KpiCard';
+import { AdminRefreshButton } from './components/AdminRefreshButton';
 
 // Dynamic imports for chart components to avoid SSR issues
 const RevenueGrowthChart = dynamic(
@@ -1118,17 +1119,15 @@ export function AdminDashboard({
               </Button>
             </div>
           )}
-          <Button
+          <AdminRefreshButton
+            onRefresh={handleRefresh}
+            refreshing={loading}
+            label="Refresh"
+            ariaLabel="Refresh Dashboard"
+            hideLabelOnMobile
             variant="outline"
             size="sm"
-            onClick={handleRefresh}
-            disabled={loading}
-            className="rounded-2xl border-[#064e3b] bg-transparent text-[#064e3b] hover:bg-emerald-50 hover:border-emerald-600 hover:shadow-md hover:shadow-emerald-900/10 hover:scale-105 transition-all duration-300 px-6 py-3 font-semibold disabled:opacity-50 disabled:hover:scale-100 disabled:hover:bg-transparent disabled:hover:border-[#064e3b]"
-            aria-label="Refresh Dashboard"
-          >
-            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-            <span className="hidden sm:inline ml-2">Refresh</span>
-          </Button>
+          />
         </div>
       }
       hideSidebarTrigger={false}

--- a/src/views/admin/BankDetails.tsx
+++ b/src/views/admin/BankDetails.tsx
@@ -1,12 +1,6 @@
-import { useState } from "react";
-import { Button } from "../../shared/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "../../shared/ui/card";
+import { useState } from 'react';
+import { Button } from '../../shared/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../shared/ui/card';
 import {
   CreditCard,
   CheckCircle,
@@ -16,13 +10,14 @@ import {
   Mail,
   Calendar,
   DollarSign,
-} from "lucide-react";
-import { useOrganization } from "../../shared/lib/hooks/useOrganization";
-import { AdminSession, Screen, Permission } from "../../shared/types";
-import { AdminLayout } from "./AdminLayout";
-import { useStripeOnboarding, StripeOnboardingDialog } from "../../features/stripe-onboarding";
-import { auth } from "../../shared/lib/firebase";
-import { useToast } from "../../shared/ui/ToastProvider";
+} from 'lucide-react';
+import { useOrganization } from '../../shared/lib/hooks/useOrganization';
+import { AdminSession, Screen, Permission } from '../../shared/types';
+import { AdminLayout } from './AdminLayout';
+import { StripeOnboardingDialog } from '../../features/stripe-onboarding';
+import { auth } from '../../shared/lib/firebase';
+import { useToast } from '../../shared/ui/ToastProvider';
+import { AdminPageError, AdminPageLoader } from './components/AdminPageStatus';
 
 interface BankDetailsProps {
   onNavigate: (screen: Screen) => void;
@@ -31,10 +26,17 @@ interface BankDetailsProps {
   hasPermission: (permission: Permission) => boolean;
 }
 
-export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }: BankDetailsProps) {
-  const { organization, loading: orgLoading, error: orgError } = useOrganization(
-    userSession.user.organizationId ?? null
-  );
+export function BankDetails({
+  onNavigate,
+  onLogout,
+  userSession,
+  hasPermission,
+}: BankDetailsProps) {
+  const {
+    organization,
+    loading: orgLoading,
+    error: orgError,
+  } = useOrganization(userSession.user.organizationId ?? null);
   const [showOnboardingDialog, setShowOnboardingDialog] = useState(false);
   const [isOnboarding, setIsOnboarding] = useState(false);
   const { showToast } = useToast();
@@ -67,7 +69,7 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
           },
           body: JSON.stringify({ orgId: organization.id }),
           signal: controller.signal,
-        }
+        },
       );
 
       clearTimeout(timeoutId);
@@ -75,7 +77,7 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(
-          errorData.error || response.statusText || 'Failed to create onboarding link.'
+          errorData.error || response.statusText || 'Failed to create onboarding link.',
         );
       }
 
@@ -85,17 +87,16 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
       } else {
         throw new Error('No onboarding URL received from server.');
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error creating Stripe onboarding link:', error);
-      
-      if (error.name === 'AbortError') {
+
+      const isAbortError = error instanceof Error && error.name === 'AbortError';
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      if (isAbortError) {
         showToast('Request timed out. Please check your connection and try again.', 'error', 4000);
       } else {
-        showToast(
-          `Failed to start Stripe onboarding: ${error.message}`,
-          'error',
-          4000
-        );
+        showToast(`Failed to start Stripe onboarding: ${errorMessage}`, 'error', 4000);
       }
       setIsOnboarding(false);
     }
@@ -103,53 +104,48 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
 
   if (orgLoading) {
     return (
-      <AdminLayout 
-        onNavigate={onNavigate} 
-        onLogout={onLogout} 
-        userSession={userSession} 
+      <AdminLayout
+        onNavigate={onNavigate}
+        onLogout={onLogout}
+        userSession={userSession}
         hasPermission={hasPermission}
         activeScreen="admin-bank-details"
       >
-        <div className="flex items-center justify-center h-full">
-          <RefreshCw className="w-8 h-8 animate-spin text-gray-400" />
-        </div>
+        <AdminPageLoader message="Loading bank details..." />
       </AdminLayout>
     );
   }
 
   if (orgError) {
     return (
-      <AdminLayout 
-        onNavigate={onNavigate} 
-        onLogout={onLogout} 
-        userSession={userSession} 
+      <AdminLayout
+        onNavigate={onNavigate}
+        onLogout={onLogout}
+        userSession={userSession}
         hasPermission={hasPermission}
         activeScreen="admin-bank-details"
       >
-        <div className="flex items-center justify-center h-full">
-          <div className="text-center">
-            <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
-            <p className="text-red-600">Error loading organization data: {orgError}</p>
-          </div>
-        </div>
+        <AdminPageError
+          title="Unable To Load Bank Details"
+          message={`Error loading organization data: ${orgError}`}
+        />
       </AdminLayout>
     );
   }
 
-  const stripeConnected = organization?.stripe?.accountId;
   const chargesEnabled = organization?.stripe?.chargesEnabled;
   const payoutsEnabled = organization?.stripe?.payoutsEnabled;
-  
+
   const isStripeSetup = chargesEnabled === true || payoutsEnabled === true;
 
   return (
-    <AdminLayout 
-      onNavigate={onNavigate} 
-      onLogout={onLogout} 
-      userSession={userSession} 
+    <AdminLayout
+      onNavigate={onNavigate}
+      onLogout={onLogout}
+      userSession={userSession}
       hasPermission={hasPermission}
       activeScreen="admin-bank-details"
-      headerTitle={(
+      headerTitle={
         <div className="flex flex-col">
           {userSession.user.organizationName && (
             <div className="flex items-center gap-1.5 mb-1">
@@ -159,15 +155,12 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
               </span>
             </div>
           )}
-          <h1 className="text-2xl font-semibold text-slate-800 tracking-tight">
-            Bank Details
-          </h1>
+          <h1 className="text-2xl font-semibold text-slate-800 tracking-tight">Bank Details</h1>
         </div>
-      )}
+      }
       headerSubtitle="Manage your payment settings and Stripe integration"
     >
       <div className="px-6 lg:px-8 pt-12 pb-8 max-w-6xl mx-auto space-y-8">
-
         {/* Stripe Account Status Card */}
         <Card className="border-2">
           <CardHeader className="pb-4">
@@ -192,7 +185,8 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
                     <div>
                       <h3 className="font-semibold text-gray-900 mb-2">Account Not Set Up</h3>
                       <p className="text-sm text-gray-700 leading-relaxed">
-                        Your Stripe account is not set up yet. Complete the setup to accept donations and receive payouts.
+                        Your Stripe account is not set up yet. Complete the setup to accept
+                        donations and receive payouts.
                       </p>
                     </div>
                   </div>
@@ -222,7 +216,8 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
                   <div>
                     <h3 className="font-semibold text-gray-900 mb-2">Under Review</h3>
                     <p className="text-sm text-gray-700 leading-relaxed">
-                      Your Stripe account is being reviewed. Payouts will be enabled shortly. You can already accept donations.
+                      Your Stripe account is being reviewed. Payouts will be enabled shortly. You
+                      can already accept donations.
                     </p>
                   </div>
                 </div>
@@ -234,7 +229,8 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
                   <div>
                     <h3 className="font-semibold text-gray-900 mb-2">Account Setup Successfully</h3>
                     <p className="text-sm text-gray-700 leading-relaxed">
-                      Your Stripe account is fully configured and ready to accept donations and process payouts.
+                      Your Stripe account is fully configured and ready to accept donations and
+                      process payouts.
                     </p>
                   </div>
                 </div>
@@ -245,7 +241,9 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
             {isStripeSetup && (
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4 border-t">
                 <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg border border-gray-200">
-                  <CheckCircle className={`w-5 h-5 ${chargesEnabled ? 'text-green-600' : 'text-gray-400'}`} />
+                  <CheckCircle
+                    className={`w-5 h-5 ${chargesEnabled ? 'text-green-600' : 'text-gray-400'}`}
+                  />
                   <div>
                     <p className="text-sm font-medium text-gray-700">Charges</p>
                     <p className="text-xs text-gray-500">
@@ -254,7 +252,9 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
                   </div>
                 </div>
                 <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg border border-gray-200">
-                  <CheckCircle className={`w-5 h-5 ${payoutsEnabled ? 'text-green-600' : 'text-gray-400'}`} />
+                  <CheckCircle
+                    className={`w-5 h-5 ${payoutsEnabled ? 'text-green-600' : 'text-gray-400'}`}
+                  />
                   <div>
                     <p className="text-sm font-medium text-gray-700">Payouts</p>
                     <p className="text-xs text-gray-500">
@@ -308,11 +308,11 @@ export function BankDetails({ onNavigate, onLogout, userSession, hasPermission }
                 <div>
                   <p className="text-sm font-medium text-gray-700 mb-1">Member Since</p>
                   <p className="text-sm text-gray-900">
-                    {userSession.user.createdAt 
+                    {userSession.user.createdAt
                       ? new Date(userSession.user.createdAt).toLocaleDateString('en-US', {
                           year: 'numeric',
                           month: 'long',
-                          day: 'numeric'
+                          day: 'numeric',
                         })
                       : 'N/A'}
                   </p>

--- a/src/views/admin/CampaignManagement.tsx
+++ b/src/views/admin/CampaignManagement.tsx
@@ -56,6 +56,7 @@ import {
 import { AdminSearchFilterConfig } from './components/AdminSearchFilterHeader';
 import { AdminDataSection } from './components/AdminDataSection';
 import { AdminEmptyState } from './components/AdminEmptyState';
+import { AdminDataSectionLoading } from './components/AdminDataSectionLoading';
 import { AdminStatsGrid } from './components/AdminStatsGrid';
 import { SortableTableHeader } from './components/SortableTableHeader';
 import { useTableSort } from '../../shared/lib/hooks/useTableSort';
@@ -1330,9 +1331,8 @@ const CampaignManagement = ({
   });
 
   // Invalidates both the management hook cache and the paginated query cache
-  const refreshAll = useCallback(() => {
-    refresh();
-    refreshPaged();
+  const refreshAll = useCallback(async () => {
+    await Promise.all([refresh(), refreshPaged()]);
   }, [refresh, refreshPaged]);
 
   const { organization, loading: orgLoading } = useOrganization(
@@ -2374,7 +2374,7 @@ const CampaignManagement = ({
       <div className="space-y-6 sm:space-y-8">
         <main className="px-6 lg:px-8 pt-10 pb-10">
           <div className="space-y-6">
-            <AdminStatsGrid className="grid gap-4 md:grid-cols-3">
+            <AdminStatsGrid className="grid grid-cols-2 gap-4 md:grid-cols-3">
               <Card className="rounded-3xl border border-gray-100 shadow-sm">
                 <CardContent className="p-5 flex items-center gap-4">
                   <div className="h-12 w-12 rounded-2xl bg-emerald-100 text-emerald-700 flex items-center justify-center">
@@ -2447,6 +2447,8 @@ const CampaignManagement = ({
               config={searchFilterConfig}
               filterValues={filterValues}
               onFilterChange={handleFilterChange}
+              onRefresh={refreshAll}
+              refreshing={fetching || loading}
               filterGridClassName="grid flex-1 grid-cols-1 gap-3 md:grid-cols-3"
               summaryText={`Showing ${filteredAndSortedCampaigns.length} of ${campaigns.length} campaigns`}
               showMobileActions={false}
@@ -2475,16 +2477,8 @@ const CampaignManagement = ({
               }
             >
               {loading ? (
-                <div className="space-y-4 p-6">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <div key={i} className="grid grid-cols-6 gap-4 py-4 border-b border-gray-200">
-                      <Skeleton className="h-10 w-full col-span-2" />
-                      <Skeleton className="h-10 w-full col-span-1" />
-                      <Skeleton className="h-10 w-full col-span-1" />
-                      <Skeleton className="h-10 w-full col-span-1" />
-                      <Skeleton className="h-10 w-full col-span-1" />
-                    </div>
-                  ))}
+                <div className="p-6">
+                  <AdminDataSectionLoading desktopColumns={6} desktopRows={5} mobileRows={3} />
                 </div>
               ) : filteredAndSortedCampaigns.length > 0 ? (
                 <>

--- a/src/views/admin/DonationManagement.tsx
+++ b/src/views/admin/DonationManagement.tsx
@@ -25,7 +25,6 @@ import {
   Building2,
   Gift,
 } from 'lucide-react';
-import { Skeleton } from '../../shared/ui/skeleton'; // Import Skeleton
 import { Ghost } from 'lucide-react'; // Import Ghost
 import { Screen, AdminSession, Permission, Donation } from '../../shared/types';
 import {
@@ -39,6 +38,7 @@ import { useTableSort } from '../../shared/lib/hooks/useTableSort';
 import { AdminSearchFilterConfig } from './components/AdminSearchFilterHeader';
 import { AdminDataSection } from './components/AdminDataSection';
 import { AdminEmptyState } from './components/AdminEmptyState';
+import { AdminDataSectionLoading } from './components/AdminDataSectionLoading';
 import { AdminStatsGrid } from './components/AdminStatsGrid';
 import { formatCurrency } from '../../shared/lib/currencyFormatter';
 import { useToast } from '../../shared/ui/ToastProvider';
@@ -141,6 +141,7 @@ export function DonationManagement({
     goNext,
     goPrev,
     pageSize,
+    refresh,
   } = useDonations(userSession.user.organizationId, {
     status: statusFilter !== 'all' ? statusFilter : undefined,
     campaignId: campaignFilter !== 'all' ? campaignFilter : undefined,
@@ -549,7 +550,7 @@ export function DonationManagement({
       <div className="space-y-6 sm:space-y-8">
         <main className="px-6 lg:px-8 pt-12 pb-8">
           {/* Stat Cards Section */}
-          <AdminStatsGrid className="grid gap-4 md:grid-cols-4 mb-6">
+          <AdminStatsGrid className="grid grid-cols-2 gap-4 md:grid-cols-4 mb-6">
             <Card className="rounded-3xl border border-gray-100 shadow-sm">
               <CardContent className="p-5 flex items-center gap-4">
                 <div className="h-12 w-12 rounded-2xl bg-emerald-100 text-emerald-700 flex items-center justify-center">
@@ -623,33 +624,13 @@ export function DonationManagement({
             config={searchFilterConfig}
             filterValues={filterValues}
             onFilterChange={handleFilterChange}
+            onRefresh={refresh}
+            refreshing={fetching}
             filterGridClassName="grid grid-cols-1 gap-3 md:grid-cols-4"
             summaryText={`Showing ${filteredDonations.length} of ${pagedDonations.length} donations`}
           >
             {loading ? (
-              <>
-                <div className="hidden space-y-4 md:block">
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <div key={i} className="grid grid-cols-6 gap-4 border-b border-gray-100 py-4">
-                      <Skeleton className="col-span-1 h-10 w-full" />
-                      <Skeleton className="col-span-1 h-10 w-full" />
-                      <Skeleton className="col-span-1 h-10 w-full" />
-                      <Skeleton className="col-span-1 h-10 w-full" />
-                      <Skeleton className="col-span-1 h-10 w-full" />
-                      <Skeleton className="col-span-1 h-10 w-full" />
-                    </div>
-                  ))}
-                </div>
-                <div className="space-y-4 md:hidden">
-                  {Array.from({ length: 3 }).map((_, i) => (
-                    <Card key={i} className="overflow-hidden rounded-3xl">
-                      <CardContent className="p-4">
-                        <Skeleton className="h-20 w-full" />
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
-              </>
+              <AdminDataSectionLoading desktopColumns={6} desktopRows={5} mobileRows={3} />
             ) : error ? (
               <div className="flex flex-col items-center justify-center p-12 text-center text-red-600">
                 <AlertCircle className="mb-3 h-10 w-10 text-red-500" />

--- a/src/views/admin/GiftAidManagement.tsx
+++ b/src/views/admin/GiftAidManagement.tsx
@@ -121,6 +121,7 @@ export function GiftAidManagement({
     pageNumber: exportHistoryPage,
     canGoNext: canGoExportHistoryNext,
     canGoPrev: canGoExportHistoryPrev,
+    goFirst: goToFirstExportHistoryPage,
     goNext: goToNextExportHistoryPage,
     goPrev: goToPrevExportHistoryPage,
     pageSize: exportHistoryPageSize,
@@ -335,8 +336,8 @@ export function GiftAidManagement({
       }
 
       setLocalOverrides({});
-      refresh();
-      refreshExportHistory();
+      goToFirstExportHistoryPage();
+      await Promise.all([refresh(), refreshExportHistory()]);
       if (exportResult.skippedCount && exportResult.skippedCount > 0) {
         showToast(
           exportResult.message ||

--- a/src/views/admin/GiftAidManagement.tsx
+++ b/src/views/admin/GiftAidManagement.tsx
@@ -29,7 +29,9 @@ import { SortableTableHeader } from './components/SortableTableHeader';
 import { useTableSort } from '../../shared/lib/hooks/useTableSort';
 import { AdminSearchFilterConfig } from './components/AdminSearchFilterHeader';
 import { AdminDataSection } from './components/AdminDataSection';
+import { AdminDataSectionLoading } from './components/AdminDataSectionLoading';
 import { AdminEmptyState } from './components/AdminEmptyState';
+import { AdminRefreshButton } from './components/AdminRefreshButton';
 import { AdminStatsGrid } from './components/AdminStatsGrid';
 import { formatCurrency } from '../../shared/lib/currencyFormatter';
 import { useGiftAid } from '../../shared/lib/hooks/useGiftAid';
@@ -114,6 +116,7 @@ export function GiftAidManagement({
   const {
     exportBatches,
     loading: exportHistoryLoading,
+    fetching: exportHistoryFetching,
     error: exportHistoryError,
     pageNumber: exportHistoryPage,
     canGoNext: canGoExportHistoryNext,
@@ -184,6 +187,14 @@ export function GiftAidManagement({
     if (!exportHistoryError) return;
     showToast(exportHistoryError, 'warning');
   }, [exportHistoryError, showToast]);
+
+  const refreshGiftAidSection = useCallback(async () => {
+    await Promise.all([refresh(), refreshExportHistory()]);
+  }, [refresh, refreshExportHistory]);
+  const refreshExportHistorySection = useCallback(async () => {
+    await refreshExportHistory();
+  }, [refreshExportHistory]);
+  const isExportHistoryRefreshing = exportHistoryLoading || exportHistoryFetching;
 
   const filteredDonationsData = giftAidDonations.map((donation) => ({
     ...donation,
@@ -531,7 +542,7 @@ export function GiftAidManagement({
         )}
 
         {/* Stats Cards */}
-        <AdminStatsGrid className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6 mb-6">
+        <AdminStatsGrid className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6 mb-6">
           <Card>
             <CardContent className="p-4 sm:p-6">
               <div className="flex items-center justify-between">
@@ -612,144 +623,294 @@ export function GiftAidManagement({
                       Re-download previous HMRC and internal Gift Aid export batches.
                     </p>
                   </div>
+                  <AdminRefreshButton
+                    onRefresh={refreshExportHistorySection}
+                    refreshing={isExportHistoryRefreshing}
+                    ariaLabel="Refresh export history"
+                  />
                 </div>
 
-                <div className="hidden md:block">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <SortableTableHeader
-                          sortable={false}
-                          sortKey="batch"
-                          currentSortKey={sortKey}
-                          currentSortDirection={sortDirection}
-                          onSort={handleSort}
-                          className="p-3"
-                        >
-                          Batch
-                        </SortableTableHeader>
-                        <SortableTableHeader
-                          sortable={false}
-                          sortKey="created"
-                          currentSortKey={sortKey}
-                          currentSortDirection={sortDirection}
-                          onSort={handleSort}
-                          className="p-3"
-                        >
-                          Created
-                        </SortableTableHeader>
-                        <SortableTableHeader
-                          sortable={false}
-                          sortKey="rows"
-                          currentSortKey={sortKey}
-                          currentSortDirection={sortDirection}
-                          onSort={handleSort}
-                          className="p-3"
-                        >
-                          Rows
-                        </SortableTableHeader>
-                        <SortableTableHeader
-                          sortable={false}
-                          sortKey="actor"
-                          currentSortKey={sortKey}
-                          currentSortDirection={sortDirection}
-                          onSort={handleSort}
-                          className="p-3"
-                        >
-                          Exported By
-                        </SortableTableHeader>
-                        <SortableTableHeader
-                          sortable={false}
-                          sortKey="status"
-                          currentSortKey={sortKey}
-                          currentSortDirection={sortDirection}
-                          onSort={handleSort}
-                          className="p-3"
-                        >
-                          Status
-                        </SortableTableHeader>
-                        <SortableTableHeader
-                          sortable={false}
-                          sortKey="downloads"
-                          currentSortKey={sortKey}
-                          currentSortDirection={sortDirection}
-                          onSort={handleSort}
-                          className="p-3"
-                        >
-                          Downloads
-                        </SortableTableHeader>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {exportHistoryLoading ? (
-                        Array.from({ length: 3 }).map((_, index) => (
-                          <TableRow key={`export-history-skeleton-${index}`}>
-                            <TableCell className="p-3">
-                              <Skeleton className="h-5 w-32" />
-                            </TableCell>
-                            <TableCell className="p-3">
-                              <Skeleton className="h-5 w-36" />
-                            </TableCell>
-                            <TableCell className="p-3">
-                              <Skeleton className="h-5 w-12" />
-                            </TableCell>
-                            <TableCell className="p-3">
-                              <Skeleton className="h-5 w-32" />
-                            </TableCell>
-                            <TableCell className="p-3">
-                              <Skeleton className="h-5 w-20" />
-                            </TableCell>
-                            <TableCell className="p-3">
-                              <Skeleton className="h-9 w-40" />
-                            </TableCell>
+                <div className="relative">
+                  {isExportHistoryRefreshing ? (
+                    <div className="pointer-events-none absolute inset-0 z-10 rounded-xl bg-white/45 backdrop-blur-[1px]">
+                      <div className="absolute left-4 top-3 flex items-center gap-2 rounded-md border border-gray-200 bg-white/90 px-2.5 py-1.5 text-[11px] font-medium text-gray-600 shadow-sm">
+                        <span className="h-3.5 w-3.5 rounded-full border-2 border-gray-300 border-t-emerald-600 motion-safe:animate-spin" />
+                        <span>Refreshing data...</span>
+                      </div>
+                    </div>
+                  ) : null}
+                  <div
+                    className={
+                      isExportHistoryRefreshing
+                        ? 'transition-opacity duration-200 opacity-70'
+                        : 'transition-opacity duration-200 opacity-100'
+                    }
+                  >
+                    <div className="hidden md:block">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <SortableTableHeader
+                              sortable={false}
+                              sortKey="batch"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="p-3"
+                            >
+                              Batch
+                            </SortableTableHeader>
+                            <SortableTableHeader
+                              sortable={false}
+                              sortKey="created"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="p-3"
+                            >
+                              Created
+                            </SortableTableHeader>
+                            <SortableTableHeader
+                              sortable={false}
+                              sortKey="rows"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="p-3"
+                            >
+                              Rows
+                            </SortableTableHeader>
+                            <SortableTableHeader
+                              sortable={false}
+                              sortKey="actor"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="p-3"
+                            >
+                              Exported By
+                            </SortableTableHeader>
+                            <SortableTableHeader
+                              sortable={false}
+                              sortKey="status"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="p-3"
+                            >
+                              Status
+                            </SortableTableHeader>
+                            <SortableTableHeader
+                              sortable={false}
+                              sortKey="downloads"
+                              currentSortKey={sortKey}
+                              currentSortDirection={sortDirection}
+                              onSort={handleSort}
+                              className="p-3"
+                            >
+                              Downloads
+                            </SortableTableHeader>
                           </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {exportHistoryLoading ? (
+                            Array.from({ length: 3 }).map((_, index) => (
+                              <TableRow key={`export-history-skeleton-${index}`}>
+                                <TableCell className="p-3">
+                                  <Skeleton className="h-5 w-32" />
+                                </TableCell>
+                                <TableCell className="p-3">
+                                  <Skeleton className="h-5 w-36" />
+                                </TableCell>
+                                <TableCell className="p-3">
+                                  <Skeleton className="h-5 w-12" />
+                                </TableCell>
+                                <TableCell className="p-3">
+                                  <Skeleton className="h-5 w-32" />
+                                </TableCell>
+                                <TableCell className="p-3">
+                                  <Skeleton className="h-5 w-20" />
+                                </TableCell>
+                                <TableCell className="p-3">
+                                  <Skeleton className="h-9 w-40" />
+                                </TableCell>
+                              </TableRow>
+                            ))
+                          ) : exportBatches.length > 0 ? (
+                            exportBatches.map((batch) => (
+                              <TableRow key={batch.id}>
+                                <TableCell className="p-3">
+                                  <div className="font-medium text-slate-900">
+                                    {batch.batchId || batch.id}
+                                  </div>
+                                </TableCell>
+                                <TableCell className="p-3 text-sm text-gray-700">
+                                  {formatBatchTimestamp(batch.completedAt || batch.createdAt)}
+                                </TableCell>
+                                <TableCell className="p-3 text-sm text-gray-700">
+                                  {batch.rowCount ?? 0}
+                                </TableCell>
+                                <TableCell className="p-3 text-sm text-gray-700">
+                                  {batch.createdByName || batch.createdByEmail || 'Unknown'}
+                                </TableCell>
+                                <TableCell className="p-3">
+                                  {batch.status === 'completed' ? (
+                                    <Badge
+                                      variant="outline"
+                                      className="bg-[#064e3b]/10 text-[#064e3b] border-[#064e3b]/20"
+                                    >
+                                      <CheckCircle className="mr-1 h-3 w-3" />
+                                      Completed
+                                    </Badge>
+                                  ) : batch.status === 'failed' ? (
+                                    <Badge
+                                      variant="outline"
+                                      className="bg-red-50 text-red-700 border-red-200"
+                                    >
+                                      <AlertCircle className="mr-1 h-3 w-3" />
+                                      Failed
+                                    </Badge>
+                                  ) : (
+                                    <Badge
+                                      variant="outline"
+                                      className="bg-yellow-50 text-yellow-700 border-yellow-200"
+                                    >
+                                      <Clock className="mr-1 h-3 w-3" />
+                                      {batch.status || 'Pending'}
+                                    </Badge>
+                                  )}
+                                </TableCell>
+                                <TableCell className="p-3">
+                                  <div className="flex flex-wrap gap-2">
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      disabled={
+                                        !canDownloadGiftAidBatchHistory ||
+                                        !batch.hmrcFile ||
+                                        activeDownloadKey === `${batch.id}:hmrc`
+                                      }
+                                      onClick={() =>
+                                        void handleDownloadBatchFile(
+                                          batch.id,
+                                          'hmrc',
+                                          batch.hmrcFile,
+                                        )
+                                      }
+                                    >
+                                      <Download className="mr-2 h-4 w-4" />
+                                      {activeDownloadKey === `${batch.id}:hmrc`
+                                        ? 'Downloading...'
+                                        : 'HMRC CSV'}
+                                    </Button>
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      disabled={
+                                        !canDownloadGiftAidBatchHistory ||
+                                        !batch.internalFile ||
+                                        activeDownloadKey === `${batch.id}:internal`
+                                      }
+                                      onClick={() =>
+                                        void handleDownloadBatchFile(
+                                          batch.id,
+                                          'internal',
+                                          batch.internalFile,
+                                        )
+                                      }
+                                    >
+                                      <Download className="mr-2 h-4 w-4" />
+                                      {activeDownloadKey === `${batch.id}:internal`
+                                        ? 'Downloading...'
+                                        : 'Internal CSV'}
+                                    </Button>
+                                  </div>
+                                </TableCell>
+                              </TableRow>
+                            ))
+                          ) : (
+                            <TableRow>
+                              <TableCell
+                                colSpan={6}
+                                className="p-6 text-center text-sm text-gray-500"
+                              >
+                                No Gift Aid export batches yet.
+                              </TableCell>
+                            </TableRow>
+                          )}
+                        </TableBody>
+                      </Table>
+                    </div>
+
+                    <div className="space-y-3 p-4 md:hidden">
+                      {exportHistoryLoading ? (
+                        Array.from({ length: 2 }).map((_, index) => (
+                          <Card
+                            key={`export-history-mobile-skeleton-${index}`}
+                            className="border border-gray-100 shadow-sm"
+                          >
+                            <CardContent className="space-y-3 p-4">
+                              <Skeleton className="h-5 w-28" />
+                              <Skeleton className="h-4 w-40" />
+                              <Skeleton className="h-9 w-full" />
+                            </CardContent>
+                          </Card>
                         ))
                       ) : exportBatches.length > 0 ? (
                         exportBatches.map((batch) => (
-                          <TableRow key={batch.id}>
-                            <TableCell className="p-3">
-                              <div className="font-medium text-slate-900">
-                                {batch.batchId || batch.id}
+                          <Card key={batch.id} className="border border-gray-100 shadow-sm">
+                            <CardContent className="space-y-3 p-4">
+                              <div className="flex items-start justify-between gap-3">
+                                <div>
+                                  <div className="font-semibold text-slate-900">
+                                    {batch.batchId || batch.id}
+                                  </div>
+                                  <div className="text-sm text-gray-500">
+                                    {formatBatchTimestamp(batch.completedAt || batch.createdAt)}
+                                  </div>
+                                </div>
+                                <div>
+                                  {batch.status === 'completed' ? (
+                                    <Badge
+                                      variant="outline"
+                                      className="bg-[#064e3b]/10 text-[#064e3b] border-[#064e3b]/20"
+                                    >
+                                      Completed
+                                    </Badge>
+                                  ) : batch.status === 'failed' ? (
+                                    <Badge
+                                      variant="outline"
+                                      className="bg-red-50 text-red-700 border-red-200"
+                                    >
+                                      Failed
+                                    </Badge>
+                                  ) : (
+                                    <Badge
+                                      variant="outline"
+                                      className="bg-yellow-50 text-yellow-700 border-yellow-200"
+                                    >
+                                      {batch.status || 'Pending'}
+                                    </Badge>
+                                  )}
+                                </div>
                               </div>
-                            </TableCell>
-                            <TableCell className="p-3 text-sm text-gray-700">
-                              {formatBatchTimestamp(batch.completedAt || batch.createdAt)}
-                            </TableCell>
-                            <TableCell className="p-3 text-sm text-gray-700">
-                              {batch.rowCount ?? 0}
-                            </TableCell>
-                            <TableCell className="p-3 text-sm text-gray-700">
-                              {batch.createdByName || batch.createdByEmail || 'Unknown'}
-                            </TableCell>
-                            <TableCell className="p-3">
-                              {batch.status === 'completed' ? (
-                                <Badge
-                                  variant="outline"
-                                  className="bg-[#064e3b]/10 text-[#064e3b] border-[#064e3b]/20"
-                                >
-                                  <CheckCircle className="mr-1 h-3 w-3" />
-                                  Completed
-                                </Badge>
-                              ) : batch.status === 'failed' ? (
-                                <Badge
-                                  variant="outline"
-                                  className="bg-red-50 text-red-700 border-red-200"
-                                >
-                                  <AlertCircle className="mr-1 h-3 w-3" />
-                                  Failed
-                                </Badge>
-                              ) : (
-                                <Badge
-                                  variant="outline"
-                                  className="bg-yellow-50 text-yellow-700 border-yellow-200"
-                                >
-                                  <Clock className="mr-1 h-3 w-3" />
-                                  {batch.status || 'Pending'}
-                                </Badge>
-                              )}
-                            </TableCell>
-                            <TableCell className="p-3">
-                              <div className="flex flex-wrap gap-2">
+
+                              <div className="grid grid-cols-2 gap-3 text-sm">
+                                <div>
+                                  <p className="text-gray-500">Rows</p>
+                                  <p className="font-medium text-slate-900">
+                                    {batch.rowCount ?? 0}
+                                  </p>
+                                </div>
+                                <div>
+                                  <p className="text-gray-500">Exported By</p>
+                                  <p className="font-medium text-slate-900">
+                                    {batch.createdByName || batch.createdByEmail || 'Unknown'}
+                                  </p>
+                                </div>
+                              </div>
+
+                              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                                 <Button
                                   variant="outline"
                                   size="sm"
@@ -789,138 +950,20 @@ export function GiftAidManagement({
                                     : 'Internal CSV'}
                                 </Button>
                               </div>
-                            </TableCell>
-                          </TableRow>
+
+                              {batch.status === 'failed' && batch.failureMessage ? (
+                                <p className="text-sm text-red-600">{batch.failureMessage}</p>
+                              ) : null}
+                            </CardContent>
+                          </Card>
                         ))
                       ) : (
-                        <TableRow>
-                          <TableCell colSpan={6} className="p-6 text-center text-sm text-gray-500">
-                            No Gift Aid export batches yet.
-                          </TableCell>
-                        </TableRow>
+                        <div className="rounded-2xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
+                          No Gift Aid export batches yet.
+                        </div>
                       )}
-                    </TableBody>
-                  </Table>
-                </div>
-
-                <div className="space-y-3 p-4 md:hidden">
-                  {exportHistoryLoading ? (
-                    Array.from({ length: 2 }).map((_, index) => (
-                      <Card
-                        key={`export-history-mobile-skeleton-${index}`}
-                        className="border border-gray-100 shadow-sm"
-                      >
-                        <CardContent className="space-y-3 p-4">
-                          <Skeleton className="h-5 w-28" />
-                          <Skeleton className="h-4 w-40" />
-                          <Skeleton className="h-9 w-full" />
-                        </CardContent>
-                      </Card>
-                    ))
-                  ) : exportBatches.length > 0 ? (
-                    exportBatches.map((batch) => (
-                      <Card key={batch.id} className="border border-gray-100 shadow-sm">
-                        <CardContent className="space-y-3 p-4">
-                          <div className="flex items-start justify-between gap-3">
-                            <div>
-                              <div className="font-semibold text-slate-900">
-                                {batch.batchId || batch.id}
-                              </div>
-                              <div className="text-sm text-gray-500">
-                                {formatBatchTimestamp(batch.completedAt || batch.createdAt)}
-                              </div>
-                            </div>
-                            <div>
-                              {batch.status === 'completed' ? (
-                                <Badge
-                                  variant="outline"
-                                  className="bg-[#064e3b]/10 text-[#064e3b] border-[#064e3b]/20"
-                                >
-                                  Completed
-                                </Badge>
-                              ) : batch.status === 'failed' ? (
-                                <Badge
-                                  variant="outline"
-                                  className="bg-red-50 text-red-700 border-red-200"
-                                >
-                                  Failed
-                                </Badge>
-                              ) : (
-                                <Badge
-                                  variant="outline"
-                                  className="bg-yellow-50 text-yellow-700 border-yellow-200"
-                                >
-                                  {batch.status || 'Pending'}
-                                </Badge>
-                              )}
-                            </div>
-                          </div>
-
-                          <div className="grid grid-cols-2 gap-3 text-sm">
-                            <div>
-                              <p className="text-gray-500">Rows</p>
-                              <p className="font-medium text-slate-900">{batch.rowCount ?? 0}</p>
-                            </div>
-                            <div>
-                              <p className="text-gray-500">Exported By</p>
-                              <p className="font-medium text-slate-900">
-                                {batch.createdByName || batch.createdByEmail || 'Unknown'}
-                              </p>
-                            </div>
-                          </div>
-
-                          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              disabled={
-                                !canDownloadGiftAidBatchHistory ||
-                                !batch.hmrcFile ||
-                                activeDownloadKey === `${batch.id}:hmrc`
-                              }
-                              onClick={() =>
-                                void handleDownloadBatchFile(batch.id, 'hmrc', batch.hmrcFile)
-                              }
-                            >
-                              <Download className="mr-2 h-4 w-4" />
-                              {activeDownloadKey === `${batch.id}:hmrc`
-                                ? 'Downloading...'
-                                : 'HMRC CSV'}
-                            </Button>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              disabled={
-                                !canDownloadGiftAidBatchHistory ||
-                                !batch.internalFile ||
-                                activeDownloadKey === `${batch.id}:internal`
-                              }
-                              onClick={() =>
-                                void handleDownloadBatchFile(
-                                  batch.id,
-                                  'internal',
-                                  batch.internalFile,
-                                )
-                              }
-                            >
-                              <Download className="mr-2 h-4 w-4" />
-                              {activeDownloadKey === `${batch.id}:internal`
-                                ? 'Downloading...'
-                                : 'Internal CSV'}
-                            </Button>
-                          </div>
-
-                          {batch.status === 'failed' && batch.failureMessage ? (
-                            <p className="text-sm text-red-600">{batch.failureMessage}</p>
-                          ) : null}
-                        </CardContent>
-                      </Card>
-                    ))
-                  ) : (
-                    <div className="rounded-2xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
-                      No Gift Aid export batches yet.
                     </div>
-                  )}
+                  </div>
                 </div>
 
                 {!exportHistoryLoading && (canGoExportHistoryPrev || canGoExportHistoryNext) ? (
@@ -933,7 +976,7 @@ export function GiftAidManagement({
                       canGoPrev={canGoExportHistoryPrev}
                       onNext={goToNextExportHistoryPage}
                       onPrev={goToPrevExportHistoryPage}
-                      loading={exportHistoryLoading}
+                      loading={isExportHistoryRefreshing}
                     />
                   </div>
                 ) : null}
@@ -948,49 +991,18 @@ export function GiftAidManagement({
           config={searchFilterConfig}
           filterValues={filterValues}
           onFilterChange={handleFilterChange}
+          onRefresh={refreshGiftAidSection}
+          refreshing={fetching || exportHistoryLoading || exportHistoryFetching}
           filterGridClassName="grid grid-cols-1 gap-3 md:grid-cols-3"
           summaryText={`Showing ${filteredDonations.length} of ${giftAidDonations.length} Gift Aid donations`}
         >
           {loading ? (
-            <>
-              <div className="hidden md:block">
-                <Table className="table-fixed">
-                  <TableBody>
-                    {Array.from({ length: 5 }).map((_, i) => (
-                      <TableRow key={i} className="h-16">
-                        <TableCell className="py-4">
-                          <Skeleton className="h-5 w-32" />
-                        </TableCell>
-                        <TableCell className="py-4">
-                          <Skeleton className="h-5 w-24" />
-                        </TableCell>
-                        <TableCell className="py-4">
-                          <Skeleton className="h-5 w-16" />
-                        </TableCell>
-                        <TableCell className="py-4">
-                          <Skeleton className="h-5 w-16" />
-                        </TableCell>
-                        <TableCell className="py-4">
-                          <Skeleton className="h-5 w-20" />
-                        </TableCell>
-                        <TableCell className="py-4">
-                          <Skeleton className="h-8 w-8 rounded" />
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-              <div className="space-y-4 md:hidden">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Card key={i} className="overflow-hidden">
-                    <CardContent className="p-4">
-                      <Skeleton className="h-20 w-full" />
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-            </>
+            <AdminDataSectionLoading
+              desktopColumns={6}
+              desktopRows={5}
+              mobileRows={3}
+              cardClassName="overflow-hidden"
+            />
           ) : filteredDonations.length > 0 ? (
             <>
               <div className="hidden md:block">

--- a/src/views/admin/GiftAidManagement.tsx
+++ b/src/views/admin/GiftAidManagement.tsx
@@ -4,9 +4,7 @@ import { GiftAidDeclaration } from '../../entities/giftAid/model/types';
 import {
   downloadGiftAidExportFile,
   exportGiftAidDeclarations,
-  fetchGiftAidExportBatches,
   giftAidApi,
-  type GiftAidExportBatch,
   type GiftAidExportFile,
 } from '../../entities/giftAid/api';
 import { AdminLayout } from './AdminLayout';
@@ -35,6 +33,7 @@ import { AdminEmptyState } from './components/AdminEmptyState';
 import { AdminStatsGrid } from './components/AdminStatsGrid';
 import { formatCurrency } from '../../shared/lib/currencyFormatter';
 import { useGiftAid } from '../../shared/lib/hooks/useGiftAid';
+import { useGiftAidExportBatches } from '../../shared/lib/hooks/useGiftAidExportBatches';
 import { PaginationControls } from '../../shared/ui/PaginationControls';
 import { useToast } from '../../shared/ui/ToastProvider';
 import { getAllCampaigns } from '../../shared/api';
@@ -73,9 +72,6 @@ export function GiftAidManagement({
   const [showDetailsDialog, setShowDetailsDialog] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isUpdatingPaid, setIsUpdatingPaid] = useState(false);
-  const [exportBatches, setExportBatches] = useState<GiftAidExportBatch[]>([]);
-  const [exportHistoryLoading, setExportHistoryLoading] = useState(true);
-  const [exportHistoryPage, setExportHistoryPage] = useState(1);
   const [activeDownloadKey, setActiveDownloadKey] = useState<string | null>(null);
   const [charitySubmittedReference, setCharitySubmittedReference] = useState('');
   const [unresolvedReconciliationCount, setUnresolvedReconciliationCount] = useState(0);
@@ -115,34 +111,21 @@ export function GiftAidManagement({
   }));
   const canExportGiftAid = hasPermission('export_giftaid');
   const canDownloadGiftAidBatchHistory = hasPermission('download_giftaid_exports');
-
-  const loadExportBatches = useCallback(
-    async (organizationId: string) => {
-      setExportHistoryLoading(true);
-      try {
-        const batches = await fetchGiftAidExportBatches(organizationId);
-        setExportBatches(batches);
-      } catch (batchError) {
-        console.error('Failed to load Gift Aid export batches:', batchError);
-        showToast('Failed to load Gift Aid export history.', 'warning');
-      } finally {
-        setExportHistoryLoading(false);
-      }
-    },
-    [showToast],
+  const {
+    exportBatches,
+    loading: exportHistoryLoading,
+    error: exportHistoryError,
+    pageNumber: exportHistoryPage,
+    canGoNext: canGoExportHistoryNext,
+    canGoPrev: canGoExportHistoryPrev,
+    goNext: goToNextExportHistoryPage,
+    goPrev: goToPrevExportHistoryPage,
+    pageSize: exportHistoryPageSize,
+    refresh: refreshExportHistory,
+  } = useGiftAidExportBatches(
+    canDownloadGiftAidBatchHistory ? userSession.user.organizationId : undefined,
+    EXPORT_HISTORY_PAGE_SIZE,
   );
-
-  const syncExportHistory = useCallback(() => {
-    const organizationId = userSession.user.organizationId;
-    if (!organizationId || !canDownloadGiftAidBatchHistory) {
-      setExportBatches([]);
-      setExportHistoryPage(1);
-      setExportHistoryLoading(false);
-      return;
-    }
-
-    void loadExportBatches(organizationId);
-  }, [canDownloadGiftAidBatchHistory, loadExportBatches, userSession.user.organizationId]);
 
   const getUnresolvedReconciliationCount = useCallback(async (organizationId: string) => {
     const issuesRef = collection(db, 'giftAidReconciliationIssues');
@@ -198,13 +181,9 @@ export function GiftAidManagement({
   }, [userSession.user.organizationId]);
 
   useEffect(() => {
-    syncExportHistory();
-  }, [syncExportHistory]);
-
-  useEffect(() => {
-    const totalPages = Math.max(1, Math.ceil(exportBatches.length / EXPORT_HISTORY_PAGE_SIZE));
-    setExportHistoryPage((currentPage) => Math.min(currentPage, totalPages));
-  }, [exportBatches]);
+    if (!exportHistoryError) return;
+    showToast(exportHistoryError, 'warning');
+  }, [exportHistoryError, showToast]);
 
   const filteredDonationsData = giftAidDonations.map((donation) => ({
     ...donation,
@@ -222,24 +201,6 @@ export function GiftAidManagement({
     defaultSortKey: 'donationDateTs',
     defaultSortDirection: 'desc',
   });
-
-  const paginatedExportBatches = exportBatches.slice(
-    (exportHistoryPage - 1) * EXPORT_HISTORY_PAGE_SIZE,
-    exportHistoryPage * EXPORT_HISTORY_PAGE_SIZE,
-  );
-  const canGoExportHistoryNext =
-    exportHistoryPage * EXPORT_HISTORY_PAGE_SIZE < exportBatches.length;
-  const canGoExportHistoryPrev = exportHistoryPage > 1;
-
-  const goToNextExportHistoryPage = () => {
-    if (!canGoExportHistoryNext) return;
-    setExportHistoryPage((currentPage) => currentPage + 1);
-  };
-
-  const goToPrevExportHistoryPage = () => {
-    if (!canGoExportHistoryPrev) return;
-    setExportHistoryPage((currentPage) => Math.max(1, currentPage - 1));
-  };
 
   const getStatusBadge = (status: string, paidConfirmed?: boolean) => {
     if (paidConfirmed) {
@@ -364,8 +325,7 @@ export function GiftAidManagement({
 
       setLocalOverrides({});
       refresh();
-      setExportHistoryPage(1);
-      await loadExportBatches(userSession.user.organizationId);
+      refreshExportHistory();
       if (exportResult.skippedCount && exportResult.skippedCount > 0) {
         showToast(
           exportResult.message ||
@@ -745,7 +705,7 @@ export function GiftAidManagement({
                           </TableRow>
                         ))
                       ) : exportBatches.length > 0 ? (
-                        paginatedExportBatches.map((batch) => (
+                        exportBatches.map((batch) => (
                           <TableRow key={batch.id}>
                             <TableCell className="p-3">
                               <div className="font-medium text-slate-900">
@@ -858,7 +818,7 @@ export function GiftAidManagement({
                       </Card>
                     ))
                   ) : exportBatches.length > 0 ? (
-                    paginatedExportBatches.map((batch) => (
+                    exportBatches.map((batch) => (
                       <Card key={batch.id} className="border border-gray-100 shadow-sm">
                         <CardContent className="space-y-3 p-4">
                           <div className="flex items-start justify-between gap-3">
@@ -963,12 +923,12 @@ export function GiftAidManagement({
                   )}
                 </div>
 
-                {!exportHistoryLoading && exportBatches.length > EXPORT_HISTORY_PAGE_SIZE ? (
+                {!exportHistoryLoading && (canGoExportHistoryPrev || canGoExportHistoryNext) ? (
                   <div className="border-t border-gray-100 px-4 py-2 sm:px-6">
                     <PaginationControls
                       pageNumber={exportHistoryPage}
-                      pageSize={EXPORT_HISTORY_PAGE_SIZE}
-                      totalOnPage={paginatedExportBatches.length}
+                      pageSize={exportHistoryPageSize}
+                      totalOnPage={exportBatches.length}
                       canGoNext={canGoExportHistoryNext}
                       canGoPrev={canGoExportHistoryPrev}
                       onNext={goToNextExportHistoryPage}

--- a/src/views/admin/GiftAidManagement.tsx
+++ b/src/views/admin/GiftAidManagement.tsx
@@ -36,18 +36,10 @@ import { AdminStatsGrid } from './components/AdminStatsGrid';
 import { formatCurrency } from '../../shared/lib/currencyFormatter';
 import { useGiftAid } from '../../shared/lib/hooks/useGiftAid';
 import { PaginationControls } from '../../shared/ui/PaginationControls';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from '../../shared/ui/pagination';
 import { useToast } from '../../shared/ui/ToastProvider';
 import { getAllCampaigns } from '../../shared/api';
 
-const EXPORT_HISTORY_PAGE_SIZE = 8;
+const EXPORT_HISTORY_PAGE_SIZE = 2;
 
 interface GiftAidManagementProps {
   onNavigate: (screen: Screen) => void;
@@ -972,45 +964,17 @@ export function GiftAidManagement({
                 </div>
 
                 {!exportHistoryLoading && exportBatches.length > EXPORT_HISTORY_PAGE_SIZE ? (
-                  <div className="border-t border-gray-100 px-4 py-4 sm:px-6">
-                    <Pagination>
-                      <PaginationContent>
-                        <PaginationItem>
-                          <PaginationPrevious
-                            href="#"
-                            onClick={(event) => {
-                              event.preventDefault();
-                              goToPrevExportHistoryPage();
-                            }}
-                            className={
-                              !canGoExportHistoryPrev ? 'pointer-events-none opacity-50' : ''
-                            }
-                          />
-                        </PaginationItem>
-                        <PaginationItem>
-                          <PaginationLink
-                            href="#"
-                            isActive
-                            size="default"
-                            onClick={(event) => event.preventDefault()}
-                          >
-                            Page {exportHistoryPage}
-                          </PaginationLink>
-                        </PaginationItem>
-                        <PaginationItem>
-                          <PaginationNext
-                            href="#"
-                            onClick={(event) => {
-                              event.preventDefault();
-                              goToNextExportHistoryPage();
-                            }}
-                            className={
-                              !canGoExportHistoryNext ? 'pointer-events-none opacity-50' : ''
-                            }
-                          />
-                        </PaginationItem>
-                      </PaginationContent>
-                    </Pagination>
+                  <div className="border-t border-gray-100 px-4 py-2 sm:px-6">
+                    <PaginationControls
+                      pageNumber={exportHistoryPage}
+                      pageSize={EXPORT_HISTORY_PAGE_SIZE}
+                      totalOnPage={paginatedExportBatches.length}
+                      canGoNext={canGoExportHistoryNext}
+                      canGoPrev={canGoExportHistoryPrev}
+                      onNext={goToNextExportHistoryPage}
+                      onPrev={goToPrevExportHistoryPage}
+                      loading={exportHistoryLoading}
+                    />
                   </div>
                 ) : null}
               </CardContent>

--- a/src/views/admin/KioskManagement.tsx
+++ b/src/views/admin/KioskManagement.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { db } from '../../shared/lib/firebase';
 import { useKiosks } from '../../shared/lib/hooks/useKiosks';
 import { useLocations } from '../../shared/lib/hooks/useLocations';
@@ -59,6 +59,7 @@ import {
 import { AdminSearchFilterConfig } from './components/AdminSearchFilterHeader';
 import { AdminDataSection } from './components/AdminDataSection';
 import { AdminEmptyState } from './components/AdminEmptyState';
+import { AdminPageLoader } from './components/AdminPageStatus';
 import { AdminStatsGrid } from './components/AdminStatsGrid';
 import { SortableTableHeader } from './components/SortableTableHeader';
 import { useTableSort } from '../../shared/lib/hooks/useTableSort';
@@ -117,7 +118,7 @@ export function KioskManagement({
   const { needsOnboarding } = useStripeOnboarding(organization);
   const [showOnboardingDialog, setShowOnboardingDialog] = useState(false);
 
-  const isLoading = kiosksLoading || campaignsLoading;
+  const isInitialLoading = kiosksLoading && kiosks.length === 0;
 
   const locationNameById = useMemo(() => {
     const map = new Map<string, string>();
@@ -196,9 +197,9 @@ export function KioskManagement({
     }
   };
 
-  useEffect(() => {
-    refreshCampaigns();
-  }, [refreshCampaigns]);
+  const refreshKioskSection = useCallback(async () => {
+    await Promise.all([refreshKiosks(), refreshCampaigns(), refetchLocations()]);
+  }, [refreshCampaigns, refreshKiosks, refetchLocations]);
 
   useEffect(() => {
     if (!locationsError) {
@@ -503,7 +504,7 @@ export function KioskManagement({
     }
   };
 
-  if (isLoading) {
+  if (isInitialLoading) {
     return (
       <AdminLayout
         onNavigate={onNavigate}
@@ -512,15 +513,7 @@ export function KioskManagement({
         hasPermission={hasPermission}
         activeScreen="admin-kiosks"
       >
-        <div className="space-y-6 sm:space-y-8">
-          <div className="text-center py-12">
-            <div className="animate-pulse">
-              <div className="w-12 h-12 bg-gray-300 rounded-full mx-auto mb-3"></div>
-              <div className="h-4 bg-gray-300 rounded w-32 mx-auto mb-2"></div>
-              <div className="h-3 bg-gray-300 rounded w-48 mx-auto"></div>
-            </div>
-          </div>
-        </div>
+        <AdminPageLoader message="Loading kiosks..." />
       </AdminLayout>
     );
   }
@@ -580,7 +573,7 @@ export function KioskManagement({
       <div className="space-y-6 sm:space-y-8">
         <main className="px-6 lg:px-8 pt-12 pb-8">
           {/* Stat Cards Section */}
-          <AdminStatsGrid className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6 mb-12">
+          <AdminStatsGrid className="grid grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6 mb-12">
             <Card>
               <CardContent className="p-3 sm:p-4 lg:p-6">
                 <div className="flex items-center justify-between">
@@ -645,6 +638,8 @@ export function KioskManagement({
             config={searchFilterConfig}
             filterValues={filterValues}
             onFilterChange={handleFilterChange}
+            onRefresh={refreshKioskSection}
+            refreshing={fetching || kiosksLoading || campaignsLoading || locationsLoading}
             filterGridClassName="grid grid-cols-1 gap-3 md:grid-cols-3"
             summaryText={`Showing ${filteredKiosks.length} of ${kiosks.length} kiosks`}
             cardClassName="overflow-hidden rounded-3xl border border-gray-100 shadow-sm"

--- a/src/views/admin/OrganizationSettings.tsx
+++ b/src/views/admin/OrganizationSettings.tsx
@@ -25,6 +25,7 @@ import {
 import { useToast } from '../../shared/ui/ToastProvider';
 import { VALIDATION_LIMITS } from '../../shared/config/constants';
 import { OrganizationSwitcher } from './OrganizationSwitcher';
+import { AdminPageError, AdminPageLoader } from './components/AdminPageStatus';
 
 interface OrganizationSettingsProps {
   onNavigate: (screen: Screen) => void;
@@ -443,9 +444,7 @@ export function OrganizationSettings({
         hasPermission={hasPermission}
         activeScreen="admin-organization-settings"
       >
-        <div className="flex h-full items-center justify-center">
-          <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
-        </div>
+        <AdminPageLoader message="Loading organization settings..." />
       </AdminLayout>
     );
   }
@@ -459,16 +458,10 @@ export function OrganizationSettings({
         hasPermission={hasPermission}
         activeScreen="admin-organization-settings"
       >
-        <div className="flex h-full items-center justify-center">
-          <Card className="w-full max-w-lg border-red-200 bg-red-50">
-            <CardHeader>
-              <CardTitle className="text-red-700">Unable To Load Settings</CardTitle>
-              <CardDescription className="text-red-600">
-                {error || 'Organization record is not available.'}
-              </CardDescription>
-            </CardHeader>
-          </Card>
-        </div>
+        <AdminPageError
+          title="Unable To Load Settings"
+          message={error || 'Organization record is not available.'}
+        />
       </AdminLayout>
     );
   }

--- a/src/views/admin/SubscriptionManagement.tsx
+++ b/src/views/admin/SubscriptionManagement.tsx
@@ -11,7 +11,6 @@ import {
   TableHeader,
   TableRow,
 } from '../../shared/ui/table';
-import { Alert, AlertDescription } from '../../shared/ui/alert';
 import {
   Dialog,
   DialogContent,
@@ -48,8 +47,11 @@ import { getSubscriptionDisplayInterval } from '../../entities/subscription/mode
 import { SortableTableHeader } from './components/SortableTableHeader';
 import { AdminSearchFilterConfig } from './components/AdminSearchFilterHeader';
 import { AdminDataSection } from './components/AdminDataSection';
+import { AdminDataSectionLoading } from './components/AdminDataSectionLoading';
 import { AdminEmptyState } from './components/AdminEmptyState';
+import { AdminPageError } from './components/AdminPageStatus';
 import { AdminStatsGrid } from './components/AdminStatsGrid';
+import { AdminStatsGridLoading } from './components/AdminStatsGridLoading';
 import { useTableSort } from '../../shared/lib/hooks/useTableSort';
 import { AdminLayout } from './AdminLayout';
 import { Screen, AdminSession, Permission } from '../../shared/types';
@@ -242,6 +244,8 @@ export function SubscriptionManagement({
     defaultSortKey: 'createdAtTs',
     defaultSortDirection: 'desc',
   });
+  const hasSubscriptionData = subscriptions.length > 0 || stats !== null;
+  const isInitialLoading = loading && !hasSubscriptionData;
 
   const intervalOptions = useMemo(() => {
     const unique = Array.from(new Set(tableData.map((s) => s.intervalLabel)));
@@ -510,18 +514,12 @@ export function SubscriptionManagement({
     >
       <div className="space-y-6 sm:space-y-8">
         <main className="px-6 lg:px-8 pt-12 pb-8 space-y-6">
-          {loading ? (
-            <div className="flex items-center justify-center p-8">
-              <RefreshCw className="w-6 h-6 animate-spin text-gray-400" />
-            </div>
-          ) : error ? (
-            <Alert variant="destructive">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
+          {error && !hasSubscriptionData ? (
+            <AdminPageError title="Unable To Load Subscriptions" message={error} />
           ) : (
             <>
-              {stats && (
-                <AdminStatsGrid className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-6 gap-4 lg:gap-6">
+              {stats ? (
+                <AdminStatsGrid className="grid grid-cols-2 lg:grid-cols-3 2xl:grid-cols-6 gap-4 lg:gap-6">
                   <Card className="rounded-3xl border border-gray-100 shadow-sm">
                     <CardContent className="p-5 flex items-center gap-4">
                       <div className="h-12 w-12 rounded-2xl bg-emerald-100 text-emerald-700 flex items-center justify-center">
@@ -634,7 +632,12 @@ export function SubscriptionManagement({
                     </CardContent>
                   </Card>
                 </AdminStatsGrid>
-              )}
+              ) : isInitialLoading ? (
+                <AdminStatsGridLoading
+                  count={6}
+                  className="grid grid-cols-2 lg:grid-cols-3 2xl:grid-cols-6 gap-4 lg:gap-6"
+                />
+              ) : null}
 
               <AdminDataSection
                 title="Recurring Subscriptions"
@@ -642,10 +645,14 @@ export function SubscriptionManagement({
                 config={searchFilterConfig}
                 filterValues={filterValues}
                 onFilterChange={handleFilterChange}
+                onRefresh={loadSubscriptions}
+                refreshing={loading}
                 filterGridClassName="grid grid-cols-1 gap-3 md:grid-cols-3"
                 summaryText={`Showing ${sortedData.length} of ${totalSubscriptionsCount} subscriptions`}
               >
-                {sortedData.length === 0 ? (
+                {isInitialLoading ? (
+                  <AdminDataSectionLoading desktopColumns={8} desktopRows={5} mobileRows={3} />
+                ) : sortedData.length === 0 ? (
                   <AdminEmptyState
                     icon={RefreshCw}
                     title="No subscriptions match your current filters"
@@ -835,7 +842,9 @@ export function SubscriptionManagement({
                   <CardDescription>Monthly MRR and recurring cash trend</CardDescription>
                 </CardHeader>
                 <CardContent>
-                  {trends.length === 0 ? (
+                  {isInitialLoading ? (
+                    <AdminDataSectionLoading desktopColumns={5} desktopRows={4} mobileRows={2} />
+                  ) : trends.length === 0 ? (
                     <p className="text-sm text-gray-500">
                       No trend data available for this window.
                     </p>

--- a/src/views/admin/UserManagement.tsx
+++ b/src/views/admin/UserManagement.tsx
@@ -56,6 +56,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../
 import { AdminLayout } from './AdminLayout';
 import { AdminSearchFilterConfig } from './components/AdminSearchFilterHeader';
 import { AdminDataSection } from './components/AdminDataSection';
+import { AdminDataSectionLoading } from './components/AdminDataSectionLoading';
 import { AdminStatsGrid } from './components/AdminStatsGrid';
 import { AdminEmptyState } from './components/AdminEmptyState';
 import { SortableTableHeader } from './components/SortableTableHeader';
@@ -254,6 +255,7 @@ export function UserManagement({
     goNext,
     goPrev,
     pageSize,
+    refresh: refreshUsersPage,
   } = useUsersPaginated(userSession.user.organizationId, {
     role: roleFilter === 'all' ? undefined : roleFilter,
     searchTerm: searchTerm.trim() || undefined,
@@ -449,7 +451,7 @@ export function UserManagement({
       <div className="space-y-6 sm:space-y-8">
         <main className="px-6 lg:px-8 pt-12 pb-8">
           {/* Stat Cards Section */}
-          <AdminStatsGrid className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
+          <AdminStatsGrid className="grid grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
             {/* Total Users Card */}
             <Card className="border-0 shadow-sm bg-white">
               <CardContent className="p-6">
@@ -517,14 +519,19 @@ export function UserManagement({
             config={searchFilterConfig}
             filterValues={filterValues}
             onFilterChange={handleFilterChange}
+            onRefresh={refreshUsersPage}
+            refreshing={fetching}
             filterGridClassName="grid grid-cols-1 gap-3 md:grid-cols-3"
             summaryText={`Showing ${filteredUsers.length} of ${pagedUsers.length} users`}
             cardClassName="overflow-hidden rounded-3xl border border-gray-100 shadow-sm"
           >
             {loading ? (
-              <div className="flex justify-center p-12">
-                <Loader2 className="h-8 w-8 animate-spin text-indigo-600" />
-              </div>
+              <AdminDataSectionLoading
+                desktopColumns={6}
+                desktopRows={5}
+                mobileRows={3}
+                cardClassName="overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm"
+              />
             ) : error ? (
               <div className="text-center text-red-600 p-12">
                 <AlertCircle className="mx-auto h-8 w-8 mb-2" />

--- a/src/views/admin/components/AdminDataSection.tsx
+++ b/src/views/admin/components/AdminDataSection.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../../shared/ui/card';
 import { AdminSearchFilterConfig, AdminSearchFilterHeader } from './AdminSearchFilterHeader';
+import { AdminRefreshButton } from './AdminRefreshButton';
 
 interface AdminDataSectionProps {
   title: string;
@@ -10,6 +11,9 @@ interface AdminDataSectionProps {
   onFilterChange: (key: string, value: unknown) => void;
   summaryText?: React.ReactNode;
   actions?: React.ReactNode;
+  onRefresh?: () => void | Promise<unknown>;
+  refreshing?: boolean;
+  showRefresh?: boolean;
   showMobileActions?: boolean;
   filterGridClassName?: string;
   wrapperClassName?: string;
@@ -26,6 +30,9 @@ export function AdminDataSection({
   onFilterChange,
   summaryText,
   actions,
+  onRefresh,
+  refreshing = false,
+  showRefresh = true,
   showMobileActions = true,
   filterGridClassName,
   wrapperClassName,
@@ -33,24 +40,96 @@ export function AdminDataSection({
   contentClassName,
   children,
 }: AdminDataSectionProps) {
+  const [isManualRefreshActive, setIsManualRefreshActive] = useState(false);
+  const [isRefreshPending, setIsRefreshPending] = useState(false);
+  const isRefreshing = refreshing || isRefreshPending;
+
+  const handleRefresh = useCallback(() => {
+    if (!onRefresh || isRefreshing) return;
+    setIsManualRefreshActive(true);
+    try {
+      const result = onRefresh();
+      if (result && typeof (result as Promise<unknown>).then === 'function') {
+        setIsRefreshPending(true);
+        void (result as Promise<unknown>).finally(() => {
+          setIsRefreshPending(false);
+        });
+      }
+    } catch {
+      setIsRefreshPending(false);
+    }
+  }, [onRefresh, isRefreshing]);
+
+  useEffect(() => {
+    if (!isManualRefreshActive) return;
+    if (isRefreshing) return;
+
+    const timeout = window.setTimeout(() => {
+      setIsManualRefreshActive(false);
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [isManualRefreshActive, isRefreshing]);
+
+  const shouldShowRefresh = Boolean(onRefresh && showRefresh);
+  const desktopRefreshAction = shouldShowRefresh ? (
+    <AdminRefreshButton onRefresh={handleRefresh} refreshing={isRefreshing} />
+  ) : null;
+  const mobileRefreshAction = shouldShowRefresh ? (
+    <AdminRefreshButton onRefresh={handleRefresh} refreshing={isRefreshing} />
+  ) : null;
+  const desktopActions =
+    desktopRefreshAction && actions ? (
+      <>
+        {desktopRefreshAction}
+        {actions}
+      </>
+    ) : (
+      (desktopRefreshAction ?? actions)
+    );
+
   return (
     <Card className={cardClassName}>
       <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <CardTitle>{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          {mobileRefreshAction ? <div className="sm:hidden">{mobileRefreshAction}</div> : null}
+        </div>
       </CardHeader>
       <CardContent className={contentClassName}>
         <AdminSearchFilterHeader
           config={config}
           filterValues={filterValues}
           onFilterChange={onFilterChange}
-          actions={actions}
+          actions={desktopActions}
+          mobileActions={actions ?? null}
           showMobileActions={showMobileActions}
           filterGridClassName={filterGridClassName}
           wrapperClassName={wrapperClassName}
           summaryText={summaryText}
         />
-        {children}
+        <div className="relative">
+          {isManualRefreshActive ? (
+            <div className="pointer-events-none absolute inset-0 z-10 rounded-xl bg-white/45 backdrop-blur-[1px]">
+              <div className="absolute left-4 top-3 flex items-center gap-2 rounded-md border border-gray-200 bg-white/90 px-2.5 py-1.5 text-[11px] font-medium text-gray-600 shadow-sm">
+                <span className="h-3.5 w-3.5 rounded-full border-2 border-gray-300 border-t-emerald-600 motion-safe:animate-spin" />
+                <span>Refreshing data...</span>
+              </div>
+            </div>
+          ) : null}
+          <div
+            className={
+              isManualRefreshActive
+                ? 'transition-opacity duration-200 opacity-70'
+                : 'transition-opacity duration-200 opacity-100'
+            }
+          >
+            {children}
+          </div>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/views/admin/components/AdminDataSectionLoading.tsx
+++ b/src/views/admin/components/AdminDataSectionLoading.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent } from '../../../shared/ui/card';
+import { Skeleton } from '../../../shared/ui/skeleton';
+
+interface AdminDataSectionLoadingProps {
+  desktopColumns?: number;
+  desktopRows?: number;
+  mobileRows?: number;
+  cardClassName?: string;
+}
+
+export function AdminDataSectionLoading({
+  desktopColumns = 6,
+  desktopRows = 5,
+  mobileRows = 3,
+  cardClassName = 'overflow-hidden rounded-3xl',
+}: AdminDataSectionLoadingProps) {
+  return (
+    <>
+      <div className="hidden space-y-4 md:block">
+        {Array.from({ length: desktopRows }).map((_, rowIndex) => (
+          <div
+            key={`admin-data-loading-row-${rowIndex}`}
+            className={`grid gap-4 border-b border-gray-100 py-4`}
+            style={{ gridTemplateColumns: `repeat(${desktopColumns}, minmax(0, 1fr))` }}
+          >
+            {Array.from({ length: desktopColumns }).map((_, colIndex) => (
+              <Skeleton
+                key={`admin-data-loading-cell-${rowIndex}-${colIndex}`}
+                className="h-10 w-full"
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+      <div className="space-y-4 md:hidden">
+        {Array.from({ length: mobileRows }).map((_, rowIndex) => (
+          <Card key={`admin-data-loading-mobile-${rowIndex}`} className={cardClassName}>
+            <CardContent className="p-4">
+              <Skeleton className="h-20 w-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/views/admin/components/AdminPageStatus.tsx
+++ b/src/views/admin/components/AdminPageStatus.tsx
@@ -1,0 +1,82 @@
+import { AlertCircle } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../../shared/ui/card';
+import { Skeleton } from '../../../shared/ui/skeleton';
+
+interface AdminPageLoaderProps {
+  message?: string;
+}
+
+export function AdminPageLoader({ message = 'Loading data...' }: AdminPageLoaderProps) {
+  return (
+    <div className="w-full px-6 pt-8 pb-6 lg:px-8">
+      <div className="mb-4 text-sm text-gray-500">{message}</div>
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Card
+            key={`admin-loader-stat-${index}`}
+            className="rounded-3xl border border-gray-100 shadow-sm"
+          >
+            <CardContent className="p-5">
+              <div className="flex items-center gap-3">
+                <Skeleton className="h-10 w-10 rounded-xl" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-3 w-20" />
+                  <Skeleton className="h-6 w-24" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card className="mt-6 rounded-3xl border border-gray-100 shadow-sm">
+        <CardContent className="p-5">
+          <div className="space-y-4">
+            <Skeleton className="h-4 w-40" />
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+            <Skeleton className="h-4 w-52" />
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, rowIndex) => (
+                <div key={`admin-loader-row-${rowIndex}`} className="grid grid-cols-6 gap-3">
+                  <Skeleton className="h-9 w-full" />
+                  <Skeleton className="h-9 w-full" />
+                  <Skeleton className="h-9 w-full" />
+                  <Skeleton className="h-9 w-full" />
+                  <Skeleton className="h-9 w-full" />
+                  <Skeleton className="h-9 w-full" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+interface AdminPageErrorProps {
+  title?: string;
+  message: string;
+}
+
+export function AdminPageError({ title = 'Unable To Load Data', message }: AdminPageErrorProps) {
+  return (
+    <div className="flex min-h-[280px] w-full items-center justify-center">
+      <Card className="w-full max-w-lg border-red-200 bg-red-50">
+        <CardHeader>
+          <div className="mb-2 flex items-center gap-2 text-red-700">
+            <AlertCircle className="h-5 w-5" />
+            <CardTitle className="text-red-700">{title}</CardTitle>
+          </div>
+          <CardDescription className="text-red-600">{message}</CardDescription>
+        </CardHeader>
+      </Card>
+    </div>
+  );
+}

--- a/src/views/admin/components/AdminRefreshButton.tsx
+++ b/src/views/admin/components/AdminRefreshButton.tsx
@@ -1,0 +1,48 @@
+import { RefreshCw } from 'lucide-react';
+import { Button } from '../../../shared/ui/button';
+
+interface AdminRefreshButtonProps {
+  onRefresh: () => void;
+  refreshing?: boolean;
+  disabled?: boolean;
+  label?: string;
+  ariaLabel?: string;
+  className?: string;
+  variant?: React.ComponentProps<typeof Button>['variant'];
+  size?: React.ComponentProps<typeof Button>['size'];
+  hideLabelOnMobile?: boolean;
+}
+
+export function AdminRefreshButton({
+  onRefresh,
+  refreshing = false,
+  disabled = false,
+  label = 'Refresh',
+  ariaLabel,
+  className,
+  variant = 'outline',
+  size = 'sm',
+  hideLabelOnMobile = false,
+}: AdminRefreshButtonProps) {
+  const isDisabled = disabled || refreshing;
+  const baseClassName =
+    'rounded-xl border-gray-200 bg-white text-gray-700 hover:bg-gray-50 hover:border-gray-300 transition-colors duration-200 disabled:opacity-50';
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      onClick={onRefresh}
+      disabled={isDisabled}
+      aria-label={ariaLabel ?? `Refresh ${label.toLowerCase()}`}
+      className={className ? `${baseClassName} ${className}` : baseClassName}
+    >
+      <RefreshCw
+        className={refreshing ? 'h-4 w-4 motion-safe:animate-[spin_1s_linear_infinite]' : 'h-4 w-4'}
+      />
+      <span className={hideLabelOnMobile ? 'ml-2 hidden sm:inline' : 'ml-2'}>
+        {refreshing ? 'Refreshing...' : label}
+      </span>
+    </Button>
+  );
+}

--- a/src/views/admin/components/AdminSearchFilterHeader.tsx
+++ b/src/views/admin/components/AdminSearchFilterHeader.tsx
@@ -30,6 +30,7 @@ interface AdminPageHeaderProps {
   filterValues: Record<string, unknown>;
   onFilterChange: (key: string, value: unknown) => void;
   actions?: React.ReactNode;
+  mobileActions?: React.ReactNode;
   showFiltersLabel?: boolean;
   wrapperClassName?: string;
   filterGridClassName?: string;
@@ -46,6 +47,7 @@ export function AdminPageHeader({
   filterValues,
   onFilterChange,
   actions,
+  mobileActions,
   showFiltersLabel = false,
   wrapperClassName,
   filterGridClassName = 'grid grid-cols-1 gap-3 md:grid-cols-3',
@@ -53,6 +55,8 @@ export function AdminPageHeader({
   dateLocale = 'en-GB',
   showMobileActions = true,
 }: AdminPageHeaderProps) {
+  const resolvedMobileActions = mobileActions === undefined ? actions : mobileActions;
+
   const renderFilter = (filter: FilterConfig) => {
     const value = filterValues[filter.key];
 
@@ -146,8 +150,8 @@ export function AdminPageHeader({
         </div>
       )}
       {summaryText ? <div className="text-sm text-gray-600">{summaryText}</div> : null}
-      {actions && showMobileActions ? (
-        <div className="mt-3 flex items-center gap-2 sm:hidden">{actions}</div>
+      {resolvedMobileActions && showMobileActions ? (
+        <div className="mt-3 flex items-center gap-2 sm:hidden">{resolvedMobileActions}</div>
       ) : null}
     </div>
   );

--- a/src/views/admin/components/AdminStatsGrid.tsx
+++ b/src/views/admin/components/AdminStatsGrid.tsx
@@ -7,7 +7,7 @@ interface AdminStatsGridProps {
 
 export function AdminStatsGrid({
   children,
-  className = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6',
+  className = 'grid grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6',
 }: AdminStatsGridProps) {
   return <div className={className}>{children}</div>;
 }

--- a/src/views/admin/components/AdminStatsGridLoading.tsx
+++ b/src/views/admin/components/AdminStatsGridLoading.tsx
@@ -1,0 +1,33 @@
+import { Card, CardContent } from '../../../shared/ui/card';
+import { Skeleton } from '../../../shared/ui/skeleton';
+import { AdminStatsGrid } from './AdminStatsGrid';
+
+interface AdminStatsGridLoadingProps {
+  count?: number;
+  className?: string;
+}
+
+export function AdminStatsGridLoading({
+  count = 4,
+  className = 'grid grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6',
+}: AdminStatsGridLoadingProps) {
+  return (
+    <AdminStatsGrid className={className}>
+      {Array.from({ length: count }).map((_, index) => (
+        <Card
+          key={`admin-stats-loading-${index}`}
+          className="rounded-3xl border border-gray-100 shadow-sm"
+        >
+          <CardContent className="p-5 flex items-center gap-4">
+            <Skeleton className="h-12 w-12 rounded-2xl" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-6 w-28" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </AdminStatsGrid>
+  );
+}


### PR DESCRIPTION
### Summary
- Centralised admin list-section UX using shared components:
  - `AdminDataSection`
  - `AdminSearchFilterHeader`
  - `AdminRefreshButton`
  - `AdminPageStatus`
  - shared loading skeletons
- Standardise refresh behaviour across admin pages.
- Standardised mobile refresh placement to section header top-right.
- Removed duplicate mobile refresh rendering below filters.
- Aligned pagination behaviour/UI (`Previous / Page N / Next`) across admin sections.
- Updated Gift Aid export history to cursor-based pagination with page size `2`.

### Before

https://github.com/user-attachments/assets/1ef3c1a3-bf89-41e9-b1d4-81b40cc82541



### After

https://github.com/user-attachments/assets/8be8b00f-892d-468a-8e7c-1fe7e146cadc




### Gift Aid Export History
- Uses cursor-based pagination on `giftAidExportBatches`.
- Query order: `createdAt desc`, `__name__ desc`.
- Added/kept fallback behaviour for missing composite index (org-filtered fetch + in-memory sort/pagination).

### Lint / Stability
- Fixed `BankDetails.tsx` lint issues:
  - removed unused import
  - removed unused variable
  - replaced `catch (error: any)` with safe `unknown` handling
- Verified `useKiosks.ts` lint is clean.

### Documentation
- Updated `docs/ADMIN_FLOW.md`
- Added `docs/ADMIN_UI_CONVENTIONS.md`
- Updated `docs/PROJECT_WORKFLOW.md`
- Updated `docs/GIFTAID_EXPORT_FLOW.md`

### Validation
- Manual verification across admin pages for refresh + loading consistency.
- `npx eslint src/views/admin/BankDetails.tsx` passes.
- `npx eslint src/shared/lib/hooks/useKiosks.ts` passes.
- Note: repo has unrelated pre-existing lint errors outside this change scope.

### Deployment / Ops Notes
- Ensure Firestore composite index exists for:
  - `giftAidExportBatches`: `organizationId ASC`, `createdAt DESC`, `__name__ DESC`
- If the index is not deployed yet, the client fallback path handles history fetch temporarily.

Closes #686 and #687 