### PR TITLE
feat: donor self-service subscription management portal

### DIFF
--- a/app/link/[token]/page.tsx
+++ b/app/link/[token]/page.tsx
@@ -3,140 +3,106 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { use } from 'react';
-
-interface ValidationResult {
-  valid: boolean;
-  tokenId?: string;
-  donationId?: string;
-  campaignId?: string;
-  amount?: number;
-  currency?: string;
-  purpose?: string;
-  expiresAt?: string;
-  error?: string;
-}
+import { Loader2 } from 'lucide-react';
+import { FUNCTION_URLS } from '@/shared/config/functions';
 
 export default function MagicLinkPage({ params }: { params: Promise<{ token: string }> }) {
   const router = useRouter();
   const { token } = use(params);
   const [validating, setValidating] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
     validateToken();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [retryCount]); // Re-run when retry count changes
+  }, []);
 
   const validateToken = async () => {
     setValidating(true);
     setError(null);
 
-    // Timeout configuration
-    const TIMEOUT_MS = 10000; // 10 seconds
-    const abortController = new AbortController();
-    const timeoutId = setTimeout(() => abortController.abort(), TIMEOUT_MS);
-
     try {
-      // Call validation endpoint
-      const response = await fetch(
-        'https://us-central1-swiftcause-app.cloudfunctions.net/validateMagicLinkToken',
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ token }),
-          signal: abortController.signal,
+      // Try subscription management magic link first
+      const response = await fetch(FUNCTION_URLS.verifySubscriptionMagicLink, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
         },
-      );
+        body: JSON.stringify({ token }),
+      });
 
-      clearTimeout(timeoutId);
+      if (response.ok) {
+        const data = await response.json();
 
-      // Parse JSON safely
-      let data: ValidationResult;
-      try {
-        data = await response.json();
-      } catch (parseError) {
-        console.error('Failed to parse response:', parseError);
-        throw new Error('Invalid server response. Please try again.');
-      }
+        if (data.success && data.email && data.token) {
+          // Store email and Firebase auth token in session storage
+          sessionStorage.setItem('donor_email', data.email);
+          sessionStorage.setItem('donor_auth_token', data.token);
 
-      if (!response.ok || !data.valid) {
-        // Handle validation errors
-        const errorMessage = getErrorMessage(data.error || 'UNKNOWN_ERROR');
-        setError(errorMessage);
-        setValidating(false);
-        return;
-      }
+          // Sign in with custom token
+          const { getAuth, signInWithCustomToken } = await import('firebase/auth');
+          const auth = getAuth();
 
-      // Cache the validation result to prevent duplicate calls in gift-aid page
-      // This prevents race conditions when user navigates to /gift-aid
-      const cacheKey = `tokenValidation_${token}`;
-      try {
-        sessionStorage.setItem(cacheKey, JSON.stringify(data));
-        sessionStorage.setItem(`${cacheKey}_timestamp`, Date.now().toString());
-      } catch {
-        // Storage unavailable — validation still proceeds without caching
-      }
+          try {
+            await signInWithCustomToken(auth, data.token);
+            // Authenticated successfully
+          } catch (authError) {
+            console.error('Firebase auth error:', authError);
+            setError('Unable to start your secure session. Please request a new link.');
+            setValidating(false);
+            return;
+          }
 
-      // Small delay for UX polish (show success state briefly)
-      await new Promise((resolve) => setTimeout(resolve, 500));
-
-      // Redirect to Gift Aid form with the plain token
-      router.push(`/gift-aid?token=${token}`);
-    } catch (err) {
-      clearTimeout(timeoutId);
-
-      // Handle specific error types
-      if (err instanceof Error) {
-        if (err.name === 'AbortError') {
-          console.error('Request timed out');
-          setError('The request took too long. Please check your connection and try again.');
-        } else {
-          console.error('Validation error:', err);
-          setError(err.message);
+          // Redirect to dashboard
+          router.push(`/manage/dashboard?email=${encodeURIComponent(data.email)}`);
+          return;
         }
-      } else {
-        console.error('Unknown error:', err);
-        setError('Unable to validate link. Please try again.');
       }
 
+      // If subscription link fails, try gift aid link (existing functionality)
+      const giftAidResponse = await fetch(FUNCTION_URLS.validateMagicLinkToken, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ token }),
+      });
+
+      if (giftAidResponse.ok) {
+        const giftAidData = await giftAidResponse.json();
+
+        if (giftAidData.valid) {
+          // Cache the validation result
+          const cacheKey = `tokenValidation_${token}`;
+          try {
+            sessionStorage.setItem(cacheKey, JSON.stringify(giftAidData));
+            sessionStorage.setItem(`${cacheKey}_timestamp`, Date.now().toString());
+          } catch {
+            // Storage unavailable
+          }
+
+          // Redirect to Gift Aid form
+          router.push(`/gift-aid?token=${token}`);
+          return;
+        }
+      }
+
+      // Both failed
+      setError('This link is invalid or has expired.');
+      setValidating(false);
+    } catch (err) {
+      console.error('Validation error:', err);
+      setError('Unable to validate link. Please try again.');
       setValidating(false);
     }
-  };
-
-  // Map error codes to user-friendly messages
-  const getErrorMessage = (errorCode: string): string => {
-    switch (errorCode) {
-      case 'TOKEN_NOT_FOUND':
-        return 'This link is invalid or has been removed.';
-      case 'TOKEN_EXPIRED':
-        return 'This link has expired. Please contact the charity for assistance.';
-      case 'TOKEN_CONSUMED':
-        return 'This link has already been used.';
-      case 'TOKEN_BLOCKED':
-        return 'This link has been blocked due to too many attempts.';
-      case 'INVALID_REQUEST':
-        return 'Invalid request. Please check the link and try again.';
-      case 'INTERNAL_ERROR':
-        return 'Server error. Please try again in a moment.';
-      default:
-        return 'This link is no longer valid.';
-    }
-  };
-
-  // Retry handler
-  const handleRetry = () => {
-    setRetryCount((prev) => prev + 1);
   };
 
   // Loading state
   if (validating) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-green-50 to-white">
+      <div className="min-h-screen flex items-center justify-center bg-[#EEEFF3]">
         <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-green-600 mb-4"></div>
+          <Loader2 className="w-12 h-12 animate-spin text-emerald-600 mx-auto mb-4" />
           <h1 className="text-2xl font-bold text-gray-800 mb-2">Validating your link...</h1>
           <p className="text-gray-600">Please wait a moment</p>
         </div>
@@ -147,7 +113,7 @@ export default function MagicLinkPage({ params }: { params: Promise<{ token: str
   // Error state
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-red-50 to-white px-4">
+      <div className="min-h-screen flex items-center justify-center bg-[#EEEFF3] px-4">
         <div className="max-w-md w-full bg-white rounded-2xl shadow-xl p-8 text-center">
           <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
             <svg
@@ -169,10 +135,10 @@ export default function MagicLinkPage({ params }: { params: Promise<{ token: str
 
           <div className="space-y-3">
             <button
-              onClick={handleRetry}
-              className="w-full bg-green-600 hover:bg-green-700 text-white font-medium py-3 px-6 rounded-xl transition-colors"
+              onClick={() => router.push('/manage')}
+              className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-medium py-3 px-6 rounded-xl transition-colors"
             >
-              Try Again
+              Request New Link
             </button>
             <button
               onClick={() => router.push('/campaigns')}
@@ -181,10 +147,6 @@ export default function MagicLinkPage({ params }: { params: Promise<{ token: str
               Browse Campaigns
             </button>
           </div>
-
-          {retryCount > 0 && (
-            <p className="text-sm text-gray-500 mt-4">Retry attempt: {retryCount}</p>
-          )}
         </div>
       </div>
     );

--- a/app/link/[token]/page.tsx
+++ b/app/link/[token]/page.tsx
@@ -35,17 +35,13 @@ export default function MagicLinkPage({ params }: { params: Promise<{ token: str
         const data = await response.json();
 
         if (data.success && data.email && data.token) {
-          // Store email and Firebase auth token in session storage
           sessionStorage.setItem('donor_email', data.email);
-          sessionStorage.setItem('donor_auth_token', data.token);
 
-          // Sign in with custom token
           const { getAuth, signInWithCustomToken } = await import('firebase/auth');
           const auth = getAuth();
 
           try {
             await signInWithCustomToken(auth, data.token);
-            // Authenticated successfully
           } catch (authError) {
             console.error('Firebase auth error:', authError);
             setError('Unable to start your secure session. Please request a new link.');
@@ -53,13 +49,21 @@ export default function MagicLinkPage({ params }: { params: Promise<{ token: str
             return;
           }
 
-          // Redirect to dashboard
-          router.push(`/manage/dashboard?email=${encodeURIComponent(data.email)}`);
+          router.push('/manage/dashboard');
           return;
         }
       }
 
-      // If subscription link fails, try gift aid link (existing functionality)
+      // Only fall through to the gift-aid handler when the token is definitively
+      // not a subscription token (404). Any other non-2xx (transient 500, 401,
+      // 410 consumed/expired) means we should not attempt a second endpoint —
+      // the token has already been identified or partially consumed.
+      if (!response.ok && response.status !== 404) {
+        setError('This link is invalid or has expired.');
+        setValidating(false);
+        return;
+      }
+
       const giftAidResponse = await fetch(FUNCTION_URLS.validateMagicLinkToken, {
         method: 'POST',
         headers: {

--- a/app/manage/check-email/page.tsx
+++ b/app/manage/check-email/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { Suspense } from 'react';
+import { ManageCheckEmailScreen } from '@/views/manage/ManageCheckEmailScreen';
+
+export default function ManageCheckEmailPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ManageCheckEmailScreen />
+    </Suspense>
+  );
+}

--- a/app/manage/dashboard/page.tsx
+++ b/app/manage/dashboard/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ManageDashboardScreen } from '@/views/manage/ManageDashboardScreen';
+
+export default function ManageDashboardPage() {
+  return <ManageDashboardScreen />;
+}

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ManageEmailScreen } from '@/views/manage/ManageEmailScreen';
+
+export default function ManagePage() {
+  return <ManageEmailScreen />;
+}

--- a/backend/firestore.indexes.json
+++ b/backend/firestore.indexes.json
@@ -191,6 +191,22 @@
       ]
     },
     {
+      "collectionGroup": "donations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "donorEmailNormalized", "order": "ASCENDING" },
+        { "fieldPath": "campaignId", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "donations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "donorEmail", "order": "ASCENDING" },
+        { "fieldPath": "campaignId", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "subscriptionMagicLinkTokens",
       "queryScope": "COLLECTION",
       "fields": [

--- a/backend/firestore.indexes.json
+++ b/backend/firestore.indexes.json
@@ -189,6 +189,30 @@
         { "fieldPath": "purpose", "order": "ASCENDING" },
         { "fieldPath": "status", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "subscriptionMagicLinkTokens",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "email", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "subscriptionMagicLinkTokens",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "expiresAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "subscriptionMagicLinkTokens",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "consumedAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/backend/firestore.rules
+++ b/backend/firestore.rules
@@ -17,6 +17,12 @@ service cloud.firestore {
       allow read, write: if false;
     }
     
+    // Subscription Magic Link Tokens - SECURE (backend only)
+    match /subscriptionMagicLinkTokens/{tokenId} {
+      // No public access - only backend functions can read/write
+      allow read, write: if false;
+    }
+    
     // Magic Link Ephemeral - PUBLIC (time-restricted, only contains plain token)
     match /magicLinkEphemeral/{tokenId} {
       // Allow reading only within 2 minutes of creation

--- a/backend/functions/.eslintrc.js
+++ b/backend/functions/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
   rules: {
     'no-restricted-globals': ['error', 'name', 'length'],
     'prefer-arrow-callback': 'error',
-    quotes: ['error', 'double', { allowTemplateLiterals: true }],
+    quotes: ['error', 'single', { allowTemplateLiterals: true }],
   },
   overrides: [
     {

--- a/backend/functions/.eslintrc.js
+++ b/backend/functions/.eslintrc.js
@@ -4,22 +4,20 @@ module.exports = {
     node: true,
   },
   parserOptions: {
-    "ecmaVersion": 2023,
+    ecmaVersion: 2023,
   },
-  extends: [
-    "eslint:recommended",
-    "google",
-  ],
+  extends: ['eslint:recommended', 'google'],
   rules: {
-    "no-restricted-globals": ["error", "name", "length"],
-    "prefer-arrow-callback": "error",
-    "quotes": ["error", "double", {"allowTemplateLiterals": true}],
+    'no-restricted-globals': ['error', 'name', 'length'],
+    'prefer-arrow-callback': 'error',
+    quotes: ['error', 'double', { allowTemplateLiterals: true }],
   },
   overrides: [
     {
-      files: ["**/*.spec.*"],
+      files: ['**/*.spec.*', '**/*.test.*'],
       env: {
         mocha: true,
+        jest: true,
       },
       rules: {},
     },

--- a/backend/functions/entities/subscription.js
+++ b/backend/functions/entities/subscription.js
@@ -88,6 +88,9 @@ const createSubscriptionDoc = async (subscriptionData) => {
   const nextPaymentAtTimestamp =
     toTimestampOrNull(nextPaymentAt) ||
     calculateNextPaymentAt(currentPeriodEnd, interval, intervalCount);
+  const donorEmail =
+    typeof metadata.donorEmail === 'string' ? metadata.donorEmail.trim() || null : null;
+  const donorEmailNormalized = donorEmail ? donorEmail.toLowerCase() : null;
 
   await subscriptionRef.set({
     stripeSubscriptionId,
@@ -99,7 +102,8 @@ const createSubscriptionDoc = async (subscriptionData) => {
     amount,
     currency,
     status,
-    donorEmail: metadata.donorEmail || null,
+    donorEmail,
+    donorEmailNormalized,
     donorName: metadata.donorName || null,
     donorPhone: metadata.donorPhone || null,
     startedAt: startedAtTimestamp,
@@ -118,7 +122,10 @@ const createSubscriptionDoc = async (subscriptionData) => {
     canceledAt: null,
     createdAt: now,
     updatedAt: now,
-    metadata: metadata,
+    metadata: {
+      ...metadata,
+      donorEmailNormalized,
+    },
   });
 
   console.log('Subscription document created:', stripeSubscriptionId);

--- a/backend/functions/handlers/subscriptionManagement.js
+++ b/backend/functions/handlers/subscriptionManagement.js
@@ -398,8 +398,12 @@ const sendSubscriptionMagicLink = (req, res) => {
         purpose: 'subscription_management',
       });
 
-      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      const magicLink = `${appUrl}/link/${token}`;
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+      if (!appUrl && process.env.NODE_ENV === 'production') {
+        console.error('NEXT_PUBLIC_APP_URL is not configured — cannot generate magic link');
+        return res.status(500).json({ error: 'Service misconfiguration. Please try again later.' });
+      }
+      const magicLink = `${appUrl || 'http://localhost:3000'}/link/${token}`;
 
       try {
         await sendSubscriptionMagicLinkEmail({

--- a/backend/functions/handlers/subscriptionManagement.js
+++ b/backend/functions/handlers/subscriptionManagement.js
@@ -1,0 +1,1042 @@
+const admin = require('firebase-admin');
+const cors = require('../middleware/cors');
+const { ensureStripeInitialized } = require('../services/stripe');
+const { sendSubscriptionMagicLinkEmail } = require('../services/email');
+const { generateToken, storeToken, verifyToken } = require('../utils/tokenManager');
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+// Firestore-backed sliding-window rate limiter.
+// Works correctly across multiple Cloud Function instances and survives
+// cold starts. Each user has a single document in `rate_limits` that stores
+// only the timestamps that fall within the current window.
+//
+// Future upgrade: swap for Redis/Upstash if sub-millisecond latency or
+// very high throughput is required.
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+const RATE_LIMIT_MAX_REQUESTS = 10; // requests per window per user
+const RATE_LIMIT_COLLECTION = 'rate_limits';
+
+// ---------------------------------------------------------------------------
+// Trusted domains for return URL validation
+// ---------------------------------------------------------------------------
+const TRUSTED_DOMAINS = [
+  'localhost:3000',
+  'swiftcause.com',
+  'swiftcause-app.web.app',
+  'swiftcause-app.firebaseapp.com',
+  'swiftcause--swiftcause-app.us-east4.hosted.app',
+  'swift-cause-web.vercel.app',
+];
+
+// ---------------------------------------------------------------------------
+// User-facing error message constants
+// (Kept as named constants to satisfy the 80-char line limit and to make
+// messages easy to update in one place.)
+// ---------------------------------------------------------------------------
+const MSG_MISSING_AUTH = 'Unauthorized: Missing authentication token';
+const MSG_INVALID_AUTH = 'Unauthorized: Invalid authentication token';
+const MSG_EMAIL_NOT_IN_TOKEN = 'Unauthorized: Email not found in token';
+const MSG_WRONG_TOKEN_PURPOSE = 'Unauthorized: Token was not issued for subscription management';
+const MSG_ACTIVE_DONATIONS =
+  'If this email has active donations, ' + 'you will receive a link shortly.';
+const MSG_SUB_CONFIG_ERROR = 'Subscription configuration error. Please contact support.';
+const MSG_ORG_NOT_FOUND = 'Organization not found. Please contact support.';
+const MSG_ORG_PAYMENT_NOT_CONFIGURED =
+  'Organization payment system not configured. Please contact support.';
+const MSG_ORG_PAYMENT_CONFIG_ERROR =
+  'Organization payment configuration error. Please contact support.';
+const MSG_FORBIDDEN = 'Forbidden: You do not have permission to access this subscription';
+const MSG_PORTAL_ERROR = 'Unable to open subscription management. Please try again later.';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured audit logger - emits JSON to Cloud Logging.
+ * @param {string} action - The action being logged
+ * @param {object} data - Additional data to include in the log entry
+ */
+const auditLog = (action, data) => {
+  console.log(
+    JSON.stringify({
+      action,
+      timestamp: new Date().toISOString(),
+      ...data,
+    }),
+  );
+};
+
+/**
+ * Runs an async handler after CORS middleware has accepted the request.
+ * @param {object} req - Express request object
+ * @param {object} res - Express response object
+ * @param {Function} handler - Async request handler
+ * @return {Promise<*>}
+ */
+const runWithCors = (req, res, handler) => {
+  return new Promise((resolve, reject) => {
+    cors(req, res, () => {
+      Promise.resolve(handler()).then(resolve, reject);
+    });
+  });
+};
+
+/**
+ * Firestore-backed sliding-window rate limiter using a transaction.
+ *
+ * The read-check-write is wrapped in a Firestore transaction so that
+ * concurrent requests for the same user are serialised at the database
+ * level. Without the transaction, two simultaneous requests could both
+ * read the same timestamp array, both pass the limit check, and both
+ * write back - effectively bypassing the limit.
+ *
+ * Failure modes:
+ * - Transaction conflict (Firestore retries automatically, up to 5 times).
+ * - Firestore unavailable: fails open so legitimate users are not blocked.
+ *   The error is logged so the issue is visible in Cloud Logging.
+ *
+ * @param {string} userId - Normalised user identifier (email or UID)
+ * @return {Promise<boolean>} True if the request is within the allowed rate
+ */
+const checkRateLimit = async (userId) => {
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const db = admin.firestore();
+  const docRef = db.collection(RATE_LIMIT_COLLECTION).doc(userId);
+
+  try {
+    const allowed = await db.runTransaction(async (tx) => {
+      const doc = await tx.get(docRef);
+      const data = doc.exists ? doc.data() : { timestamps: [] };
+
+      // Prune timestamps outside the current window
+      const recent = (data.timestamps || []).filter((ts) => ts > windowStart);
+
+      if (recent.length >= RATE_LIMIT_MAX_REQUESTS) {
+        // Do not write - just signal rejection
+        return false;
+      }
+
+      // Atomically append and persist within the same transaction.
+      // merge: true preserves any fields added by future schema changes.
+      recent.push(now);
+      tx.set(docRef, { userId, timestamps: recent, updatedAt: now }, { merge: true });
+      return true;
+    });
+
+    return allowed;
+  } catch (err) {
+    // Fail open: a rate-limit check failure should not block legitimate users.
+    // The error is logged for observability.
+    console.error('Rate limit check failed (failing open):', err.message);
+    return true;
+  }
+};
+
+/**
+ * Validates that a return URL belongs to a trusted domain.
+ * Only called when NEXT_PUBLIC_APP_URL is externally configured - the
+ * check guards against misconfiguration, not user-supplied input.
+ * @param {string} url - URL to validate
+ * @return {boolean} True if the host is in TRUSTED_DOMAINS
+ */
+const isValidReturnUrl = (url) => {
+  try {
+    const { host } = new URL(url);
+    return TRUSTED_DOMAINS.some((domain) => host === domain || host.endsWith(`.${domain}`));
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Extracts the donor email from a subscription document, checking both the
+ * root field and the nested metadata field for backwards compatibility.
+ * Centralised here so callers never repeat the fallback logic.
+ * @param {object} data - Firestore subscription document data
+ * @return {string} Lowercase email, or empty string if absent
+ */
+const getSubscriptionEmail = (data) => {
+  return (
+    data.donorEmailNormalized ||
+    data.metadata?.donorEmailNormalized ||
+    data.donorEmail ||
+    data.metadata?.donorEmail ||
+    ''
+  ).toLowerCase();
+};
+
+/**
+ * Returns true when a subscription belongs to the normalized email.
+ * @param {object} data - Firestore subscription document data
+ * @param {string} emailNormalized - Lowercase email
+ * @return {boolean}
+ */
+const subscriptionMatchesEmail = (data, emailNormalized) => {
+  const candidates = [
+    data.donorEmail,
+    data.donorEmailNormalized,
+    data.metadata?.donorEmail,
+    data.metadata?.donorEmailNormalized,
+  ];
+
+  return candidates.some((value) => {
+    return typeof value === 'string' && value.trim().toLowerCase() === emailNormalized;
+  });
+};
+
+/**
+ * Fetches subscriptions by normalized email.
+ * Runs four indexed queries in parallel to cover all storage patterns:
+ * - donorEmailNormalized (new normalized field)
+ * - metadata.donorEmailNormalized (new normalized field in metadata)
+ * - donorEmail (legacy exact-match, works when stored lowercase)
+ * - metadata.donorEmail (legacy exact-match in metadata)
+ *
+ * Mixed-case legacy docs (e.g. "Donor@Example.com") will be found once
+ * donorEmailNormalized is backfilled. Until then they are missed by these
+ * queries, which is the correct trade-off: a full collection scan is not
+ * an acceptable permanent solution at scale.
+ * @param {object} ref - Firestore subscriptions collection reference
+ * @param {string} emailNormalized - Lowercase email
+ * @return {Promise<object[]>} Deduplicated subscription documents
+ */
+const fetchSubscriptionsForEmail = async (ref, emailNormalized) => {
+  const querySnaps = await Promise.all([
+    ref.where('donorEmailNormalized', '==', emailNormalized).get(),
+    ref.where('metadata.donorEmailNormalized', '==', emailNormalized).get(),
+    ref.where('donorEmail', '==', emailNormalized).get(),
+    ref.where('metadata.donorEmail', '==', emailNormalized).get(),
+  ]);
+
+  const subMap = new Map();
+  querySnaps.forEach((snap) => {
+    snap.forEach((doc) => {
+      subMap.set(doc.id, { id: doc.id, ...doc.data() });
+    });
+  });
+
+  return Array.from(subMap.values());
+};
+
+/**
+ * Validates that a subscription document contains all required fields.
+ * @param {object} data - Firestore subscription document data
+ * @return {{valid: boolean, missingFields: string[]}}
+ */
+const validateSubscriptionData = (data) => {
+  const required = ['customerId', 'organizationId'];
+  const missingFields = required.filter((f) => !data[f]);
+
+  if (!getSubscriptionEmail(data)) {
+    missingFields.push('donorEmail');
+  }
+
+  return { valid: missingFields.length === 0, missingFields };
+};
+
+/**
+ * Maps a Stripe API error to a safe HTTP status + user-facing message.
+ * Full error details are written to audit logs; nothing internal is
+ * forwarded to the client.
+ * @param {Error} error - Stripe error object
+ * @param {object} context - Additional context for the audit log
+ * @return {{status: number, message: string}}
+ */
+const handleStripeError = (error, context) => {
+  auditLog('stripe_error', {
+    errorType: error.type,
+    errorCode: error.code,
+    errorMessage: error.message,
+    ...context,
+  });
+
+  if (error.code === 'resource_missing') {
+    return {
+      status: 404,
+      message: 'Subscription not found in payment system.' + ' Please contact support.',
+    };
+  }
+
+  if (error.code === 'account_invalid') {
+    return { status: 500, message: MSG_ORG_PAYMENT_CONFIG_ERROR };
+  }
+
+  const errorMap = {
+    StripeInvalidRequestError: {
+      status: 400,
+      message: 'Unable to open subscription management.' + ' Please contact support.',
+    },
+    StripeAuthenticationError: {
+      status: 500,
+      message: 'Service configuration error. Please contact support.',
+    },
+    StripePermissionError: {
+      status: 403,
+      message: 'Unable to access subscription. Please contact support.',
+    },
+    StripeRateLimitError: {
+      status: 429,
+      message: 'Service temporarily unavailable. Please try again shortly.',
+    },
+    StripeConnectionError: {
+      status: 503,
+      message: 'Service temporarily unavailable. Please try again.',
+    },
+  };
+
+  return errorMap[error.type] || { status: 500, message: MSG_PORTAL_ERROR };
+};
+
+/**
+ * Trims a string and returns null if the result is empty.
+ * @param {*} value - Value to normalize
+ * @return {string|null}
+ */
+const normalizeString = (value) => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+/**
+ * Verifies the Bearer token in the Authorization header using Firebase Auth.
+ * Throws a typed error (with .status) on failure so callers can respond
+ * consistently without duplicating auth logic.
+ * @param {object} req - Express request object
+ * @return {Promise<object>} Decoded Firebase ID token claims
+ */
+const verifyBearerToken = async (req) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    const err = new Error(MSG_MISSING_AUTH);
+    err.status = 401;
+    throw err;
+  }
+  let decodedToken;
+  try {
+    decodedToken = await admin.auth().verifyIdToken(authHeader.split('Bearer ')[1]);
+  } catch {
+    const err = new Error(MSG_INVALID_AUTH);
+    err.status = 401;
+    throw err;
+  }
+
+  if (decodedToken.purpose !== 'subscription_management' || decodedToken.type !== 'donor') {
+    const err = new Error(MSG_WRONG_TOKEN_PURPOSE);
+    err.status = 401;
+    throw err;
+  }
+
+  return decodedToken;
+};
+
+// ---------------------------------------------------------------------------
+// Endpoint: sendSubscriptionMagicLink
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends a one-time magic link to the donor's email address.
+ * Checks both root and metadata.donorEmail fields for backwards compat.
+ * Always returns a generic success message to avoid email enumeration.
+ * @param {object} req - Express request object
+ * @param {object} res - Express response object
+ */
+const sendSubscriptionMagicLink = (req, res) => {
+  return runWithCors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return res.status(405).json({ error: 'Method not allowed' });
+      }
+
+      const email = normalizeString(req.body?.email);
+
+      if (!email || !EMAIL_REGEX.test(email)) {
+        return res.status(400).json({ error: 'Valid email is required' });
+      }
+
+      const emailNormalized = email.toLowerCase();
+      const db = admin.firestore();
+      const ref = db.collection('subscriptions');
+      const subscriptions = await fetchSubscriptionsForEmail(ref, emailNormalized);
+      const hasSubscriptions = subscriptions.length > 0;
+
+      // Return the same response regardless - prevents email enumeration
+      if (!hasSubscriptions) {
+        return res.status(200).json({
+          success: true,
+          message: MSG_ACTIVE_DONATIONS,
+        });
+      }
+
+      const token = generateToken();
+      await storeToken(token, {
+        email: emailNormalized,
+        purpose: 'subscription_management',
+      });
+
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+      const magicLink = `${appUrl}/link/${token}`;
+
+      try {
+        await sendSubscriptionMagicLinkEmail({
+          to: email,
+          magicLink,
+          expiresInMinutes: 15,
+        });
+      } catch (emailError) {
+        console.error('Failed to send magic link email:', emailError);
+
+        // Always return the link in the response when email fails so the
+        // flow can be tested without a working email provider.
+        // TODO: remove devLink from production response once SendGrid is fixed.
+        console.log('MAGIC_LINK_FOR_TESTING:', magicLink);
+        return res.status(200).json({
+          success: true,
+          message: 'Email service unavailable. Check logs for magic link.',
+          devLink: magicLink,
+        });
+      }
+
+      const response = { success: true, message: MSG_ACTIVE_DONATIONS };
+
+      if (process.env.NODE_ENV === 'development') {
+        response.devLink = magicLink;
+      }
+
+      return res.status(200).json(response);
+    } catch (error) {
+      console.error('Error sending magic link:', error);
+      return res.status(500).json({ error: 'Failed to send magic link' });
+    }
+  });
+};
+
+// Endpoint: verifySubscriptionMagicLink
+
+/**
+ * Verifies a magic link token and returns a Firebase custom token.
+ * The custom token is used by the frontend to sign in via
+ * signInWithCustomToken, after which the client obtains a real ID token
+ * for subsequent API calls.
+ * @param {object} req - Express request object
+ * @param {object} res - Express response object
+ */
+const verifySubscriptionMagicLink = (req, res) => {
+  return runWithCors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return res.status(405).json({ error: 'Method not allowed' });
+      }
+
+      const token = normalizeString(req.body?.token);
+
+      if (!token) {
+        return res.status(400).json({ error: 'Token is required' });
+      }
+
+      try {
+        const tokenData = await verifyToken(token);
+        const { email } = tokenData;
+
+        const crypto = require('crypto');
+        const uid = `donor_${crypto.createHash('sha256').update(email).digest('hex')}`;
+
+        const customToken = await admin.auth().createCustomToken(uid, {
+          email,
+          purpose: 'subscription_management',
+          type: 'donor',
+        });
+
+        return res.status(200).json({
+          success: true,
+          email,
+          token: customToken,
+        });
+      } catch (error) {
+        const errorMessage = error.message || 'UNKNOWN_ERROR';
+        const statusMap = {
+          TOKEN_NOT_FOUND: 401,
+          TOKEN_CONSUMED: 401,
+          TOKEN_EXPIRED: 401,
+          TOKEN_INVALID: 401,
+        };
+
+        return res.status(statusMap[errorMessage] || 500).json({
+          error: errorMessage,
+          message: getErrorMessage(errorMessage),
+        });
+      }
+    } catch (error) {
+      console.error('Error verifying magic link:', error);
+      return res.status(500).json({ error: 'Failed to verify token' });
+    }
+  });
+};
+
+// Endpoint: getSubscriptionsByEmail
+
+/**
+ * Returns all subscriptions for the authenticated donor.
+ * Requires a valid Firebase ID token (obtained after signInWithCustomToken).
+ * Queries both root and metadata.donorEmail for backwards compatibility.
+ * @param {object} req - Express request object
+ * @param {object} res - Express response object
+ */
+const getSubscriptionsByEmail = (req, res) => {
+  return runWithCors(req, res, async () => {
+    try {
+      if (req.method !== 'GET' && req.method !== 'POST') {
+        return res.status(405).json({ error: 'Method not allowed' });
+      }
+
+      let decodedToken;
+      try {
+        decodedToken = await verifyBearerToken(req);
+      } catch (err) {
+        return res.status(err.status || 401).json({ error: err.message });
+      }
+
+      if (!decodedToken.email) {
+        return res.status(401).json({ error: MSG_EMAIL_NOT_IN_TOKEN });
+      }
+
+      const emailNormalized = decodedToken.email.toLowerCase();
+      const db = admin.firestore();
+      const ref = db.collection('subscriptions');
+      const subscriptions = await fetchSubscriptionsForEmail(ref, emailNormalized);
+
+      if (subscriptions.length === 0) {
+        return res.status(200).json({ subscriptions: [], count: 0 });
+      }
+
+      // Enrich each subscription with live campaign title / org name
+      const enriched = await Promise.all(
+        subscriptions.map(async (sub) => {
+          try {
+            const campaignDoc = await db.collection('campaigns').doc(sub.campaignId).get();
+
+            if (campaignDoc.exists) {
+              const cd = campaignDoc.data();
+              const meta = sub.metadata || {};
+              return {
+                ...sub,
+                metadata: {
+                  ...meta,
+                  campaignTitle: cd.title || meta.campaignTitle,
+                  organizationName: cd.organizationName || meta.organizationName,
+                },
+              };
+            }
+          } catch (err) {
+            console.error('Error fetching campaign details:', err);
+          }
+          return sub;
+        }),
+      );
+
+      // Sort: active first, then newest first within each status group
+      enriched.sort((a, b) => {
+        const aActive = a.status === 'active' ? 0 : 1;
+        const bActive = b.status === 'active' ? 0 : 1;
+        if (aActive !== bActive) return aActive - bActive;
+        return (b.createdAt?.toMillis?.() || 0) - (a.createdAt?.toMillis?.() || 0);
+      });
+
+      // Serialise Firestore Timestamps to ISO strings so the frontend
+      // receives a consistent format regardless of SDK version.
+      const TIMESTAMP_FIELDS = [
+        'currentPeriodEnd',
+        'createdAt',
+        'updatedAt',
+        'startedAt',
+        'lastPaymentAt',
+        'nextPaymentAt',
+        'canceledAt',
+      ];
+
+      const serialise = (sub) => {
+        const out = { ...sub };
+        TIMESTAMP_FIELDS.forEach((field) => {
+          const val = out[field];
+          if (val && typeof val.toMillis === 'function') {
+            out[field] = new Date(val.toMillis()).toISOString();
+          } else if (val && typeof val._seconds === 'number') {
+            // Fallback for plain-object Timestamps (_seconds/_nanoseconds)
+            out[field] = new Date(val._seconds * 1000).toISOString();
+          }
+        });
+        return out;
+      };
+
+      return res.status(200).json({
+        subscriptions: enriched.map(serialise),
+        count: enriched.length,
+      });
+    } catch (error) {
+      console.error('Error fetching subscriptions:', error);
+      return res.status(500).json({
+        error: 'Failed to fetch subscriptions',
+        details: error.message,
+      });
+    }
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Endpoint: createCustomerPortalSession
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a Stripe Billing Portal session for the authenticated donor.
+ *
+ * Architecture note - platform vs connected accounts:
+ * Subscriptions are created on the PLATFORM Stripe account using
+ * transfer_data.destination to route funds to the connected org account.
+ * Therefore the Stripe Customer object lives on the platform account and
+ * the portal session must be created WITHOUT a stripeAccount parameter.
+ * stripeAccountId is fetched and validated here only to confirm the
+ * organisation's Stripe integration is correctly configured; it is not
+ * passed to the Stripe API call.
+ *
+ * Security features:
+ * - Firebase ID token authentication
+ * - In-memory rate limiting (10 req/min per user)
+ * - Email-based ownership validation
+ * - Secondary customerId presence check (future: validate against allowlist)
+ * - Subscription data integrity validation
+ * - Stripe account format validation (org integrity check)
+ * - Return URL domain allowlist
+ * - Structured audit logging (stack traces redacted in production)
+ * - Safe Stripe error mapping
+ * @param {object} req - Express request object
+ * @param {object} res - Express response object
+ */
+const createCustomerPortalSession = (req, res) => {
+  return runWithCors(req, res, async () => {
+    const startTime = Date.now();
+    let authenticatedEmail = null;
+    let subscriptionId = null;
+
+    try {
+      // 1. METHOD VALIDATION
+      if (req.method !== 'POST') {
+        return res.status(405).json({ error: 'Method not allowed' });
+      }
+
+      // 2. AUTHENTICATION
+      let decodedToken;
+      try {
+        decodedToken = await verifyBearerToken(req);
+      } catch (err) {
+        auditLog('portal_session_failed', {
+          reason: err.message,
+          ip: req.ip,
+        });
+        return res.status(err.status || 401).json({ error: err.message });
+      }
+
+      authenticatedEmail = decodedToken.email;
+
+      if (!authenticatedEmail) {
+        auditLog('portal_session_failed', {
+          reason: 'email_not_in_token',
+          uid: decodedToken.uid,
+        });
+        return res.status(401).json({ error: MSG_EMAIL_NOT_IN_TOKEN });
+      }
+
+      const emailNormalized = authenticatedEmail.toLowerCase();
+
+      // 3. RATE LIMITING
+      // NOTE: Firestore-backed - works across all instances.
+      const withinLimit = await checkRateLimit(emailNormalized);
+      if (!withinLimit) {
+        auditLog('portal_session_rate_limited', {
+          email: emailNormalized,
+          ip: req.ip,
+        });
+        return res.status(429).json({
+          error: 'Too many requests. Please try again shortly.',
+        });
+      }
+
+      // 4. INPUT VALIDATION
+      subscriptionId = normalizeString(req.body?.subscriptionId);
+
+      if (!subscriptionId) {
+        auditLog('portal_session_failed', {
+          reason: 'missing_subscription_id',
+          email: emailNormalized,
+        });
+        return res.status(400).json({ error: 'Subscription ID is required' });
+      }
+
+      if (subscriptionId.length < 10 || subscriptionId.length > 100) {
+        auditLog('portal_session_failed', {
+          reason: 'invalid_subscription_id_format',
+          email: emailNormalized,
+          subscriptionId,
+        });
+        return res.status(400).json({ error: 'Invalid subscription ID format' });
+      }
+
+      // 5. FETCH SUBSCRIPTION
+      const db = admin.firestore();
+      const subscriptionDoc = await db.collection('subscriptions').doc(subscriptionId).get();
+
+      if (!subscriptionDoc.exists) {
+        auditLog('portal_session_failed', {
+          reason: 'subscription_not_found',
+          email: emailNormalized,
+          subscriptionId,
+        });
+        return res.status(404).json({ error: 'Subscription not found' });
+      }
+
+      const subscriptionData = subscriptionDoc.data();
+
+      // 6. DATA INTEGRITY CHECK
+      const validation = validateSubscriptionData(subscriptionData);
+      if (!validation.valid) {
+        auditLog('portal_session_failed', {
+          reason: 'subscription_data_invalid',
+          email: emailNormalized,
+          subscriptionId,
+          missingFields: validation.missingFields,
+        });
+        return res.status(500).json({ error: MSG_SUB_CONFIG_ERROR });
+      }
+
+      // 7. OWNERSHIP VALIDATION
+      // Primary: email match. Email is not a globally unique identity but is
+      // sufficient here because the token was issued to this email address.
+      // Secondary: customerId presence is verified below (step 8).
+      // Future: validate customerId against an email->customerIds allowlist.
+      const subscriptionEmail = getSubscriptionEmail(subscriptionData);
+
+      if (!subscriptionMatchesEmail(subscriptionData, emailNormalized)) {
+        auditLog('portal_session_unauthorized', {
+          reason: 'email_mismatch',
+          authenticatedEmail: emailNormalized,
+          subscriptionEmail: subscriptionEmail || 'none',
+          subscriptionId,
+          ip: req.ip,
+        });
+        return res.status(403).json({ error: MSG_FORBIDDEN });
+      }
+
+      // 8. EXTRACT AND VALIDATE REQUIRED FIELDS
+      const { customerId, organizationId } = subscriptionData;
+
+      if (!customerId) {
+        auditLog('portal_session_failed', {
+          reason: 'missing_customer_id',
+          email: emailNormalized,
+          subscriptionId,
+        });
+        return res.status(500).json({ error: MSG_SUB_CONFIG_ERROR });
+      }
+
+      if (!organizationId) {
+        auditLog('portal_session_failed', {
+          reason: 'missing_organization_id',
+          email: emailNormalized,
+          subscriptionId,
+        });
+        return res.status(500).json({ error: MSG_SUB_CONFIG_ERROR });
+      }
+
+      // 9. FETCH ORGANISATION - validate Stripe account integrity
+      // stripeAccountId is NOT passed to the portal session (platform model),
+      // but we verify it exists and is well-formed as an org health check.
+      const orgDoc = await db.collection('organizations').doc(organizationId).get();
+
+      if (!orgDoc.exists) {
+        auditLog('portal_session_failed', {
+          reason: 'organization_not_found',
+          email: emailNormalized,
+          subscriptionId,
+          organizationId,
+        });
+        return res.status(500).json({ error: MSG_ORG_NOT_FOUND });
+      }
+
+      const stripeAccountId = orgDoc.data().stripe?.accountId;
+
+      if (!stripeAccountId) {
+        auditLog('portal_session_failed', {
+          reason: 'missing_stripe_account_id',
+          email: emailNormalized,
+          subscriptionId,
+          organizationId,
+        });
+        return res.status(500).json({ error: MSG_ORG_PAYMENT_NOT_CONFIGURED });
+      }
+
+      // Validate format as an org integrity check only - not used in API call
+      if (!stripeAccountId.startsWith('acct_')) {
+        auditLog('portal_session_failed', {
+          reason: 'invalid_stripe_account_id_format',
+          email: emailNormalized,
+          subscriptionId,
+          organizationId,
+          stripeAccountId: stripeAccountId.substring(0, 10) + '...',
+        });
+        return res.status(500).json({ error: MSG_ORG_PAYMENT_CONFIG_ERROR });
+      }
+
+      // Log a warning if customerId prefix doesn't match expected Stripe format
+      // (non-blocking - future hook point for deeper customer ownership checks)
+      if (!customerId.startsWith('cus_')) {
+        auditLog('potential_data_inconsistency', {
+          reason: 'unexpected_customer_id_format',
+          customerId: customerId.substring(0, 10) + '...',
+          organizationId,
+          subscriptionId,
+        });
+      }
+
+      // 10. VALIDATE RETURN URL
+      // The URL is constructed from an env var, not user input. The check
+      // guards against misconfiguration (e.g. a typo in NEXT_PUBLIC_APP_URL).
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+      const returnUrl = `${appUrl}/manage/dashboard`;
+
+      if (!isValidReturnUrl(returnUrl)) {
+        auditLog('portal_session_failed', {
+          reason: 'invalid_return_url',
+          email: emailNormalized,
+          subscriptionId,
+          returnUrl,
+        });
+        return res.status(500).json({
+          error: 'Configuration error. Please contact support.',
+        });
+      }
+
+      // 11. CREATE STRIPE PORTAL SESSION
+      // Customer lives on the PLATFORM account - no stripeAccount param.
+      const stripe = ensureStripeInitialized();
+
+      let session;
+      try {
+        session = await stripe.billingPortal.sessions.create({
+          customer: customerId,
+          return_url: returnUrl,
+        });
+      } catch (stripeError) {
+        const errorInfo = handleStripeError(stripeError, {
+          email: emailNormalized,
+          subscriptionId,
+          organizationId,
+          stripeAccountId: stripeAccountId.substring(0, 10) + '...',
+          customerId: customerId.substring(0, 10) + '...',
+        });
+        return res.status(errorInfo.status).json({ error: errorInfo.message });
+      }
+
+      // 12. SUCCESS
+      const duration = Date.now() - startTime;
+      auditLog('portal_session_created', {
+        email: emailNormalized,
+        subscriptionId,
+        organizationId,
+        stripeAccountId: stripeAccountId.substring(0, 10) + '...',
+        customerId: customerId.substring(0, 10) + '...',
+        sessionId: session.id,
+        duration_ms: duration,
+      });
+
+      return res.status(200).json({ success: true, url: session.url });
+    } catch (error) {
+      // 13. CATCH-ALL - never expose internals to the client
+      const duration = Date.now() - startTime;
+      auditLog('portal_session_error', {
+        reason: 'unexpected_error',
+        error: error.message,
+        // Redact stack traces in production to avoid leaking file paths
+        stack: process.env.NODE_ENV === 'development' ? error.stack : undefined,
+        email: authenticatedEmail,
+        subscriptionId,
+        duration_ms: duration,
+      });
+
+      return res.status(500).json({ error: MSG_PORTAL_ERROR });
+    }
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Helper: getErrorMessage
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a token error code to a user-friendly message.
+ * @param {string} errorCode - The error code from verifyToken
+ * @return {string} User-friendly message
+ */
+const getErrorMessage = (errorCode) => {
+  const messages = {
+    TOKEN_NOT_FOUND: 'This link is invalid or has been removed.',
+    TOKEN_EXPIRED: 'This link has expired. Please request a new one.',
+    TOKEN_CONSUMED: 'This link has already been used.',
+    TOKEN_INVALID: 'This link is no longer valid.',
+  };
+
+  return messages[errorCode] || 'This link is no longer valid.';
+};
+
+// ---------------------------------------------------------------------------
+// Endpoint: getPaymentHistory
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the payment history (donations) for a specific subscription.
+ * Requires a valid donor magic-link token. Validates that the subscription
+ * belongs to the authenticated donor before returning any data.
+ * @param {object} req - Express request object
+ * @param {object} res - Express response object
+ */
+const getPaymentHistory = (req, res) => {
+  return runWithCors(req, res, async () => {
+    try {
+      if (req.method !== 'GET' && req.method !== 'POST') {
+        return res.status(405).json({ error: 'Method not allowed' });
+      }
+
+      // 1. AUTHENTICATION
+      let decodedToken;
+      try {
+        decodedToken = await verifyBearerToken(req);
+      } catch (err) {
+        return res.status(err.status || 401).json({ error: err.message });
+      }
+
+      if (!decodedToken.email) {
+        return res.status(401).json({ error: MSG_EMAIL_NOT_IN_TOKEN });
+      }
+
+      const emailNormalized = decodedToken.email.toLowerCase();
+
+      // 2. INPUT VALIDATION
+      const subscriptionId = normalizeString(req.body?.subscriptionId || req.query?.subscriptionId);
+
+      if (!subscriptionId) {
+        return res.status(400).json({ error: 'Subscription ID is required' });
+      }
+
+      // 3. FETCH SUBSCRIPTION AND VERIFY OWNERSHIP
+      const db = admin.firestore();
+      const subscriptionDoc = await db.collection('subscriptions').doc(subscriptionId).get();
+
+      if (!subscriptionDoc.exists) {
+        return res.status(404).json({ error: 'Subscription not found' });
+      }
+
+      const subscriptionData = subscriptionDoc.data();
+
+      if (!subscriptionMatchesEmail(subscriptionData, emailNormalized)) {
+        auditLog('payment_history_unauthorized', {
+          reason: 'email_mismatch',
+          authenticatedEmail: emailNormalized,
+          subscriptionId,
+          ip: req.ip,
+        });
+        return res.status(403).json({ error: MSG_FORBIDDEN });
+      }
+
+      // 4. FETCH DONATIONS FOR THIS SUBSCRIPTION
+      // Strategy: try three query patterns and merge results.
+      // (1) subscriptionId field match — for recurring Stripe invoices
+      // (2) metadata.subscriptionId match — legacy storage pattern
+      // (3) donorEmail + campaignId fallback — for kiosk/one-time donations
+      //     that were never linked by subscriptionId
+      const donorEmail = getSubscriptionEmail(subscriptionData);
+
+      const tsToIso = (val) => {
+        if (!val) return null;
+        if (typeof val.toMillis === 'function') {
+          return new Date(val.toMillis()).toISOString();
+        }
+        if (typeof val._seconds === 'number') {
+          return new Date(val._seconds * 1000).toISOString();
+        }
+        if (typeof val.seconds === 'number') {
+          return new Date(val.seconds * 1000).toISOString();
+        }
+        return typeof val === 'string' ? val : null;
+      };
+
+      const donationMap = new Map();
+
+      const addSnap = (snap) => {
+        snap.forEach((doc) => {
+          if (!donationMap.has(doc.id)) {
+            donationMap.set(doc.id, doc.data());
+          }
+        });
+      };
+
+      // Query 1: direct subscriptionId link
+      const q1 = await db
+        .collection('donations')
+        .where('subscriptionId', '==', subscriptionId)
+        .get();
+      addSnap(q1);
+
+      // Query 2: email + campaign fallback (covers kiosk/legacy docs)
+      if (donorEmail && subscriptionData.campaignId) {
+        const q2 = await db
+          .collection('donations')
+          .where('donorEmail', '==', donorEmail)
+          .where('campaignId', '==', subscriptionData.campaignId)
+          .get();
+        addSnap(q2);
+      }
+
+      const payments = [];
+      donationMap.forEach((d, id) => {
+        payments.push({
+          id,
+          amount: d.amount,
+          currency: d.currency,
+          status: d.paymentStatus || 'success',
+          campaignTitle: d.campaignTitleSnapshot || d.metadata?.campaignTitleSnapshot || null,
+          createdAt: tsToIso(d.createdAt) || tsToIso(d.timestamp) || null,
+          isGiftAid: d.isGiftAid || false,
+        });
+      });
+
+      // Sort newest first
+      payments.sort((a, b) => {
+        const toMs = (v) => (v ? new Date(v).getTime() : 0);
+        return toMs(b.createdAt) - toMs(a.createdAt);
+      });
+
+      return res.status(200).json({
+        payments,
+        count: payments.length,
+        subscriptionId,
+      });
+    } catch (error) {
+      console.error('Error fetching payment history:', error);
+      return res.status(500).json({
+        error: 'Failed to fetch payment history',
+      });
+    }
+  });
+};
+
+module.exports = {
+  sendSubscriptionMagicLink,
+  verifySubscriptionMagicLink,
+  getSubscriptionsByEmail,
+  createCustomerPortalSession,
+  getPaymentHistory,
+};

--- a/backend/functions/handlers/subscriptionManagement.js
+++ b/backend/functions/handlers/subscriptionManagement.js
@@ -2,7 +2,13 @@ const admin = require('firebase-admin');
 const cors = require('../middleware/cors');
 const { ensureStripeInitialized } = require('../services/stripe');
 const { sendSubscriptionMagicLinkEmail } = require('../services/email');
-const { generateToken, storeToken, verifyToken, consumeToken } = require('../utils/tokenManager');
+const {
+  generateToken,
+  storeToken,
+  verifyToken,
+  consumeToken,
+  releaseToken,
+} = require('../utils/tokenManager');
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -480,23 +486,26 @@ const verifySubscriptionMagicLink = (req, res) => {
         return res.status(400).json({ error: 'Token is required' });
       }
 
+      let tokenClaimed = false;
       try {
-        // Step 1: Validate without consuming — token stays active if anything
-        // below fails transiently, so the donor can click the link again.
+        // Step 1: Atomically claim the token (active → claiming).
+        // Concurrent requests see 'claiming' and get TOKEN_CONSUMED immediately,
+        // closing the verify/mint/consume race window.
         const tokenData = await verifyToken(token);
+        tokenClaimed = true;
         const { email } = tokenData;
 
         const crypto = require('crypto');
         const uid = `donor_${crypto.createHash('sha256').update(email).digest('hex')}`;
 
-        // Step 2: Issue Firebase custom token BEFORE consuming the magic link.
+        // Step 2: Issue Firebase custom token.
         const customToken = await admin.auth().createCustomToken(uid, {
           email,
           purpose: 'subscription_management',
           type: 'donor',
         });
 
-        // Step 3: Consume only after successful issuance.
+        // Step 3: Commit (claiming → consumed) only after successful issuance.
         await consumeToken(token);
 
         return res.status(200).json({
@@ -505,6 +514,14 @@ const verifySubscriptionMagicLink = (req, res) => {
           token: customToken,
         });
       } catch (error) {
+        // If the token was claimed but a downstream step failed, release it
+        // back to 'active' so the donor can retry via the same link.
+        if (tokenClaimed) {
+          await releaseToken(token).catch((releaseErr) => {
+            console.error('Failed to release token after error:', releaseErr.message);
+          });
+        }
+
         const errorMessage = error.message || 'UNKNOWN_ERROR';
         const statusMap = {
           TOKEN_NOT_FOUND: 401,
@@ -860,8 +877,15 @@ const createCustomerPortalSession = (req, res) => {
       // 10. VALIDATE RETURN URL
       // The URL is constructed from an env var, not user input. The check
       // guards against misconfiguration (e.g. a typo in NEXT_PUBLIC_APP_URL).
-      const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      const returnUrl = `${appUrl}/manage/dashboard`;
+      // Fail explicitly in production rather than silently falling back to
+      // localhost — localhost is in TRUSTED_DOMAINS for dev and would otherwise
+      // pass isValidReturnUrl, creating a real portal session with a useless URL.
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+      if (!appUrl && process.env.NODE_ENV === 'production') {
+        console.error('NEXT_PUBLIC_APP_URL is not configured — cannot build portal return URL');
+        return res.status(500).json({ error: 'Service misconfiguration. Please try again later.' });
+      }
+      const returnUrl = `${appUrl || 'http://localhost:3000'}/manage/dashboard`;
 
       if (!isValidReturnUrl(returnUrl)) {
         auditLog('portal_session_failed', {
@@ -1051,26 +1075,31 @@ const getPaymentHistory = (req, res) => {
       addSnap(q1);
 
       // Query 2: email + campaign fallback (covers kiosk/legacy docs).
-      // Two parallel queries cover both storage patterns:
-      // - donorEmailNormalized (new docs written with a normalised field)
-      // - donorEmail exact match (legacy docs stored in lowercase)
-      // Mixed-case legacy docs (e.g. "Donor@Example.com") are missed until
-      // donorEmailNormalized is backfilled, consistent with the subscription queries.
+      // Treated as best-effort: a failure here (e.g. missing composite index)
+      // must not mask q1 results or surface as an empty-payment response.
+      // Errors are logged and q1 results are returned without the fallback data.
       if (donorEmail && subscriptionData.campaignId) {
-        const [q2a, q2b] = await Promise.all([
-          db
-            .collection('donations')
-            .where('donorEmailNormalized', '==', donorEmail)
-            .where('campaignId', '==', subscriptionData.campaignId)
-            .get(),
-          db
-            .collection('donations')
-            .where('donorEmail', '==', donorEmail)
-            .where('campaignId', '==', subscriptionData.campaignId)
-            .get(),
-        ]);
-        addSnap(q2a);
-        addSnap(q2b);
+        try {
+          const [q2a, q2b] = await Promise.all([
+            db
+              .collection('donations')
+              .where('donorEmailNormalized', '==', donorEmail)
+              .where('campaignId', '==', subscriptionData.campaignId)
+              .get(),
+            db
+              .collection('donations')
+              .where('donorEmail', '==', donorEmail)
+              .where('campaignId', '==', subscriptionData.campaignId)
+              .get(),
+          ]);
+          addSnap(q2a);
+          addSnap(q2b);
+        } catch (q2Error) {
+          console.error(
+            'Payment history fallback queries failed (returning q1 results only):',
+            q2Error.message,
+          );
+        }
       }
 
       const payments = [];

--- a/backend/functions/handlers/subscriptionManagement.js
+++ b/backend/functions/handlers/subscriptionManagement.js
@@ -235,10 +235,10 @@ const fetchSubscriptionsForEmail = async (ref, emailNormalized) => {
  */
 const subscriptionsExistForEmail = async (ref, emailNormalized) => {
   const snaps = await Promise.all([
-    ref.where('donorEmailNormalized', '==', emailNormalized).select().limit(1).get(),
-    ref.where('metadata.donorEmailNormalized', '==', emailNormalized).select().limit(1).get(),
-    ref.where('donorEmail', '==', emailNormalized).select().limit(1).get(),
-    ref.where('metadata.donorEmail', '==', emailNormalized).select().limit(1).get(),
+    ref.where('donorEmailNormalized', '==', emailNormalized).limit(1).get(),
+    ref.where('metadata.donorEmailNormalized', '==', emailNormalized).limit(1).get(),
+    ref.where('donorEmail', '==', emailNormalized).limit(1).get(),
+    ref.where('metadata.donorEmail', '==', emailNormalized).limit(1).get(),
   ]);
   return snaps.some((snap) => !snap.empty);
 };
@@ -410,12 +410,13 @@ const sendSubscriptionMagicLink = (req, res) => {
       } catch (emailError) {
         console.error('Failed to send magic link email:', emailError);
 
-        // In non-production environments log the link so the flow can be
-        // tested without a working email provider. Never expose it in the
-        // response — doing so bypasses email ownership verification and
-        // reintroduces email enumeration.
         if (process.env.NODE_ENV !== 'production') {
           console.log('MAGIC_LINK_FOR_TESTING:', magicLink);
+          return res.status(200).json({
+            success: true,
+            message: MSG_ACTIVE_DONATIONS,
+            devLink: magicLink,
+          });
         }
 
         return res.status(500).json({

--- a/backend/functions/handlers/subscriptionManagement.js
+++ b/backend/functions/handlers/subscriptionManagement.js
@@ -225,6 +225,25 @@ const fetchSubscriptionsForEmail = async (ref, emailNormalized) => {
 };
 
 /**
+ * Checks whether any subscription exists for the given email without
+ * loading document data. Runs 4 existence queries in parallel (one per
+ * storage pattern), each limited to 1 document with no field projections,
+ * and resolves true as soon as any query returns a result.
+ * @param {object} ref - Firestore subscriptions collection reference
+ * @param {string} emailNormalized - Lowercase email
+ * @return {Promise<boolean>}
+ */
+const subscriptionsExistForEmail = async (ref, emailNormalized) => {
+  const snaps = await Promise.all([
+    ref.where('donorEmailNormalized', '==', emailNormalized).select().limit(1).get(),
+    ref.where('metadata.donorEmailNormalized', '==', emailNormalized).select().limit(1).get(),
+    ref.where('donorEmail', '==', emailNormalized).select().limit(1).get(),
+    ref.where('metadata.donorEmail', '==', emailNormalized).select().limit(1).get(),
+  ]);
+  return snaps.some((snap) => !snap.empty);
+};
+
+/**
  * Validates that a subscription document contains all required fields.
  * @param {object} data - Firestore subscription document data
  * @return {{valid: boolean, missingFields: string[]}}
@@ -363,8 +382,7 @@ const sendSubscriptionMagicLink = (req, res) => {
       const emailNormalized = email.toLowerCase();
       const db = admin.firestore();
       const ref = db.collection('subscriptions');
-      const subscriptions = await fetchSubscriptionsForEmail(ref, emailNormalized);
-      const hasSubscriptions = subscriptions.length > 0;
+      const hasSubscriptions = await subscriptionsExistForEmail(ref, emailNormalized);
 
       // Return the same response regardless - prevents email enumeration
       if (!hasSubscriptions) {
@@ -392,20 +410,22 @@ const sendSubscriptionMagicLink = (req, res) => {
       } catch (emailError) {
         console.error('Failed to send magic link email:', emailError);
 
-        // Always return the link in the response when email fails so the
-        // flow can be tested without a working email provider.
-        // TODO: remove devLink from production response once SendGrid is fixed.
-        console.log('MAGIC_LINK_FOR_TESTING:', magicLink);
-        return res.status(200).json({
-          success: true,
-          message: 'Email service unavailable. Check logs for magic link.',
-          devLink: magicLink,
+        // In non-production environments log the link so the flow can be
+        // tested without a working email provider. Never expose it in the
+        // response — doing so bypasses email ownership verification and
+        // reintroduces email enumeration.
+        if (process.env.NODE_ENV !== 'production') {
+          console.log('MAGIC_LINK_FOR_TESTING:', magicLink);
+        }
+
+        return res.status(500).json({
+          error: 'Email service unavailable. Please try again later.',
         });
       }
 
       const response = { success: true, message: MSG_ACTIVE_DONATIONS };
 
-      if (process.env.NODE_ENV === 'development') {
+      if (process.env.NODE_ENV !== 'production') {
         response.devLink = magicLink;
       }
 
@@ -540,11 +560,11 @@ const getSubscriptionsByEmail = (req, res) => {
         }),
       );
 
-      // Sort: active first, then newest first within each status group
+      // Sort: active-like subscriptions first, then newest first within each group
       enriched.sort((a, b) => {
-        const aActive = a.status === 'active' ? 0 : 1;
-        const bActive = b.status === 'active' ? 0 : 1;
-        if (aActive !== bActive) return aActive - bActive;
+        const aActiveLike = a.status === 'active' || a.status === 'trialing' ? 0 : 1;
+        const bActiveLike = b.status === 'active' || b.status === 'trialing' ? 0 : 1;
+        if (aActiveLike !== bActiveLike) return aActiveLike - bActiveLike;
         return (b.createdAt?.toMillis?.() || 0) - (a.createdAt?.toMillis?.() || 0);
       });
 
@@ -579,10 +599,11 @@ const getSubscriptionsByEmail = (req, res) => {
         count: enriched.length,
       });
     } catch (error) {
-      console.error('Error fetching subscriptions:', error);
+      const errorId = `sub_fetch_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+      console.error(`Error fetching subscriptions [${errorId}]:`, error);
       return res.status(500).json({
         error: 'Failed to fetch subscriptions',
-        details: error.message,
+        errorId,
       });
     }
   });
@@ -952,11 +973,10 @@ const getPaymentHistory = (req, res) => {
       }
 
       // 4. FETCH DONATIONS FOR THIS SUBSCRIPTION
-      // Strategy: try three query patterns and merge results.
+      // Strategy: two query patterns merged via donationMap dedup.
       // (1) subscriptionId field match — for recurring Stripe invoices
-      // (2) metadata.subscriptionId match — legacy storage pattern
-      // (3) donorEmail + campaignId fallback — for kiosk/one-time donations
-      //     that were never linked by subscriptionId
+      // (2) donorEmail/donorEmailNormalized + campaignId fallback — for
+      //     kiosk/one-time donations never linked by subscriptionId
       const donorEmail = getSubscriptionEmail(subscriptionData);
 
       const tsToIso = (val) => {
@@ -990,14 +1010,27 @@ const getPaymentHistory = (req, res) => {
         .get();
       addSnap(q1);
 
-      // Query 2: email + campaign fallback (covers kiosk/legacy docs)
+      // Query 2: email + campaign fallback (covers kiosk/legacy docs).
+      // Two parallel queries cover both storage patterns:
+      // - donorEmailNormalized (new docs written with a normalised field)
+      // - donorEmail exact match (legacy docs stored in lowercase)
+      // Mixed-case legacy docs (e.g. "Donor@Example.com") are missed until
+      // donorEmailNormalized is backfilled, consistent with the subscription queries.
       if (donorEmail && subscriptionData.campaignId) {
-        const q2 = await db
-          .collection('donations')
-          .where('donorEmail', '==', donorEmail)
-          .where('campaignId', '==', subscriptionData.campaignId)
-          .get();
-        addSnap(q2);
+        const [q2a, q2b] = await Promise.all([
+          db
+            .collection('donations')
+            .where('donorEmailNormalized', '==', donorEmail)
+            .where('campaignId', '==', subscriptionData.campaignId)
+            .get(),
+          db
+            .collection('donations')
+            .where('donorEmail', '==', donorEmail)
+            .where('campaignId', '==', subscriptionData.campaignId)
+            .get(),
+        ]);
+        addSnap(q2a);
+        addSnap(q2b);
       }
 
       const payments = [];

--- a/backend/functions/handlers/subscriptionManagement.js
+++ b/backend/functions/handlers/subscriptionManagement.js
@@ -528,6 +528,12 @@ const getSubscriptionsByEmail = (req, res) => {
       }
 
       const emailNormalized = decodedToken.email.toLowerCase();
+
+      const withinLimit = await checkRateLimit(emailNormalized);
+      if (!withinLimit) {
+        return res.status(429).json({ error: 'Too many requests. Please try again shortly.' });
+      }
+
       const db = admin.firestore();
       const ref = db.collection('subscriptions');
       const subscriptions = await fetchSubscriptionsForEmail(ref, emailNormalized);
@@ -536,30 +542,32 @@ const getSubscriptionsByEmail = (req, res) => {
         return res.status(200).json({ subscriptions: [], count: 0 });
       }
 
-      // Enrich each subscription with live campaign title / org name
-      const enriched = await Promise.all(
-        subscriptions.map(async (sub) => {
-          try {
-            const campaignDoc = await db.collection('campaigns').doc(sub.campaignId).get();
+      // Batch-fetch all unique campaigns in one getAll() call instead of N reads.
+      const campaignIds = [...new Set(subscriptions.map((s) => s.campaignId).filter(Boolean))];
+      const campaignMap = new Map();
+      if (campaignIds.length > 0) {
+        const refs = campaignIds.map((id) => db.collection('campaigns').doc(id));
+        const docs = await db.getAll(...refs);
+        docs.forEach((d) => {
+          if (d.exists) campaignMap.set(d.id, d.data());
+        });
+      }
 
-            if (campaignDoc.exists) {
-              const cd = campaignDoc.data();
-              const meta = sub.metadata || {};
-              return {
-                ...sub,
-                metadata: {
-                  ...meta,
-                  campaignTitle: cd.title || meta.campaignTitle,
-                  organizationName: cd.organizationName || meta.organizationName,
-                },
-              };
-            }
-          } catch (err) {
-            console.error('Error fetching campaign details:', err);
-          }
-          return sub;
-        }),
-      );
+      const enriched = subscriptions.map((sub) => {
+        const cd = campaignMap.get(sub.campaignId);
+        if (cd) {
+          const meta = sub.metadata || {};
+          return {
+            ...sub,
+            metadata: {
+              ...meta,
+              campaignTitle: cd.title || meta.campaignTitle,
+              organizationName: cd.organizationName || meta.organizationName,
+            },
+          };
+        }
+        return sub;
+      });
 
       // Sort: active-like subscriptions first, then newest first within each group
       enriched.sort((a, b) => {
@@ -946,7 +954,13 @@ const getPaymentHistory = (req, res) => {
 
       const emailNormalized = decodedToken.email.toLowerCase();
 
-      // 2. INPUT VALIDATION
+      // 2. RATE LIMITING
+      const withinLimit = await checkRateLimit(emailNormalized);
+      if (!withinLimit) {
+        return res.status(429).json({ error: 'Too many requests. Please try again shortly.' });
+      }
+
+      // 3. INPUT VALIDATION
       const subscriptionId = normalizeString(req.body?.subscriptionId || req.query?.subscriptionId);
 
       if (!subscriptionId) {

--- a/backend/functions/handlers/subscriptionManagement.js
+++ b/backend/functions/handlers/subscriptionManagement.js
@@ -2,7 +2,7 @@ const admin = require('firebase-admin');
 const cors = require('../middleware/cors');
 const { ensureStripeInitialized } = require('../services/stripe');
 const { sendSubscriptionMagicLinkEmail } = require('../services/email');
-const { generateToken, storeToken, verifyToken } = require('../utils/tokenManager');
+const { generateToken, storeToken, verifyToken, consumeToken } = require('../utils/tokenManager');
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -381,6 +381,21 @@ const sendSubscriptionMagicLink = (req, res) => {
 
       const emailNormalized = email.toLowerCase();
       const db = admin.firestore();
+
+      // Rate limiting BEFORE token generation and email send.
+      // Checked sequentially: email first so a known-limited email short-circuits
+      // before the IP counter is incremented.
+      const emailAllowed = await checkRateLimit(emailNormalized);
+      if (!emailAllowed) {
+        return res.status(429).json({ error: 'Too many requests. Please try again later.' });
+      }
+
+      const clientIp = req.headers['x-forwarded-for']?.split(',')[0].trim() || req.ip || 'unknown';
+      const ipAllowed = await checkRateLimit(`ip:${clientIp}`);
+      if (!ipAllowed) {
+        return res.status(429).json({ error: 'Too many requests. Please try again later.' });
+      }
+
       const ref = db.collection('subscriptions');
       const hasSubscriptions = await subscriptionsExistForEmail(ref, emailNormalized);
 
@@ -466,17 +481,23 @@ const verifySubscriptionMagicLink = (req, res) => {
       }
 
       try {
+        // Step 1: Validate without consuming — token stays active if anything
+        // below fails transiently, so the donor can click the link again.
         const tokenData = await verifyToken(token);
         const { email } = tokenData;
 
         const crypto = require('crypto');
         const uid = `donor_${crypto.createHash('sha256').update(email).digest('hex')}`;
 
+        // Step 2: Issue Firebase custom token BEFORE consuming the magic link.
         const customToken = await admin.auth().createCustomToken(uid, {
           email,
           purpose: 'subscription_management',
           type: 'donor',
         });
+
+        // Step 3: Consume only after successful issuance.
+        await consumeToken(token);
 
         return res.status(200).json({
           success: true,

--- a/backend/functions/handlers/subscriptionManagement.test.js
+++ b/backend/functions/handlers/subscriptionManagement.test.js
@@ -26,12 +26,13 @@ jest.mock('../utils/tokenManager', () => ({
   generateToken: jest.fn(),
   storeToken: jest.fn(),
   verifyToken: jest.fn(),
+  consumeToken: jest.fn(),
 }));
 
 const admin = require('firebase-admin');
 const { ensureStripeInitialized } = require('../services/stripe');
 const { sendSubscriptionMagicLinkEmail } = require('../services/email');
-const { generateToken, storeToken, verifyToken } = require('../utils/tokenManager');
+const { generateToken, storeToken, verifyToken, consumeToken } = require('../utils/tokenManager');
 
 const {
   sendSubscriptionMagicLink,

--- a/backend/functions/handlers/subscriptionManagement.test.js
+++ b/backend/functions/handlers/subscriptionManagement.test.js
@@ -1,0 +1,1140 @@
+// ---------------------------------------------------------------------------
+// subscriptionManagement.test.js
+// ---------------------------------------------------------------------------
+// Tests for the four subscription management endpoints:
+//   - sendSubscriptionMagicLink
+//   - verifySubscriptionMagicLink
+//   - getSubscriptionsByEmail
+//   - createCustomerPortalSession
+//
+// Also covers the Firestore-backed rate limiter in isolation.
+// ---------------------------------------------------------------------------
+
+jest.mock('firebase-admin', () => require('../testUtils/mockFirebaseAdmin'));
+
+jest.mock('../middleware/cors', () => (req, res, callback) => callback());
+
+jest.mock('../services/stripe', () => ({
+  ensureStripeInitialized: jest.fn(),
+}));
+
+jest.mock('../services/email', () => ({
+  sendSubscriptionMagicLinkEmail: jest.fn(),
+}));
+
+jest.mock('../utils/tokenManager', () => ({
+  generateToken: jest.fn(),
+  storeToken: jest.fn(),
+  verifyToken: jest.fn(),
+}));
+
+const admin = require('firebase-admin');
+const { ensureStripeInitialized } = require('../services/stripe');
+const { sendSubscriptionMagicLinkEmail } = require('../services/email');
+const { generateToken, storeToken, verifyToken } = require('../utils/tokenManager');
+
+const {
+  sendSubscriptionMagicLink,
+  verifySubscriptionMagicLink,
+  getSubscriptionsByEmail,
+  createCustomerPortalSession,
+  getPaymentHistory,
+} = require('./subscriptionManagement');
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal Express-like response object.
+ * @return {{statusCode: number, body: *, status: Function, json: Function}}
+ */
+const makeRes = () => {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res;
+};
+
+/**
+ * Build a minimal Express-like request object.
+ * @param {{method?: string, body?: object, token?: string|null}} opts
+ * @return {object} Request object
+ */
+const makeReq = ({ method = 'POST', body = {}, token = null } = {}) => ({
+  method,
+  body,
+  headers: token ? { authorization: `Bearer ${token}` } : {},
+  ip: '127.0.0.1',
+});
+
+/**
+ * Seed a Firestore document via the mock.
+ * @param {string} collection - Collection name
+ * @param {string} id - Document ID
+ * @param {object} data - Document data
+ * @return {Promise<void>}
+ */
+const seed = async (collection, id, data) => {
+  await admin.firestore().collection(collection).doc(id).set(data);
+};
+
+/**
+ * Stub admin.auth().verifyIdToken to return a valid donor magic-link token.
+ * @param {string} email - Email to embed in the decoded token
+ */
+const stubAuth = (email) => {
+  admin.auth = jest.fn(() => ({
+    verifyIdToken: jest.fn().mockResolvedValue({
+      email,
+      uid: `uid_${email}`,
+      purpose: 'subscription_management',
+      type: 'donor',
+    }),
+    createCustomToken: jest.fn().mockResolvedValue('custom-token-stub'),
+  }));
+};
+
+/** Make admin.auth().verifyIdToken throw */
+const stubAuthFail = () => {
+  admin.auth = jest.fn(() => ({
+    verifyIdToken: jest.fn().mockRejectedValue(new Error('invalid token')),
+  }));
+};
+
+/**
+ * Stub a valid Firebase token that was NOT issued by the donor magic link.
+ * @param {string} email - Email to embed in the decoded token
+ */
+const stubWrongPurposeAuth = (email) => {
+  admin.auth = jest.fn(() => ({
+    verifyIdToken: jest.fn().mockResolvedValue({
+      email,
+      uid: `uid_${email}`,
+      purpose: 'admin',
+      type: 'admin',
+    }),
+  }));
+};
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  admin.__reset();
+  jest.clearAllMocks();
+  generateToken.mockReturnValue('tok_abc123');
+  storeToken.mockResolvedValue(undefined);
+  sendSubscriptionMagicLinkEmail.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ===========================================================================
+// sendSubscriptionMagicLink
+// ===========================================================================
+
+describe('sendSubscriptionMagicLink', () => {
+  it('returns 405 for non-POST requests', async () => {
+    const res = makeRes();
+    await sendSubscriptionMagicLink(makeReq({ method: 'GET' }), res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 400 when email is missing', async () => {
+    const res = makeRes();
+    await sendSubscriptionMagicLink(makeReq({ body: {} }), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/email/i);
+  });
+
+  it('returns 400 for an invalid email format', async () => {
+    const res = makeRes();
+    await sendSubscriptionMagicLink(makeReq({ body: { email: 'not-an-email' } }), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 200 with generic message when no subscriptions exist', async () => {
+    const res = makeRes();
+    await sendSubscriptionMagicLink(makeReq({ body: { email: 'unknown@example.com' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    // Must NOT reveal whether the email exists
+    expect(storeToken).not.toHaveBeenCalled();
+  });
+
+  it('sends magic link when subscription found via root donorEmail', async () => {
+    await seed('subscriptions', 'sub_1', {
+      donorEmail: 'donor@example.com',
+      customerId: 'cus_1',
+      organizationId: 'org_1',
+    });
+
+    const res = makeRes();
+    await sendSubscriptionMagicLink(makeReq({ body: { email: 'donor@example.com' } }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(storeToken).toHaveBeenCalledWith(
+      'tok_abc123',
+      expect.objectContaining({
+        email: 'donor@example.com',
+        purpose: 'subscription_management',
+      }),
+    );
+    expect(sendSubscriptionMagicLinkEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'donor@example.com',
+        magicLink: expect.stringContaining('/link/tok_abc123'),
+      }),
+    );
+  });
+
+  it('sends magic link when subscription found via metadata.donorEmail', async () => {
+    await seed('subscriptions', 'sub_2', {
+      metadata: { donorEmail: 'meta@example.com' },
+      customerId: 'cus_2',
+      organizationId: 'org_1',
+    });
+
+    const res = makeRes();
+    await sendSubscriptionMagicLink(makeReq({ body: { email: 'meta@example.com' } }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(sendSubscriptionMagicLinkEmail).toHaveBeenCalled();
+  });
+
+  it('finds subscriptions through root donorEmailNormalized', async () => {
+    await seed('subscriptions', 'sub_3', {
+      donorEmail: 'Upper@Example.com',
+      donorEmailNormalized: 'upper@example.com',
+      customerId: 'cus_3',
+      organizationId: 'org_1',
+    });
+
+    const res = makeRes();
+    await sendSubscriptionMagicLink(makeReq({ body: { email: 'UPPER@EXAMPLE.COM' } }), res);
+
+    expect(sendSubscriptionMagicLinkEmail).toHaveBeenCalled();
+  });
+
+  it('finds subscriptions through metadata.donorEmailNormalized', async () => {
+    await seed('subscriptions', 'sub_4', {
+      metadata: {
+        donorEmail: 'MetaUpper@Example.com',
+        donorEmailNormalized: 'metaupper@example.com',
+      },
+      customerId: 'cus_4',
+      organizationId: 'org_1',
+    });
+
+    const res = makeRes();
+    await sendSubscriptionMagicLink(makeReq({ body: { email: 'METAUPPER@EXAMPLE.COM' } }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(sendSubscriptionMagicLinkEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'METAUPPER@EXAMPLE.COM' }),
+    );
+  });
+
+  it('returns 200 with devLink when email service is unavailable', async () => {
+    // SendGrid is currently non-functional; the handler falls back to returning
+    // the magic link directly in the response body so the flow stays testable.
+    await seed('subscriptions', 'sub_email_fail', {
+      donorEmail: 'donor@example.com',
+      customerId: 'cus_1',
+      organizationId: 'org_1',
+    });
+    sendSubscriptionMagicLinkEmail.mockRejectedValue(new Error('SMTP down'));
+
+    const res = makeRes();
+    await sendSubscriptionMagicLink(makeReq({ body: { email: 'donor@example.com' } }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.devLink).toMatch(/\/link\//);
+  });
+});
+
+// ===========================================================================
+// verifySubscriptionMagicLink
+// ===========================================================================
+
+describe('verifySubscriptionMagicLink', () => {
+  beforeEach(() => {
+    admin.auth = jest.fn(() => ({
+      createCustomToken: jest.fn().mockResolvedValue('custom-token-stub'),
+    }));
+  });
+
+  it('returns 405 for non-POST requests', async () => {
+    const res = makeRes();
+    await verifySubscriptionMagicLink(makeReq({ method: 'GET' }), res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 400 when token is missing', async () => {
+    const res = makeRes();
+    await verifySubscriptionMagicLink(makeReq({ body: {} }), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 401 when token is expired', async () => {
+    verifyToken.mockRejectedValue(new Error('TOKEN_EXPIRED'));
+
+    const res = makeRes();
+    await verifySubscriptionMagicLink(makeReq({ body: { token: 'expired-tok' } }), res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error).toBe('TOKEN_EXPIRED');
+  });
+
+  it('returns 401 when token has already been consumed', async () => {
+    verifyToken.mockRejectedValue(new Error('TOKEN_CONSUMED'));
+
+    const res = makeRes();
+    await verifySubscriptionMagicLink(makeReq({ body: { token: 'used-tok' } }), res);
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 200 with custom token on valid token', async () => {
+    verifyToken.mockResolvedValue({ email: 'donor@example.com' });
+
+    const res = makeRes();
+    await verifySubscriptionMagicLink(makeReq({ body: { token: 'valid-tok' } }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.email).toBe('donor@example.com');
+    expect(res.body.token).toBe('custom-token-stub');
+  });
+});
+
+// ===========================================================================
+// getSubscriptionsByEmail
+// ===========================================================================
+
+describe('getSubscriptionsByEmail', () => {
+  it('returns 405 for unsupported methods', async () => {
+    stubAuth('donor@example.com');
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'DELETE' }), res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 401 when no auth header is present', async () => {
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when token is invalid', async () => {
+    stubAuthFail();
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'bad-token' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when token was not issued by donor magic link', async () => {
+    stubWrongPurposeAuth('donor@example.com');
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'admin-token' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns empty array when donor has no subscriptions', async () => {
+    stubAuth('nobody@example.com');
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'valid' }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.subscriptions).toEqual([]);
+    expect(res.body.count).toBe(0);
+  });
+
+  it('returns subscriptions found via root donorEmail', async () => {
+    stubAuth('donor@example.com');
+    await seed('subscriptions', 'sub_root', {
+      donorEmail: 'donor@example.com',
+      customerId: 'cus_1',
+      organizationId: 'org_1',
+      status: 'active',
+      amount: 1000,
+    });
+
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'valid' }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.subscriptions[0].id).toBe('sub_root');
+  });
+
+  it('returns subscriptions found via metadata.donorEmail', async () => {
+    stubAuth('meta@example.com');
+    await seed('subscriptions', 'sub_meta', {
+      metadata: { donorEmail: 'meta@example.com' },
+      customerId: 'cus_2',
+      organizationId: 'org_1',
+      status: 'active',
+      amount: 500,
+    });
+
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'valid' }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBe(1);
+  });
+
+  it('returns subscriptions found via root donorEmailNormalized', async () => {
+    stubAuth('donor@example.com');
+    await seed('subscriptions', 'sub_mixed_case', {
+      donorEmail: 'Donor@Example.com',
+      donorEmailNormalized: 'donor@example.com',
+      customerId: 'cus_mixed',
+      organizationId: 'org_1',
+      status: 'active',
+      amount: 500,
+    });
+
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'valid' }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.subscriptions[0].id).toBe('sub_mixed_case');
+  });
+
+  it('returns subscriptions found via metadata.donorEmailNormalized', async () => {
+    stubAuth('nested@example.com');
+    await seed('subscriptions', 'sub_nested_normalized', {
+      metadata: {
+        donorEmail: 'Nested@Example.com',
+        donorEmailNormalized: 'nested@example.com',
+      },
+      customerId: 'cus_nested',
+      organizationId: 'org_1',
+      status: 'active',
+      amount: 500,
+    });
+
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'valid' }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.subscriptions[0].id).toBe('sub_nested_normalized');
+  });
+
+  it('deduplicates subscriptions that appear in both queries', async () => {
+    stubAuth('both@example.com');
+    // Same doc matches both root and metadata query
+    await seed('subscriptions', 'sub_both', {
+      donorEmail: 'both@example.com',
+      metadata: { donorEmail: 'both@example.com' },
+      customerId: 'cus_3',
+      organizationId: 'org_1',
+      status: 'active',
+      amount: 750,
+    });
+
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'valid' }), res);
+
+    expect(res.body.count).toBe(1);
+  });
+
+  it('sorts active subscriptions before inactive ones', async () => {
+    stubAuth('sorted@example.com');
+    await seed('subscriptions', 'sub_cancelled', {
+      donorEmail: 'sorted@example.com',
+      status: 'cancelled',
+      amount: 500,
+      createdAt: admin.firestore.Timestamp.fromMillis(2000),
+    });
+    await seed('subscriptions', 'sub_active', {
+      donorEmail: 'sorted@example.com',
+      status: 'active',
+      amount: 1000,
+      createdAt: admin.firestore.Timestamp.fromMillis(1000),
+    });
+
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'valid' }), res);
+
+    expect(res.body.subscriptions[0].id).toBe('sub_active');
+    expect(res.body.subscriptions[1].id).toBe('sub_cancelled');
+  });
+
+  it('sorts subscriptions with same status by newest createdAt', async () => {
+    stubAuth('newest@example.com');
+    await seed('subscriptions', 'sub_old', {
+      donorEmail: 'newest@example.com',
+      status: 'active',
+      createdAt: admin.firestore.Timestamp.fromMillis(1000),
+    });
+    await seed('subscriptions', 'sub_new', {
+      donorEmail: 'newest@example.com',
+      status: 'active',
+      createdAt: admin.firestore.Timestamp.fromMillis(3000),
+    });
+
+    const res = makeRes();
+    await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'valid' }), res);
+
+    expect(res.body.subscriptions[0].id).toBe('sub_new');
+    expect(res.body.subscriptions[1].id).toBe('sub_old');
+  });
+});
+
+// ===========================================================================
+// createCustomerPortalSession
+// ===========================================================================
+
+describe('createCustomerPortalSession', () => {
+  const VALID_SUB_ID = 'sub_portal_test';
+  const DONOR_EMAIL = 'portal@example.com';
+  const ORG_ID = 'org_portal';
+  const CUSTOMER_ID = 'cus_portal123';
+  const STRIPE_ACCOUNT_ID = 'acct_portal123';
+
+  const seedValidData = async () => {
+    await seed('subscriptions', VALID_SUB_ID, {
+      donorEmail: DONOR_EMAIL,
+      customerId: CUSTOMER_ID,
+      organizationId: ORG_ID,
+    });
+    await seed('organizations', ORG_ID, {
+      stripe: { accountId: STRIPE_ACCOUNT_ID },
+    });
+  };
+
+  beforeEach(async () => {
+    stubAuth(DONOR_EMAIL);
+    await seedValidData();
+    ensureStripeInitialized.mockReturnValue({
+      billingPortal: {
+        sessions: {
+          create: jest.fn().mockResolvedValue({
+            id: 'bps_test',
+            url: 'https://billing.stripe.com/session/test',
+          }),
+        },
+      },
+    });
+  });
+
+  it('returns 405 for non-POST requests', async () => {
+    const res = makeRes();
+    await createCustomerPortalSession(makeReq({ method: 'GET', token: 'valid' }), res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 401 when no auth header is present', async () => {
+    const res = makeRes();
+    await createCustomerPortalSession(makeReq({ body: { subscriptionId: VALID_SUB_ID } }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when token is invalid', async () => {
+    stubAuthFail();
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: VALID_SUB_ID }, token: 'bad' }),
+      res,
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when token was not issued by donor magic link', async () => {
+    stubWrongPurposeAuth(DONOR_EMAIL);
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: VALID_SUB_ID }, token: 'admin-token' }),
+      res,
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 400 when subscriptionId is missing', async () => {
+    const res = makeRes();
+    await createCustomerPortalSession(makeReq({ body: {}, token: 'valid' }), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/subscription id/i);
+  });
+
+  it('returns 400 when subscriptionId is too short', async () => {
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: 'short' }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 when subscription does not exist', async () => {
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: 'sub_nonexistent_id' }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 403 when authenticated email does not match subscription', async () => {
+    stubAuth('attacker@example.com');
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: VALID_SUB_ID }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error).toMatch(/permission/i);
+  });
+
+  it('returns 403 for metadata.donorEmail mismatch too', async () => {
+    await seed('subscriptions', 'sub_meta_only', {
+      metadata: { donorEmail: 'real@example.com' },
+      customerId: CUSTOMER_ID,
+      organizationId: ORG_ID,
+    });
+    stubAuth('attacker@example.com');
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: 'sub_meta_only' }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 500 when subscription is missing customerId', async () => {
+    await seed('subscriptions', 'sub_no_customer', {
+      donorEmail: DONOR_EMAIL,
+      organizationId: ORG_ID,
+      // customerId intentionally omitted
+    });
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: 'sub_no_customer' }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('returns 500 when organization does not exist', async () => {
+    await seed('subscriptions', 'sub_bad_org', {
+      donorEmail: DONOR_EMAIL,
+      customerId: CUSTOMER_ID,
+      organizationId: 'org_missing',
+    });
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: 'sub_bad_org' }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('returns 500 when organization has no Stripe account configured', async () => {
+    await seed('organizations', 'org_no_stripe', { stripe: {} });
+    await seed('subscriptions', 'sub_no_stripe', {
+      donorEmail: DONOR_EMAIL,
+      customerId: CUSTOMER_ID,
+      organizationId: 'org_no_stripe',
+    });
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: 'sub_no_stripe' }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('returns 500 when Stripe account ID has invalid format', async () => {
+    await seed('organizations', 'org_bad_acct', {
+      stripe: { accountId: 'invalid_format' },
+    });
+    await seed('subscriptions', 'sub_bad_acct', {
+      donorEmail: DONOR_EMAIL,
+      customerId: CUSTOMER_ID,
+      organizationId: 'org_bad_acct',
+    });
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: 'sub_bad_acct' }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('returns 200 with portal URL on success', async () => {
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: VALID_SUB_ID }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.url).toBe('https://billing.stripe.com/session/test');
+  });
+
+  it('creates portal session on platform account (no stripeAccount param)', async () => {
+    const stripeMock = ensureStripeInitialized();
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: VALID_SUB_ID }, token: 'valid' }),
+      res,
+    );
+
+    const createCall = stripeMock.billingPortal.sessions.create.mock.calls[0][0];
+    expect(createCall.customer).toBe(CUSTOMER_ID);
+    // Must NOT include stripeAccount - customers live on platform account
+    expect(createCall.stripeAccount).toBeUndefined();
+  });
+
+  it('accepts subscription with email in metadata.donorEmail', async () => {
+    await seed('subscriptions', 'sub_meta_email', {
+      metadata: { donorEmail: DONOR_EMAIL },
+      customerId: CUSTOMER_ID,
+      organizationId: ORG_ID,
+    });
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: 'sub_meta_email' }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 429 when rate limit is exceeded', async () => {
+    // Freeze time so the window boundary is deterministic
+    const frozenNow = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(frozenNow);
+
+    // Seed 10 timestamps firmly inside the current window
+    const timestamps = Array.from({ length: 10 }, (_, i) => frozenNow - 50000 + i);
+    await seed('rate_limits', DONOR_EMAIL, {
+      userId: DONOR_EMAIL,
+      timestamps,
+      updatedAt: frozenNow,
+    });
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: VALID_SUB_ID }, token: 'valid' }),
+      res,
+    );
+
+    jest.spyOn(Date, 'now').mockRestore();
+    expect(res.statusCode).toBe(429);
+    expect(res.body.error).toMatch(/too many requests/i);
+  });
+
+  it('allows request after rate limit window expires', async () => {
+    // Freeze time so the window boundary is deterministic
+    const frozenNow = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(frozenNow);
+
+    // All timestamps are firmly outside the 60s window
+    const timestamps = Array.from({ length: 10 }, (_, i) => frozenNow - 120000 + i);
+    await seed('rate_limits', DONOR_EMAIL, {
+      userId: DONOR_EMAIL,
+      timestamps,
+      updatedAt: frozenNow - 120000,
+    });
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: VALID_SUB_ID }, token: 'valid' }),
+      res,
+    );
+
+    jest.spyOn(Date, 'now').mockRestore();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('handles Stripe API errors gracefully', async () => {
+    const stripeError = new Error('No such customer');
+    stripeError.type = 'StripeInvalidRequestError';
+    stripeError.code = 'resource_missing';
+    ensureStripeInitialized.mockReturnValue({
+      billingPortal: {
+        sessions: { create: jest.fn().mockRejectedValue(stripeError) },
+      },
+    });
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: VALID_SUB_ID }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(404);
+    // Must not expose internal error details
+    expect(res.body.error).not.toContain('No such customer');
+  });
+});
+
+// ===========================================================================
+// getPaymentHistory
+// ===========================================================================
+
+describe('getPaymentHistory', () => {
+  const DONOR_EMAIL = 'history@example.com';
+  const SUB_ID = 'sub_history_001';
+
+  const seedSub = async (overrides = {}) => {
+    await seed('subscriptions', SUB_ID, {
+      donorEmail: DONOR_EMAIL,
+      customerId: 'cus_hist',
+      organizationId: 'org_hist',
+      campaignId: 'camp_hist',
+      ...overrides,
+    });
+  };
+
+  beforeEach(() => {
+    stubAuth(DONOR_EMAIL);
+  });
+
+  it('returns 405 for GET requests without subscriptionId support', async () => {
+    const res = makeRes();
+    await getPaymentHistory(makeReq({ method: 'DELETE', token: 'valid' }), res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 401 when no auth header is present', async () => {
+    const res = makeRes();
+    await getPaymentHistory(makeReq({ method: 'POST', body: { subscriptionId: SUB_ID } }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when token is invalid', async () => {
+    stubAuthFail();
+    const res = makeRes();
+    await getPaymentHistory(
+      makeReq({ method: 'POST', body: { subscriptionId: SUB_ID }, token: 'bad' }),
+      res,
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when token was not issued by donor magic link', async () => {
+    stubWrongPurposeAuth(DONOR_EMAIL);
+    const res = makeRes();
+    await getPaymentHistory(
+      makeReq({ method: 'POST', body: { subscriptionId: SUB_ID }, token: 'admin-tok' }),
+      res,
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 400 when subscriptionId is missing', async () => {
+    const res = makeRes();
+    await getPaymentHistory(makeReq({ method: 'POST', body: {}, token: 'valid' }), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/subscription id/i);
+  });
+
+  it('returns 404 when subscription does not exist', async () => {
+    const res = makeRes();
+    await getPaymentHistory(
+      makeReq({ method: 'POST', body: { subscriptionId: 'sub_nonexistent_xyz' }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 403 when authenticated email does not match subscription', async () => {
+    await seedSub();
+    stubAuth('attacker@example.com');
+    const res = makeRes();
+    await getPaymentHistory(
+      makeReq({ method: 'POST', body: { subscriptionId: SUB_ID }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns empty payments array when no donations exist for subscription', async () => {
+    await seedSub();
+    const res = makeRes();
+    await getPaymentHistory(
+      makeReq({ method: 'POST', body: { subscriptionId: SUB_ID }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body.payments).toEqual([]);
+    expect(res.body.count).toBe(0);
+    expect(res.body.subscriptionId).toBe(SUB_ID);
+  });
+
+  it('returns donations linked by subscriptionId field', async () => {
+    await seedSub();
+    await seed('donations', 'don_1', {
+      subscriptionId: SUB_ID,
+      amount: 1000,
+      currency: 'gbp',
+      donorEmail: DONOR_EMAIL,
+      campaignId: 'camp_hist',
+      campaignTitleSnapshot: 'Help Dogs',
+      isGiftAid: false,
+      createdAt: admin.firestore.Timestamp.fromMillis(2000),
+    });
+
+    const res = makeRes();
+    await getPaymentHistory(
+      makeReq({ method: 'POST', body: { subscriptionId: SUB_ID }, token: 'valid' }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.payments[0].amount).toBe(1000);
+    expect(res.body.payments[0].campaignTitle).toBe('Help Dogs');
+    expect(res.body.payments[0].isGiftAid).toBe(false);
+  });
+
+  it('returns payments via email+campaignId fallback for legacy donations', async () => {
+    await seedSub();
+    await seed('donations', 'don_legacy', {
+      // No subscriptionId field — legacy storage
+      donorEmail: DONOR_EMAIL,
+      campaignId: 'camp_hist',
+      amount: 500,
+      currency: 'gbp',
+      isGiftAid: true,
+      createdAt: admin.firestore.Timestamp.fromMillis(1000),
+    });
+
+    const res = makeRes();
+    await getPaymentHistory(
+      makeReq({ method: 'POST', body: { subscriptionId: SUB_ID }, token: 'valid' }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBe(1);
+    expect(res.body.payments[0].isGiftAid).toBe(true);
+  });
+
+  it('deduplicates donations that match both query patterns', async () => {
+    await seedSub();
+    await seed('donations', 'don_both', {
+      subscriptionId: SUB_ID,
+      donorEmail: DONOR_EMAIL,
+      campaignId: 'camp_hist',
+      amount: 750,
+      currency: 'gbp',
+      isGiftAid: false,
+      createdAt: admin.firestore.Timestamp.fromMillis(1000),
+    });
+
+    const res = makeRes();
+    await getPaymentHistory(
+      makeReq({ method: 'POST', body: { subscriptionId: SUB_ID }, token: 'valid' }),
+      res,
+    );
+
+    expect(res.body.count).toBe(1);
+  });
+
+  it('sorts payments newest first', async () => {
+    await seedSub();
+    await seed('donations', 'don_old', {
+      subscriptionId: SUB_ID,
+      amount: 500,
+      currency: 'gbp',
+      createdAt: admin.firestore.Timestamp.fromMillis(1000),
+    });
+    await seed('donations', 'don_new', {
+      subscriptionId: SUB_ID,
+      amount: 1000,
+      currency: 'gbp',
+      createdAt: admin.firestore.Timestamp.fromMillis(5000),
+    });
+
+    const res = makeRes();
+    await getPaymentHistory(
+      makeReq({ method: 'POST', body: { subscriptionId: SUB_ID }, token: 'valid' }),
+      res,
+    );
+
+    expect(res.body.payments[0].id).toBe('don_new');
+    expect(res.body.payments[1].id).toBe('don_old');
+  });
+
+  it('accepts subscription email stored in metadata.donorEmail', async () => {
+    await seed('subscriptions', 'sub_meta_hist', {
+      metadata: { donorEmail: DONOR_EMAIL },
+      customerId: 'cus_mh',
+      organizationId: 'org_hist',
+      campaignId: 'camp_hist',
+    });
+    await seed('donations', 'don_meta', {
+      subscriptionId: 'sub_meta_hist',
+      amount: 800,
+      currency: 'gbp',
+      createdAt: admin.firestore.Timestamp.fromMillis(1000),
+    });
+
+    const res = makeRes();
+    await getPaymentHistory(
+      makeReq({ method: 'POST', body: { subscriptionId: 'sub_meta_hist' }, token: 'valid' }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.count).toBe(1);
+  });
+});
+
+// ===========================================================================
+// Rate limiter (Firestore transaction)
+// ===========================================================================
+
+describe('Firestore rate limiter', () => {
+  const USER = 'ratelimit@example.com';
+  const RL_SUB_ID = 'sub_rl_test_001'; // must be >= 10 chars
+
+  // We test the rate limiter indirectly through createCustomerPortalSession
+  // since checkRateLimit is not exported. The tests below verify the
+  // Firestore document state after requests.
+
+  beforeEach(async () => {
+    stubAuth(USER);
+    await seed('subscriptions', RL_SUB_ID, {
+      donorEmail: USER,
+      customerId: 'cus_rl',
+      organizationId: 'org_rl',
+    });
+    await seed('organizations', 'org_rl', {
+      stripe: { accountId: 'acct_rl123456' },
+    });
+    ensureStripeInitialized.mockReturnValue({
+      billingPortal: {
+        sessions: {
+          create: jest.fn().mockResolvedValue({
+            id: 'bps_rl',
+            url: 'https://billing.stripe.com/rl',
+          }),
+        },
+      },
+    });
+  });
+
+  it('records a timestamp in rate_limits after a successful request', async () => {
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: RL_SUB_ID }, token: 'valid' }),
+      res,
+    );
+
+    expect(res.statusCode).toBe(200);
+    const doc = admin.__getDoc('rate_limits', USER);
+    expect(doc).toBeDefined();
+    expect(doc.timestamps.length).toBe(1);
+    expect(doc.userId).toBe(USER);
+  });
+
+  it('accumulates timestamps across multiple requests', async () => {
+    for (let i = 0; i < 3; i++) {
+      const res = makeRes();
+      await createCustomerPortalSession(
+        makeReq({ body: { subscriptionId: RL_SUB_ID }, token: 'valid' }),
+        res,
+      );
+      expect(res.statusCode).toBe(200);
+    }
+
+    const doc = admin.__getDoc('rate_limits', USER);
+    expect(doc.timestamps.length).toBe(3);
+  });
+
+  it('blocks the 11th request within the same window', async () => {
+    // Make 10 allowed requests
+    for (let i = 0; i < 10; i++) {
+      const res = makeRes();
+      await createCustomerPortalSession(
+        makeReq({ body: { subscriptionId: RL_SUB_ID }, token: 'valid' }),
+        res,
+      );
+      expect(res.statusCode).toBe(200);
+    }
+
+    // 11th request must be rejected
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: RL_SUB_ID }, token: 'valid' }),
+      res,
+    );
+    expect(res.statusCode).toBe(429);
+  });
+
+  it('prunes expired timestamps so old requests do not count', async () => {
+    // Freeze time so the window boundary is deterministic
+    const frozenNow = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(frozenNow);
+
+    // Seed 9 timestamps firmly outside the 60s window
+    const oldTimestamps = Array.from({ length: 9 }, (_, i) => frozenNow - 120000 + i);
+    await seed('rate_limits', USER, {
+      userId: USER,
+      timestamps: oldTimestamps,
+      updatedAt: frozenNow - 120000,
+    });
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: RL_SUB_ID }, token: 'valid' }),
+      res,
+    );
+
+    jest.spyOn(Date, 'now').mockRestore();
+    expect(res.statusCode).toBe(200);
+
+    // Only the new timestamp should remain
+    const doc = admin.__getDoc('rate_limits', USER);
+    expect(doc.timestamps.length).toBe(1);
+  });
+
+  it('uses merge:true so extra fields on the document are preserved', async () => {
+    // Pre-seed the document with an extra field
+    await seed('rate_limits', USER, {
+      userId: USER,
+      timestamps: [],
+      updatedAt: 0,
+      customField: 'preserved',
+    });
+
+    const res = makeRes();
+    await createCustomerPortalSession(
+      makeReq({ body: { subscriptionId: RL_SUB_ID }, token: 'valid' }),
+      res,
+    );
+
+    const doc = admin.__getDoc('rate_limits', USER);
+    expect(doc.customField).toBe('preserved');
+  });
+});

--- a/backend/functions/handlers/subscriptionManagement.test.js
+++ b/backend/functions/handlers/subscriptionManagement.test.js
@@ -462,9 +462,9 @@ describe('getSubscriptionsByEmail', () => {
 
   it('sorts active subscriptions before inactive ones', async () => {
     stubAuth('sorted@example.com');
-    await seed('subscriptions', 'sub_cancelled', {
+    await seed('subscriptions', 'sub_canceled', {
       donorEmail: 'sorted@example.com',
-      status: 'cancelled',
+      status: 'canceled',
       amount: 500,
       createdAt: admin.firestore.Timestamp.fromMillis(2000),
     });
@@ -479,7 +479,7 @@ describe('getSubscriptionsByEmail', () => {
     await getSubscriptionsByEmail(makeReq({ method: 'GET', token: 'valid' }), res);
 
     expect(res.body.subscriptions[0].id).toBe('sub_active');
-    expect(res.body.subscriptions[1].id).toBe('sub_cancelled');
+    expect(res.body.subscriptions[1].id).toBe('sub_canceled');
   });
 
   it('sorts subscriptions with same status by newest createdAt', async () => {

--- a/backend/functions/handlers/subscriptionManagement.test.js
+++ b/backend/functions/handlers/subscriptionManagement.test.js
@@ -27,12 +27,19 @@ jest.mock('../utils/tokenManager', () => ({
   storeToken: jest.fn(),
   verifyToken: jest.fn(),
   consumeToken: jest.fn(),
+  releaseToken: jest.fn(),
 }));
 
 const admin = require('firebase-admin');
 const { ensureStripeInitialized } = require('../services/stripe');
 const { sendSubscriptionMagicLinkEmail } = require('../services/email');
-const { generateToken, storeToken, verifyToken, consumeToken } = require('../utils/tokenManager');
+const {
+  generateToken,
+  storeToken,
+  verifyToken,
+  consumeToken,
+  releaseToken,
+} = require('../utils/tokenManager');
 
 const {
   sendSubscriptionMagicLink,

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -1,5 +1,6 @@
 const functions = require('firebase-functions');
 const { onRequest } = require('firebase-functions/v2/https');
+const { onSchedule } = require('firebase-functions/v2/scheduler');
 const { defineSecret } = require('firebase-functions/params');
 const admin = require('firebase-admin');
 
@@ -47,6 +48,7 @@ const {
   getPaymentHistory,
 } = require('./handlers/subscriptionManagement');
 const { createStripeAccountForNewOrg, sendWelcomeEmailForNewOrg } = require('./handlers/triggers');
+const { cleanupExpiredTokens, deleteOldTokens } = require('./utils/tokenManager');
 const { verifySignupRecaptcha } = require('./handlers/signup');
 const { kioskLogin } = require('./handlers/kiosk');
 const { completeEmailVerification } = require('./handlers/verification');
@@ -173,6 +175,20 @@ exports.createConnectionToken = functions.https.onRequest(
 );
 exports.createStripeAccountForNewOrg = createStripeAccountForNewOrg;
 exports.sendWelcomeEmailForNewOrg = sendWelcomeEmailForNewOrg;
+
+// Runs daily at 03:00 UTC.
+// Two-phase cleanup keeps the subscriptionMagicLinkTokens collection bounded:
+//   Phase 1 — cleanupExpiredTokens: marks any still-active docs whose expiresAt
+//     has passed. This catches tokens that were never verified (user abandoned the
+//     flow) and were therefore never flipped to 'expired' by verifyToken.
+//   Phase 2 — deleteOldTokens: hard-deletes docs that are already consumed or
+//     expired AND older than 30 days. Without this the collection grows by one
+//     document per magic-link request with no upper bound, increasing read costs
+//     and making the status/expiresAt indexes progressively slower.
+exports.cleanupSubscriptionTokens = onSchedule('every 24 hours', async () => {
+  await cleanupExpiredTokens();
+  await deleteOldTokens();
+});
 exports.kioskLogin = functions.https.onRequest(kioskLogin);
 exports.updateOrganizationSettings = functions.https.onRequest(updateOrganizationSettings);
 

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -39,6 +39,13 @@ const {
   cancelRecurringSubscription,
   updateSubscriptionPaymentMethod,
 } = require('./handlers/subscriptions');
+const {
+  sendSubscriptionMagicLink,
+  verifySubscriptionMagicLink,
+  getSubscriptionsByEmail,
+  createCustomerPortalSession,
+  getPaymentHistory,
+} = require('./handlers/subscriptionManagement');
 const { createStripeAccountForNewOrg, sendWelcomeEmailForNewOrg } = require('./handlers/triggers');
 const { verifySignupRecaptcha } = require('./handlers/signup');
 const { kioskLogin } = require('./handlers/kiosk');
@@ -149,6 +156,17 @@ exports.updateSubscriptionPaymentMethod = functions.https.onRequest(
   { secrets: [stripeSecretKey] },
   updateSubscriptionPaymentMethod,
 );
+exports.sendSubscriptionMagicLink = functions.https.onRequest(
+  { secrets: [sendgridApiKey, sendgridFromEmail, sendgridFromName] },
+  sendSubscriptionMagicLink,
+);
+exports.verifySubscriptionMagicLink = functions.https.onRequest(verifySubscriptionMagicLink);
+exports.getSubscriptionsByEmail = functions.https.onRequest(getSubscriptionsByEmail);
+exports.createCustomerPortalSession = functions.https.onRequest(
+  { secrets: [stripeSecretKey] },
+  createCustomerPortalSession,
+);
+exports.getPaymentHistory = functions.https.onRequest(getPaymentHistory);
 exports.createConnectionToken = functions.https.onRequest(
   { secrets: [stripeSecretKey] },
   createConnectionToken,

--- a/backend/functions/services/email.js
+++ b/backend/functions/services/email.js
@@ -1,13 +1,13 @@
-const dotenv = require("dotenv");
-const sgMail = require("@sendgrid/mail");
-const admin = require("firebase-admin");
+const dotenv = require('dotenv');
+const sgMail = require('@sendgrid/mail');
+const admin = require('firebase-admin');
 
 dotenv.config();
 
 let isInitialized = false;
 
 const sanitizeErrorMessage = (error) => {
-  const message = error?.message || String(error || "Unknown error");
+  const message = error?.message || String(error || 'Unknown error');
   return String(message).slice(0, 500);
 };
 
@@ -22,9 +22,9 @@ const logEmailEvent = async ({
 }) => {
   try {
     const db = admin.firestore();
-    await db.collection("emailEvents").add({
-      eventType: eventType || "unknown",
-      provider: "sendgrid",
+    await db.collection('emailEvents').add({
+      eventType: eventType || 'unknown',
+      provider: 'sendgrid',
       status,
       recipient,
       statusCode: statusCode || null,
@@ -36,21 +36,21 @@ const logEmailEvent = async ({
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
     });
   } catch (logError) {
-    console.error("Failed to write emailEvents audit log:", sanitizeErrorMessage(logError));
+    console.error('Failed to write emailEvents audit log:', sanitizeErrorMessage(logError));
   }
 };
 
 const getEmailConfig = () => {
   const apiKey = process.env.SENDGRID_API_KEY;
   const fromEmail = process.env.SENDGRID_FROM_EMAIL;
-  const fromName = process.env.SENDGRID_FROM_NAME || "SwiftCause";
+  const fromName = process.env.SENDGRID_FROM_NAME || 'SwiftCause';
 
   if (!apiKey) {
-    throw new Error("SENDGRID_API_KEY is not configured.");
+    throw new Error('SENDGRID_API_KEY is not configured.');
   }
 
   if (!fromEmail) {
-    throw new Error("SENDGRID_FROM_EMAIL is not configured.");
+    throw new Error('SENDGRID_FROM_EMAIL is not configured.');
   }
 
   return {
@@ -62,24 +62,24 @@ const getEmailConfig = () => {
 
 const ensureEmailInitialized = () => {
   if (isInitialized) return;
-  const {apiKey} = getEmailConfig();
+  const { apiKey } = getEmailConfig();
   sgMail.setApiKey(apiKey);
   isInitialized = true;
 };
 
-const escapeHtml = (value = "") =>
+const escapeHtml = (value = '') =>
   String(value)
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#39;");
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 
-const buildEmailShell = ({preheader, title, bodyHtml}) => `<!DOCTYPE html>
+const buildEmailShell = ({ preheader, title, bodyHtml }) => `<!DOCTYPE html>
 <html>
   <body style="margin:0; padding:24px; background:#f6f8fb; font-family: Arial, sans-serif; color:#1f2937;">
     <div style="display:none; max-height:0; overflow:hidden; opacity:0;">
-      ${escapeHtml(preheader || "")}
+      ${escapeHtml(preheader || '')}
     </div>
     <div style="max-width:640px; margin:0 auto; background:#ffffff; border:1px solid #e5e7eb; border-radius:14px; overflow:hidden;">
       <div style="background:#064e3b; color:#ffffff; padding:18px 24px;">
@@ -96,18 +96,10 @@ const buildEmailShell = ({preheader, title, bodyHtml}) => `<!DOCTYPE html>
   </body>
 </html>`;
 
-const sendEmail = async ({
-  to,
-  subject,
-  text,
-  html,
-  categories,
-  customArgs,
-  auditEventType,
-}) => {
+const sendEmail = async ({ to, subject, text, html, categories, customArgs, auditEventType }) => {
   ensureEmailInitialized();
-  const {fromEmail, fromName} = getEmailConfig();
-  const recipient = Array.isArray(to) ? to.join(",") : String(to || "");
+  const { fromEmail, fromName } = getEmailConfig();
+  const recipient = Array.isArray(to) ? to.join(',') : String(to || '');
 
   try {
     const [response] = await sgMail.send({
@@ -125,12 +117,12 @@ const sendEmail = async ({
 
     const result = {
       statusCode: response?.statusCode,
-      messageId: response?.headers?.["x-message-id"] || null,
+      messageId: response?.headers?.['x-message-id'] || null,
     };
 
     await logEmailEvent({
       eventType: auditEventType,
-      status: "success",
+      status: 'success',
       recipient,
       statusCode: result.statusCode,
       providerMessageId: result.messageId,
@@ -141,7 +133,7 @@ const sendEmail = async ({
   } catch (error) {
     await logEmailEvent({
       eventType: auditEventType,
-      status: "failed",
+      status: 'failed',
       recipient,
       customArgs,
       errorMessage: sanitizeErrorMessage(error),
@@ -160,83 +152,83 @@ const sendDonationThankYouEmail = async ({
   donationId,
   organizationId,
 }) => {
-  const safeDonorName = (typeof donorName === "string" && donorName.trim()) ?
-    donorName.trim() :
-    "Donor";
-  const safeCampaignName = (typeof campaignName === "string" && campaignName.trim()) ?
-    campaignName.trim() :
-    null;
-  const safeOrganizationName = (typeof organizationName === "string" && organizationName.trim()) ?
-    organizationName.trim() :
-    null;
-  const upperCurrency = typeof currency === "string" ? currency.toUpperCase() : "";
-  const amountDisplay = typeof amount === "number" ?
-    `${(amount / 100).toFixed(2)} ${upperCurrency}`.trim() :
-    null;
+  const safeDonorName =
+    typeof donorName === 'string' && donorName.trim() ? donorName.trim() : 'Donor';
+  const safeCampaignName =
+    typeof campaignName === 'string' && campaignName.trim() ? campaignName.trim() : null;
+  const safeOrganizationName =
+    typeof organizationName === 'string' && organizationName.trim()
+      ? organizationName.trim()
+      : null;
+  const upperCurrency = typeof currency === 'string' ? currency.toUpperCase() : '';
+  const amountDisplay =
+    typeof amount === 'number' ? `${(amount / 100).toFixed(2)} ${upperCurrency}`.trim() : null;
 
-  const subject = safeCampaignName ?
-    `Thank you for supporting ${safeCampaignName}!` :
-    "Thank you for your donation!";
+  const subject = safeCampaignName
+    ? `Thank you for supporting ${safeCampaignName}!`
+    : 'Thank you for your donation!';
 
   const textLines = [
     `Dear ${safeDonorName},`,
-    "",
-    "Thank you for your generous donation to our campaign.",
+    '',
+    'Thank you for your generous donation to our campaign.',
   ];
 
   if (amountDisplay) textLines.push(`Amount: ${amountDisplay}`);
   if (safeCampaignName) textLines.push(`Campaign: ${safeCampaignName}`);
 
   textLines.push(
-      "",
-      "We truly appreciate your kindness and belief in our mission.",
-      "",
-      "With gratitude,",
-      safeOrganizationName ?
-        `on behalf of the ${safeOrganizationName} team.` :
-        "on behalf of the charity team.",
-      "",
-      "Powered by SwiftCause",
+    '',
+    'We truly appreciate your kindness and belief in our mission.',
+    '',
+    'With gratitude,',
+    safeOrganizationName
+      ? `on behalf of the ${safeOrganizationName} team.`
+      : 'on behalf of the charity team.',
+    '',
+    'Powered by SwiftCause',
   );
 
   const html = buildEmailShell({
-    preheader: "Thanks for your donation. Your support helps campaigns move forward.",
-    title: "Thank You for Your Donation",
+    preheader: 'Thanks for your donation. Your support helps campaigns move forward.',
+    title: 'Thank You for Your Donation',
     bodyHtml: `
       <p style="margin:0 0 12px;">Dear ${escapeHtml(safeDonorName)},</p>
       <p style="margin:0 0 12px;">Thank you for your generous donation to our campaign.</p>
-      ${amountDisplay ? `<p style="margin:0 0 8px;"><strong>Amount:</strong> ${escapeHtml(amountDisplay)}</p>` : ""}
-      ${safeCampaignName ? `<p style="margin:0 0 12px;"><strong>Campaign:</strong> ${escapeHtml(safeCampaignName)}</p>` : ""}
+      ${amountDisplay ? `<p style="margin:0 0 8px;"><strong>Amount:</strong> ${escapeHtml(amountDisplay)}</p>` : ''}
+      ${safeCampaignName ? `<p style="margin:0 0 12px;"><strong>Campaign:</strong> ${escapeHtml(safeCampaignName)}</p>` : ''}
       <p style="margin:0 0 12px;">We truly appreciate your kindness and belief in our mission.</p>
       <p style="margin:0 0 10px;">With gratitude,<br/><strong>${escapeHtml(
-        safeOrganizationName ?
-          `on behalf of the ${safeOrganizationName} team.` :
-          "on behalf of the charity team.",
+        safeOrganizationName
+          ? `on behalf of the ${safeOrganizationName} team.`
+          : 'on behalf of the charity team.',
       )}</strong></p>
       <p style="margin:0; color:#6b7280; font-size:13px;">Powered by SwiftCause</p>
     `,
   });
 
-  const normalizedRecipient = String(to || "").trim().toLowerCase();
+  const normalizedRecipient = String(to || '')
+    .trim()
+    .toLowerCase();
   if (donationId && normalizedRecipient) {
     const existingSend = await admin
-        .firestore()
-        .collection("emailEvents")
-        .where("eventType", "==", "donation_thank_you")
-        .where("status", "==", "success")
-        .where("donationId", "==", donationId)
-        .where("recipient", "==", normalizedRecipient)
-        .limit(1)
-        .get();
+      .firestore()
+      .collection('emailEvents')
+      .where('eventType', '==', 'donation_thank_you')
+      .where('status', '==', 'success')
+      .where('donationId', '==', donationId)
+      .where('recipient', '==', normalizedRecipient)
+      .limit(1)
+      .get();
 
     if (!existingSend.empty) {
       await logEmailEvent({
-        eventType: "donation_thank_you",
-        status: "deduplicated",
+        eventType: 'donation_thank_you',
+        status: 'deduplicated',
         recipient: normalizedRecipient,
         customArgs: {
-          donationId: donationId || "",
-          organizationId: organizationId || "",
+          donationId: donationId || '',
+          organizationId: organizationId || '',
         },
       });
       return {
@@ -250,14 +242,14 @@ const sendDonationThankYouEmail = async ({
   return sendEmail({
     to: normalizedRecipient || to,
     subject,
-    text: textLines.join("\n"),
+    text: textLines.join('\n'),
     html,
-    categories: ["donation-thank-you"],
+    categories: ['donation-thank-you'],
     customArgs: {
-      donationId: donationId || "",
-      organizationId: organizationId || "",
+      donationId: donationId || '',
+      organizationId: organizationId || '',
     },
-    auditEventType: "donation_thank_you",
+    auditEventType: 'donation_thank_you',
   });
 };
 
@@ -268,28 +260,28 @@ const sendOrganizationWelcomeEmail = async ({
   organizationId,
   uid,
 }) => {
-  const safeRecipientName = (typeof recipientName === "string" && recipientName.trim()) ?
-    recipientName.trim() :
-    "there";
-  const safeOrgName = (typeof organizationName === "string" && organizationName.trim()) ?
-    organizationName.trim() :
-    "your organization";
+  const safeRecipientName =
+    typeof recipientName === 'string' && recipientName.trim() ? recipientName.trim() : 'there';
+  const safeOrgName =
+    typeof organizationName === 'string' && organizationName.trim()
+      ? organizationName.trim()
+      : 'your organization';
 
   const subject = `Welcome to SwiftCause, ${safeOrgName}!`;
   const text = [
     `Hi ${safeRecipientName},`,
-    "",
+    '',
     `Welcome to SwiftCause. Your organization (${safeOrgName}) is now set up.`,
-    "You can now sign in and start setting up campaigns, kiosks, and Stripe onboarding.",
-    "If you need help getting started, just reply to this email.",
-    "",
-    "Welcome aboard,",
-    "SwiftCause Team",
-  ].join("\n");
+    'You can now sign in and start setting up campaigns, kiosks, and Stripe onboarding.',
+    'If you need help getting started, just reply to this email.',
+    '',
+    'Welcome aboard,',
+    'SwiftCause Team',
+  ].join('\n');
 
   const html = buildEmailShell({
-    preheader: "Your SwiftCause organization is ready. Sign in to get started.",
-    title: "Welcome to SwiftCause",
+    preheader: 'Your SwiftCause organization is ready. Sign in to get started.',
+    title: 'Welcome to SwiftCause',
     bodyHtml: `
       <p style="margin:0 0 12px;">Hi ${escapeHtml(safeRecipientName)},</p>
       <p style="margin:0 0 12px;">Welcome to SwiftCause. Your organization <strong>${escapeHtml(safeOrgName)}</strong> is now set up.</p>
@@ -304,50 +296,45 @@ const sendOrganizationWelcomeEmail = async ({
     subject,
     text,
     html,
-    categories: ["organization-welcome"],
+    categories: ['organization-welcome'],
     customArgs: {
-      organizationId: organizationId || "",
-      uid: uid || "",
+      organizationId: organizationId || '',
+      uid: uid || '',
     },
-    auditEventType: "org_welcome",
+    auditEventType: 'org_welcome',
   });
 };
 
-const sendContactConfirmationEmail = async ({
-  to,
-  firstName,
-  message,
-}) => {
-  const safeFirstName = (typeof firstName === "string" && firstName.trim()) ?
-    firstName.trim() :
-    "there";
-  const safeMessage = typeof message === "string" ? message.trim() : "";
-  const messageHtml = escapeHtml(safeMessage).replace(/\r?\n/g, "<br/>");
+const sendContactConfirmationEmail = async ({ to, firstName, message }) => {
+  const safeFirstName =
+    typeof firstName === 'string' && firstName.trim() ? firstName.trim() : 'there';
+  const safeMessage = typeof message === 'string' ? message.trim() : '';
+  const messageHtml = escapeHtml(safeMessage).replace(/\r?\n/g, '<br/>');
 
-  const subject = "We received your message";
+  const subject = 'We received your message';
   const text = [
     `Hi ${safeFirstName},`,
-    "",
-    "Thanks for contacting SwiftCause. We received your message and will get back to you shortly.",
-    "Our team usually replies within one business day.",
-    "",
-    "Message:",
-    safeMessage || "(No message provided)",
-    "",
-    "Regards,",
-    "SwiftCause Team",
-  ].join("\n");
+    '',
+    'Thanks for contacting SwiftCause. We received your message and will get back to you shortly.',
+    'Our team usually replies within one business day.',
+    '',
+    'Message:',
+    safeMessage || '(No message provided)',
+    '',
+    'Regards,',
+    'SwiftCause Team',
+  ].join('\n');
 
   const html = buildEmailShell({
-    preheader: "We received your message and will get back to you shortly.",
-    title: "We Received Your Message",
+    preheader: 'We received your message and will get back to you shortly.',
+    title: 'We Received Your Message',
     bodyHtml: `
       <p style="margin:0 0 12px;">Hi ${escapeHtml(safeFirstName)},</p>
       <p style="margin:0 0 12px;">Thanks for contacting SwiftCause. We received your message and will get back to you shortly.</p>
       <p style="margin:0 0 12px;">Our team usually replies within one business day.</p>
       <p style="margin:0 0 6px;"><strong>Your message</strong></p>
       <div style="margin:0 0 12px; padding:12px; border:1px solid #e5e7eb; border-radius:10px; background:#f9fafb;">
-        ${messageHtml || "(No message provided)"}
+        ${messageHtml || '(No message provided)'}
       </div>
       <p style="margin:0;">Regards,<br/><strong>SwiftCause Team</strong></p>
     `,
@@ -358,8 +345,84 @@ const sendContactConfirmationEmail = async ({
     subject,
     text,
     html,
-    categories: ["contact-confirmation"],
-    auditEventType: "contact_confirmation",
+    categories: ['contact-confirmation'],
+    auditEventType: 'contact_confirmation',
+  });
+};
+
+/**
+ * Send subscription management magic link email
+ * @param {object} params - Email parameters
+ * @param {string} params.to - Recipient email
+ * @param {string} params.magicLink - Magic link URL
+ * @param {number} params.expiresInMinutes - Link expiration time
+ * @return {Promise<object>} SendGrid response
+ */
+const sendSubscriptionMagicLinkEmail = async ({ to, magicLink, expiresInMinutes = 15 }) => {
+  const subject = 'Access Your Donations - SwiftCause';
+
+  const text = [
+    'Hello,',
+    '',
+    'You requested access to manage your donations.',
+    '',
+    'Click the link below to securely access your donation dashboard:',
+    magicLink,
+    '',
+    `This link will expire in ${expiresInMinutes} minutes and can only be used once.`,
+    '',
+    "If you didn't request this, you can safely ignore this email.",
+    '',
+    'Best regards,',
+    'SwiftCause Team',
+  ].join('\n');
+
+  const html = buildEmailShell({
+    preheader: 'Click to securely access your donation dashboard',
+    title: 'Access Your Donations',
+    bodyHtml: `
+      <p style="margin:0 0 12px;">Hello,</p>
+      <p style="margin:0 0 12px;">You requested access to manage your donations.</p>
+      <p style="margin:0 0 20px;">Click the button below to securely access your donation dashboard:</p>
+      
+      <table role="presentation" style="width:100%; border-collapse:collapse;">
+        <tr>
+          <td align="center" style="padding:10px 0;">
+            <a href="${escapeHtml(magicLink)}" 
+               style="display:inline-block; padding:16px 32px; background-color:#047857; color:#ffffff; text-decoration:none; border-radius:12px; font-weight:600; font-size:16px;">
+              Access Dashboard
+            </a>
+          </td>
+        </tr>
+      </table>
+      
+      <p style="margin:24px 0 0; font-size:14px; line-height:1.6; color:#6b7280;">
+        Or copy and paste this link into your browser:
+      </p>
+      <p style="margin:8px 0 0; font-size:13px; line-height:1.6; color:#047857; word-break:break-all;">
+        ${escapeHtml(magicLink)}
+      </p>
+      
+      <div style="margin:24px 0 0; padding:16px; background:#f3f4f6; border-left:4px solid #047857; border-radius:8px;">
+        <p style="margin:0; font-size:14px; line-height:1.6; color:#374151;">
+          <strong>🔒 Security Notice:</strong><br>
+          This link expires in <strong>${expiresInMinutes} minutes</strong> and can only be used once.
+        </p>
+      </div>
+      
+      <p style="margin:16px 0 0; font-size:14px; color:#6b7280;">
+        If you didn't request this, you can safely ignore this email.
+      </p>
+    `,
+  });
+
+  return sendEmail({
+    to,
+    subject,
+    text,
+    html,
+    categories: ['subscription-magic-link'],
+    auditEventType: 'subscription_magic_link',
   });
 };
 
@@ -369,4 +432,5 @@ module.exports = {
   sendDonationThankYouEmail,
   sendOrganizationWelcomeEmail,
   sendContactConfirmationEmail,
+  sendSubscriptionMagicLinkEmail,
 };

--- a/backend/functions/testUtils/mockFirebaseAdmin.js
+++ b/backend/functions/testUtils/mockFirebaseAdmin.js
@@ -2,9 +2,36 @@ const collections = new Map();
 let transactionQueue = Promise.resolve();
 let autoIdCounter = 0;
 
+const makeTimestamp = (ms) => ({
+  __type: 'timestamp',
+  ms,
+  toMillis() {
+    return this.ms;
+  },
+  toDate() {
+    return new Date(this.ms);
+  },
+});
+
 const clone = (value) => {
   if (value === undefined) return undefined;
-  return JSON.parse(JSON.stringify(value));
+  if (value === null || typeof value !== 'object') return value;
+  if (value.__type === 'timestamp' && typeof value.ms === 'number') {
+    return makeTimestamp(value.ms);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => clone(item));
+  }
+
+  const next = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (item && typeof item.toMillis === 'function' && typeof item.toDate === 'function') {
+      next[key] = makeTimestamp(item.toMillis());
+    } else {
+      next[key] = clone(item);
+    }
+  }
+  return next;
 };
 
 const getCollectionStore = (name) => {
@@ -29,17 +56,11 @@ const mergeData = (current = {}, incoming = {}) => {
   return next;
 };
 
-const createSnapshot = (id, data) => ({
-  id,
-  exists: data !== undefined,
-  data: () => clone(data),
-});
-
 const doc = (collectionName, id) => ({
   id,
   async get() {
     const stored = getCollectionStore(collectionName).get(id);
-    return createSnapshot(id, stored);
+    return createSnapshot(collectionName, id, stored);
   },
   async set(data, options = {}) {
     const store = getCollectionStore(collectionName);
@@ -55,18 +76,104 @@ const doc = (collectionName, id) => ({
     }
     store.set(id, mergeData(current, data));
   },
+  async delete() {
+    getCollectionStore(collectionName).delete(id);
+  },
+});
+
+const createSnapshot = (collectionName, id, data) => ({
+  id,
+  ref: doc(collectionName, id),
+  exists: data !== undefined,
+  data: () => clone(data),
+});
+
+const getFieldValue = (data, field) => {
+  const parts = field.split('.');
+  let actual = data;
+  for (const part of parts) {
+    actual = actual != null ? actual[part] : undefined;
+  }
+  return actual;
+};
+
+const comparableValue = (value) => {
+  if (value && typeof value.toMillis === 'function') {
+    return value.toMillis();
+  }
+  if (value && value.__type === 'timestamp' && typeof value.ms === 'number') {
+    return value.ms;
+  }
+  return value;
+};
+
+const matchesFilter = (actualValue, op, expectedValue) => {
+  const actual = comparableValue(actualValue);
+  const expected = comparableValue(expectedValue);
+  if (op === '==') return actual === expected;
+  if (op === '!=') return actual !== expected;
+  if (op === '>') return actual > expected;
+  if (op === '>=') return actual >= expected;
+  if (op === '<') return actual < expected;
+  if (op === '<=') return actual <= expected;
+  return false;
+};
+
+const createQuerySnapshot = (docs) => ({
+  docs,
+  empty: docs.length === 0,
+  size: docs.length,
+  forEach(fn) {
+    docs.forEach(fn);
+  },
 });
 
 const firestoreInstance = {
   collection(name) {
+    // Build a chainable query object that filters the in-memory store
+    const buildQuery = (collectionName, filters, limitCount) => ({
+      where(field, op, value) {
+        return buildQuery(collectionName, [...filters, { field, op, value }], limitCount);
+      },
+      limit(n) {
+        return buildQuery(collectionName, filters, n);
+      },
+      async get() {
+        const store = getCollectionStore(collectionName);
+        let entries = Array.from(store.entries());
+
+        for (const { field, op, value } of filters) {
+          entries = entries.filter(([, data]) => {
+            // Support nested field paths like "metadata.donorEmail"
+            return matchesFilter(getFieldValue(data, field), op, value);
+          });
+        }
+
+        if (limitCount != null) {
+          entries = entries.slice(0, limitCount);
+        }
+
+        const docs = entries.map(([id, data]) => createSnapshot(collectionName, id, data));
+        return createQuerySnapshot(docs);
+      },
+    });
+
     return {
       doc(id) {
         return doc(name, id);
       },
+      where(field, op, value) {
+        return buildQuery(name, [{ field, op, value }], null);
+      },
+      limit(n) {
+        return buildQuery(name, [], n);
+      },
       async get() {
         const store = getCollectionStore(name);
-        const docs = Array.from(store.entries()).map(([id, value]) => createSnapshot(id, value));
-        return { docs };
+        const docs = Array.from(store.entries()).map(([id, value]) =>
+          createSnapshot(name, id, value),
+        );
+        return createQuerySnapshot(docs);
       },
       async add(data) {
         autoIdCounter += 1;
@@ -96,6 +203,9 @@ const firestoreInstance = {
       update(ref, data) {
         operations.push(() => ref.update(data));
       },
+      delete(ref) {
+        operations.push(() => ref.delete());
+      },
     };
 
     try {
@@ -109,6 +219,25 @@ const firestoreInstance = {
       release();
       throw error;
     }
+  },
+  batch() {
+    const operations = [];
+    return {
+      set(ref, data, options) {
+        operations.push(() => ref.set(data, options));
+      },
+      update(ref, data) {
+        operations.push(() => ref.update(data));
+      },
+      delete(ref) {
+        operations.push(() => ref.delete());
+      },
+      async commit() {
+        for (const operation of operations) {
+          await operation();
+        }
+      },
+    };
   },
 };
 
@@ -127,20 +256,9 @@ const admin = {
 };
 
 admin.firestore.Timestamp = {
-  now: () => ({
-    __type: 'timestamp',
-    ms: Date.now(),
-    toMillis() {
-      return this.ms;
-    },
-  }),
-  fromDate: (date) => ({
-    __type: 'timestamp',
-    ms: date.getTime(),
-    toMillis() {
-      return this.ms;
-    },
-  }),
+  now: () => makeTimestamp(Date.now()),
+  fromDate: (date) => makeTimestamp(date.getTime()),
+  fromMillis: (ms) => makeTimestamp(ms),
 };
 
 admin.firestore.FieldValue = {

--- a/backend/functions/utils/tokenManager.js
+++ b/backend/functions/utils/tokenManager.js
@@ -51,7 +51,6 @@ const storeToken = async (token, { email, purpose = 'subscription_management' })
 
   console.log('Token stored:', {
     tokenHash: tokenHash.substring(0, 10) + '...',
-    email,
     purpose,
     expiresAt: expiresAt.toDate().toISOString(),
   });

--- a/backend/functions/utils/tokenManager.js
+++ b/backend/functions/utils/tokenManager.js
@@ -81,9 +81,12 @@ const verifyToken = async (token) => {
 
     const tokenData = tokenDoc.data();
 
-    // Check if already consumed
-    if (tokenData.status === 'consumed') {
-      console.warn('Token already consumed:', tokenHash.substring(0, 10) + '...');
+    // Check if already consumed or being claimed by a concurrent request
+    if (tokenData.status === 'consumed' || tokenData.status === 'claiming') {
+      console.warn(
+        'Token already consumed or claim in progress:',
+        tokenHash.substring(0, 10) + '...',
+      );
       throw new Error('TOKEN_CONSUMED');
     }
 
@@ -108,11 +111,14 @@ const verifyToken = async (token) => {
       throw new Error('TOKEN_INVALID');
     }
 
-    // Token is valid — return data without consuming.
-    // The caller must call consumeToken() only after any downstream operations
-    // (e.g. Firebase custom-token issuance) complete successfully. This ensures
-    // a transient Auth failure does not burn the link with no retry path.
-    console.log('Token verified (not yet consumed):', {
+    // Atomically claim the token: active → claiming.
+    // Any concurrent request will see 'claiming' and receive TOKEN_CONSUMED,
+    // eliminating the verify/mint/consume race window. The caller must call
+    // consumeToken() on success or releaseToken() on failure so the token
+    // is never left permanently in the 'claiming' state.
+    transaction.update(tokenRef, { status: 'claiming' });
+
+    console.log('Token claimed:', {
       tokenHash: tokenHash.substring(0, 10) + '...',
       email: tokenData.email,
     });
@@ -146,7 +152,7 @@ const consumeToken = async (token) => {
 
   await db.runTransaction(async (transaction) => {
     const tokenDoc = await transaction.get(tokenRef);
-    if (!tokenDoc.exists || tokenDoc.data().status !== 'active') return;
+    if (!tokenDoc.exists || tokenDoc.data().status !== 'claiming') return;
     transaction.update(tokenRef, {
       status: 'consumed',
       consumedAt: admin.firestore.Timestamp.now(),
@@ -154,6 +160,27 @@ const consumeToken = async (token) => {
   });
 
   console.log('Token consumed:', { tokenHash: tokenHash.substring(0, 10) + '...' });
+};
+
+/**
+ * Roll back a claimed token to active so the donor can retry.
+ * Must be called when any operation after verifyToken fails (e.g. createCustomToken).
+ * Silently no-ops if the token is not in 'claiming' state.
+ * @param {string} token - Plain token (will be hashed)
+ * @return {Promise<void>}
+ */
+const releaseToken = async (token) => {
+  const tokenHash = hashToken(token);
+  const db = admin.firestore();
+  const tokenRef = db.collection(COLLECTION_NAME).doc(tokenHash);
+
+  await db.runTransaction(async (transaction) => {
+    const tokenDoc = await transaction.get(tokenRef);
+    if (!tokenDoc.exists || tokenDoc.data().status !== 'claiming') return;
+    transaction.update(tokenRef, { status: 'active' });
+  });
+
+  console.log('Token released back to active:', { tokenHash: tokenHash.substring(0, 10) + '...' });
 };
 
 /**
@@ -251,6 +278,7 @@ module.exports = {
   storeToken,
   verifyToken,
   consumeToken,
+  releaseToken,
   cleanupExpiredTokens,
   deleteOldTokens,
   TOKEN_EXPIRY_MS,

--- a/backend/functions/utils/tokenManager.js
+++ b/backend/functions/utils/tokenManager.js
@@ -1,0 +1,234 @@
+const admin = require('firebase-admin');
+const crypto = require('crypto');
+
+/**
+ * Token Manager for Subscription Magic Links
+ * Handles secure token generation, storage, and verification in Firestore
+ */
+
+const COLLECTION_NAME = 'subscriptionMagicLinkTokens';
+const TOKEN_EXPIRY_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Generate a secure random token
+ * @return {string} 64-character hex token (256 bits)
+ */
+const generateToken = () => {
+  return crypto.randomBytes(32).toString('hex');
+};
+
+/**
+ * Hash a token for storage (prevents token exposure in database)
+ * @param {string} token - Plain token
+ * @return {string} SHA-256 hash of token
+ */
+const hashToken = (token) => {
+  return crypto.createHash('sha256').update(token).digest('hex');
+};
+
+/**
+ * Store a token in Firestore
+ * @param {string} token - Plain token (will be hashed)
+ * @param {object} data - Token data
+ * @param {string} data.email - Donor email
+ * @param {string} data.purpose - Token purpose (e.g., 'subscription_management')
+ * @return {Promise<string>} Token hash (document ID)
+ */
+const storeToken = async (token, { email, purpose = 'subscription_management' }) => {
+  const tokenHash = hashToken(token);
+  const db = admin.firestore();
+  const timestamp = admin.firestore.Timestamp.now();
+  const expiresAt = admin.firestore.Timestamp.fromMillis(Date.now() + TOKEN_EXPIRY_MS);
+
+  await db.collection(COLLECTION_NAME).doc(tokenHash).set({
+    email: email.toLowerCase().trim(),
+    purpose,
+    status: 'active',
+    expiresAt,
+    createdAt: timestamp,
+    consumedAt: null,
+  });
+
+  console.log('Token stored:', {
+    tokenHash: tokenHash.substring(0, 10) + '...',
+    email,
+    purpose,
+    expiresAt: expiresAt.toDate().toISOString(),
+  });
+
+  return tokenHash;
+};
+
+/**
+ * Verify and consume a token (one-time use)
+ * @param {string} token - Plain token
+ * @return {Promise<object>} Token data if valid
+ * @throws {Error} If token is invalid, expired, or already consumed
+ */
+const verifyToken = async (token) => {
+  const tokenHash = hashToken(token);
+  const db = admin.firestore();
+
+  // Use transaction to prevent race conditions
+  const result = await db.runTransaction(async (transaction) => {
+    const tokenRef = db.collection(COLLECTION_NAME).doc(tokenHash);
+    const tokenDoc = await transaction.get(tokenRef);
+
+    // Check if token exists
+    if (!tokenDoc.exists) {
+      console.warn('Token not found:', tokenHash.substring(0, 10) + '...');
+      throw new Error('TOKEN_NOT_FOUND');
+    }
+
+    const tokenData = tokenDoc.data();
+
+    // Check if already consumed
+    if (tokenData.status === 'consumed') {
+      console.warn('Token already consumed:', tokenHash.substring(0, 10) + '...');
+      throw new Error('TOKEN_CONSUMED');
+    }
+
+    // Check if expired
+    const now = Date.now();
+    const expiresAt = tokenData.expiresAt?.toMillis();
+
+    if (!expiresAt || expiresAt < now) {
+      console.warn('Token expired:', tokenHash.substring(0, 10) + '...');
+
+      // Mark as expired
+      transaction.update(tokenRef, {
+        status: 'expired',
+      });
+
+      return { error: 'TOKEN_EXPIRED' };
+    }
+
+    // Check status
+    if (tokenData.status !== 'active') {
+      console.warn('Token not active:', tokenData.status);
+      throw new Error('TOKEN_INVALID');
+    }
+
+    // Token is valid - consume it (one-time use)
+    transaction.update(tokenRef, {
+      status: 'consumed',
+      consumedAt: admin.firestore.Timestamp.now(),
+    });
+
+    console.log('Token verified and consumed:', {
+      tokenHash: tokenHash.substring(0, 10) + '...',
+      email: tokenData.email,
+    });
+
+    return {
+      email: tokenData.email,
+      purpose: tokenData.purpose,
+      createdAt: tokenData.createdAt,
+    };
+  });
+
+  if (result.error) {
+    throw new Error(result.error);
+  }
+
+  return result;
+};
+
+/**
+ * Cleanup expired tokens (should be called periodically)
+ * @return {Promise<number>} Number of tokens marked as expired
+ */
+const cleanupExpiredTokens = async () => {
+  const db = admin.firestore();
+  const now = admin.firestore.Timestamp.now();
+
+  // Find expired tokens
+  const expiredTokens = await db
+    .collection(COLLECTION_NAME)
+    .where('expiresAt', '<', now)
+    .where('status', '==', 'active')
+    .limit(100) // Process in batches
+    .get();
+
+  if (expiredTokens.empty) {
+    return 0;
+  }
+
+  // Mark as expired in batch
+  const batch = db.batch();
+  expiredTokens.docs.forEach((doc) => {
+    batch.update(doc.ref, { status: 'expired' });
+  });
+
+  await batch.commit();
+
+  console.log('Cleaned up expired tokens:', expiredTokens.size);
+  return expiredTokens.size;
+};
+
+/**
+ * Delete old consumed/expired tokens (for periodic cleanup)
+ * Deletes tokens that are consumed or expired and older than X days
+ * @param {number} daysOld - Delete tokens older than this many days (default: 30)
+ * @return {Promise<number>} Number of tokens deleted
+ */
+const deleteOldTokens = async (daysOld = 30) => {
+  const db = admin.firestore();
+  const cutoffDate = admin.firestore.Timestamp.fromMillis(
+    Date.now() - daysOld * 24 * 60 * 60 * 1000,
+  );
+
+  // Find old consumed tokens
+  const oldConsumedTokens = await db
+    .collection(COLLECTION_NAME)
+    .where('status', '==', 'consumed')
+    .where('consumedAt', '<', cutoffDate)
+    .limit(100) // Process in batches
+    .get();
+
+  // Find old expired tokens
+  const oldExpiredTokens = await db
+    .collection(COLLECTION_NAME)
+    .where('status', '==', 'expired')
+    .where('expiresAt', '<', cutoffDate)
+    .limit(100) // Process in batches
+    .get();
+
+  const totalToDelete = oldConsumedTokens.size + oldExpiredTokens.size;
+
+  if (totalToDelete === 0) {
+    return 0;
+  }
+
+  // Delete in batch
+  const batch = db.batch();
+
+  oldConsumedTokens.docs.forEach((doc) => {
+    batch.delete(doc.ref);
+  });
+
+  oldExpiredTokens.docs.forEach((doc) => {
+    batch.delete(doc.ref);
+  });
+
+  await batch.commit();
+
+  console.log('Deleted old tokens:', {
+    consumed: oldConsumedTokens.size,
+    expired: oldExpiredTokens.size,
+    total: totalToDelete,
+    olderThan: `${daysOld} days`,
+  });
+
+  return totalToDelete;
+};
+
+module.exports = {
+  generateToken,
+  hashToken,
+  storeToken,
+  verifyToken,
+  cleanupExpiredTokens,
+  deleteOldTokens,
+  TOKEN_EXPIRY_MS,
+};

--- a/backend/functions/utils/tokenManager.js
+++ b/backend/functions/utils/tokenManager.js
@@ -108,13 +108,11 @@ const verifyToken = async (token) => {
       throw new Error('TOKEN_INVALID');
     }
 
-    // Token is valid - consume it (one-time use)
-    transaction.update(tokenRef, {
-      status: 'consumed',
-      consumedAt: admin.firestore.Timestamp.now(),
-    });
-
-    console.log('Token verified and consumed:', {
+    // Token is valid — return data without consuming.
+    // The caller must call consumeToken() only after any downstream operations
+    // (e.g. Firebase custom-token issuance) complete successfully. This ensures
+    // a transient Auth failure does not burn the link with no retry path.
+    console.log('Token verified (not yet consumed):', {
       tokenHash: tokenHash.substring(0, 10) + '...',
       email: tokenData.email,
     });
@@ -131,6 +129,31 @@ const verifyToken = async (token) => {
   }
 
   return result;
+};
+
+/**
+ * Atomically mark a previously-verified token as consumed.
+ * Must be called only after all downstream operations (e.g. custom-token
+ * issuance) have succeeded. Silently no-ops if the token was already consumed
+ * by a concurrent request so the caller never throws on a race.
+ * @param {string} token - Plain token (will be hashed)
+ * @return {Promise<void>}
+ */
+const consumeToken = async (token) => {
+  const tokenHash = hashToken(token);
+  const db = admin.firestore();
+  const tokenRef = db.collection(COLLECTION_NAME).doc(tokenHash);
+
+  await db.runTransaction(async (transaction) => {
+    const tokenDoc = await transaction.get(tokenRef);
+    if (!tokenDoc.exists || tokenDoc.data().status !== 'active') return;
+    transaction.update(tokenRef, {
+      status: 'consumed',
+      consumedAt: admin.firestore.Timestamp.now(),
+    });
+  });
+
+  console.log('Token consumed:', { tokenHash: tokenHash.substring(0, 10) + '...' });
 };
 
 /**
@@ -227,6 +250,7 @@ module.exports = {
   hashToken,
   storeToken,
   verifyToken,
+  consumeToken,
   cleanupExpiredTokens,
   deleteOldTokens,
   TOKEN_EXPIRY_MS,

--- a/backend/functions/utils/tokenManager.test.js
+++ b/backend/functions/utils/tokenManager.test.js
@@ -6,6 +6,7 @@ const {
   hashToken,
   storeToken,
   verifyToken,
+  consumeToken,
   cleanupExpiredTokens,
   deleteOldTokens,
   TOKEN_EXPIRY_MS,
@@ -80,6 +81,13 @@ describe('tokenManager', () => {
         purpose: 'subscription_management',
       }),
     );
+
+    // Token should still be active after verify-only step
+    const beforeConsume = admin.__getDoc(COLLECTION, hashToken('one-time-token'));
+    expect(beforeConsume.status).toBe('active');
+
+    // Consume explicitly (as the handler does after createCustomToken succeeds)
+    await consumeToken('one-time-token');
 
     const stored = admin.__getDoc(COLLECTION, hashToken('one-time-token'));
     expect(stored.status).toBe('consumed');

--- a/backend/functions/utils/tokenManager.test.js
+++ b/backend/functions/utils/tokenManager.test.js
@@ -7,6 +7,7 @@ const {
   storeToken,
   verifyToken,
   consumeToken,
+  releaseToken,
   cleanupExpiredTokens,
   deleteOldTokens,
   TOKEN_EXPIRY_MS,
@@ -82,9 +83,9 @@ describe('tokenManager', () => {
       }),
     );
 
-    // Token should still be active after verify-only step
+    // After verifyToken, token must be in 'claiming' state (blocks concurrent requests)
     const beforeConsume = admin.__getDoc(COLLECTION, hashToken('one-time-token'));
-    expect(beforeConsume.status).toBe('active');
+    expect(beforeConsume.status).toBe('claiming');
 
     // Consume explicitly (as the handler does after createCustomToken succeeds)
     await consumeToken('one-time-token');
@@ -94,6 +95,37 @@ describe('tokenManager', () => {
     expect(stored.consumedAt.toMillis()).toEqual(expect.any(Number));
 
     await expect(verifyToken('one-time-token')).rejects.toThrow('TOKEN_CONSUMED');
+  });
+
+  it('rejects a concurrent claim on the same token', async () => {
+    await storeToken('race-token', {
+      email: 'donor@example.com',
+      purpose: 'subscription_management',
+    });
+
+    // First claim succeeds
+    await verifyToken('race-token');
+    expect(admin.__getDoc(COLLECTION, hashToken('race-token')).status).toBe('claiming');
+
+    // Second concurrent claim sees 'claiming' and is rejected
+    await expect(verifyToken('race-token')).rejects.toThrow('TOKEN_CONSUMED');
+  });
+
+  it('releases a claimed token back to active on downstream failure', async () => {
+    await storeToken('release-token', {
+      email: 'donor@example.com',
+      purpose: 'subscription_management',
+    });
+
+    await verifyToken('release-token');
+    expect(admin.__getDoc(COLLECTION, hashToken('release-token')).status).toBe('claiming');
+
+    await releaseToken('release-token');
+    expect(admin.__getDoc(COLLECTION, hashToken('release-token')).status).toBe('active');
+
+    // Token is claimable again after release
+    const result = await verifyToken('release-token');
+    expect(result.email).toBe('donor@example.com');
   });
 
   it('rejects unknown tokens', async () => {

--- a/backend/functions/utils/tokenManager.test.js
+++ b/backend/functions/utils/tokenManager.test.js
@@ -1,0 +1,164 @@
+jest.mock('firebase-admin', () => require('../testUtils/mockFirebaseAdmin'));
+
+const admin = require('firebase-admin');
+const {
+  generateToken,
+  hashToken,
+  storeToken,
+  verifyToken,
+  cleanupExpiredTokens,
+  deleteOldTokens,
+  TOKEN_EXPIRY_MS,
+} = require('./tokenManager');
+
+const COLLECTION = 'subscriptionMagicLinkTokens';
+
+const silenceLogs = () => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+};
+
+describe('tokenManager', () => {
+  beforeEach(() => {
+    admin.__reset();
+    jest.clearAllMocks();
+    silenceLogs();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('generates unique 64-character hex tokens', () => {
+    const first = generateToken();
+    const second = generateToken();
+
+    expect(first).toMatch(/^[a-f0-9]{64}$/);
+    expect(second).toMatch(/^[a-f0-9]{64}$/);
+    expect(first).not.toBe(second);
+  });
+
+  it('hashes tokens deterministically without returning the plain token', () => {
+    const token = 'plain-token';
+    const firstHash = hashToken(token);
+    const secondHash = hashToken(token);
+
+    expect(firstHash).toBe(secondHash);
+    expect(firstHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(firstHash).not.toBe(token);
+  });
+
+  it('stores only the hashed token and normalises email', async () => {
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+
+    const tokenHash = await storeToken('secret-token', {
+      email: ' Donor@Example.com ',
+      purpose: 'subscription_management',
+    });
+
+    expect(admin.__getDoc(COLLECTION, 'secret-token')).toBeUndefined();
+
+    const stored = admin.__getDoc(COLLECTION, tokenHash);
+    expect(stored.email).toBe('donor@example.com');
+    expect(stored.purpose).toBe('subscription_management');
+    expect(stored.status).toBe('active');
+    expect(stored.expiresAt.toMillis()).toBe(now + TOKEN_EXPIRY_MS);
+    expect(stored.consumedAt).toBeNull();
+  });
+
+  it('verifies and consumes an active token once', async () => {
+    await storeToken('one-time-token', {
+      email: 'donor@example.com',
+      purpose: 'subscription_management',
+    });
+
+    const result = await verifyToken('one-time-token');
+    expect(result).toEqual(
+      expect.objectContaining({
+        email: 'donor@example.com',
+        purpose: 'subscription_management',
+      }),
+    );
+
+    const stored = admin.__getDoc(COLLECTION, hashToken('one-time-token'));
+    expect(stored.status).toBe('consumed');
+    expect(stored.consumedAt.toMillis()).toEqual(expect.any(Number));
+
+    await expect(verifyToken('one-time-token')).rejects.toThrow('TOKEN_CONSUMED');
+  });
+
+  it('rejects unknown tokens', async () => {
+    await expect(verifyToken('missing-token')).rejects.toThrow('TOKEN_NOT_FOUND');
+  });
+
+  it('marks expired active tokens as expired during verification', async () => {
+    const start = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(start);
+    await storeToken('expired-token', {
+      email: 'donor@example.com',
+      purpose: 'subscription_management',
+    });
+
+    Date.now.mockReturnValue(start + TOKEN_EXPIRY_MS + 1);
+
+    await expect(verifyToken('expired-token')).rejects.toThrow('TOKEN_EXPIRED');
+
+    const stored = admin.__getDoc(COLLECTION, hashToken('expired-token'));
+    expect(stored.status).toBe('expired');
+  });
+
+  it('marks expired active tokens during cleanup', async () => {
+    const now = Date.now();
+    const db = admin.firestore();
+    await db
+      .collection(COLLECTION)
+      .doc('expired')
+      .set({
+        email: 'old@example.com',
+        status: 'active',
+        expiresAt: admin.firestore.Timestamp.fromMillis(now - 1),
+      });
+    await db
+      .collection(COLLECTION)
+      .doc('fresh')
+      .set({
+        email: 'fresh@example.com',
+        status: 'active',
+        expiresAt: admin.firestore.Timestamp.fromMillis(now + 10000),
+      });
+
+    const count = await cleanupExpiredTokens();
+
+    expect(count).toBe(1);
+    expect(admin.__getDoc(COLLECTION, 'expired').status).toBe('expired');
+    expect(admin.__getDoc(COLLECTION, 'fresh').status).toBe('active');
+  });
+
+  it('deletes old consumed and expired tokens', async () => {
+    const now = Date.now();
+    const cutoffPast = admin.firestore.Timestamp.fromMillis(now - 31 * 24 * 60 * 60 * 1000);
+    const recent = admin.firestore.Timestamp.fromMillis(now);
+    const db = admin.firestore();
+
+    await db.collection(COLLECTION).doc('old_consumed').set({
+      status: 'consumed',
+      consumedAt: cutoffPast,
+    });
+    await db.collection(COLLECTION).doc('old_expired').set({
+      status: 'expired',
+      expiresAt: cutoffPast,
+    });
+    await db.collection(COLLECTION).doc('recent_consumed').set({
+      status: 'consumed',
+      consumedAt: recent,
+    });
+
+    const count = await deleteOldTokens(30);
+
+    expect(count).toBe(2);
+    expect(admin.__getDoc(COLLECTION, 'old_consumed')).toBeUndefined();
+    expect(admin.__getDoc(COLLECTION, 'old_expired')).toBeUndefined();
+    expect(admin.__getDoc(COLLECTION, 'recent_consumed')).toBeDefined();
+  });
+});

--- a/docs/DONOR_SUBSCRIPTION_MANAGEMENT.md
+++ b/docs/DONOR_SUBSCRIPTION_MANAGEMENT.md
@@ -1,0 +1,521 @@
+# Donor Subscription Management Portal
+
+This document is the canonical guide for the donor-facing subscription management portal.
+It replaces the temporary migration, quick-start, security-fix, and Stripe portal notes that were created during implementation.
+
+## Scope
+
+The portal lets a donor:
+
+1. Enter an email at `/manage`.
+2. Receive a one-time magic link.
+3. Sign in with a Firebase custom-token session created from that magic link.
+4. View a flat list of their subscriptions at `/manage/dashboard`.
+5. Open Stripe Customer Portal for a selected subscription via the Manage button.
+
+This flow is for donor self-service only. Admin subscription management remains separate.
+
+## User Flow
+
+```text
+/manage
+  email input
+  POST sendSubscriptionMagicLink
+
+email link
+  /link/[token]
+  POST verifySubscriptionMagicLink
+  signInWithCustomToken
+
+/manage/dashboard
+  GET getSubscriptionsByEmail with Firebase ID token
+  render flat subscription list
+
+Manage button
+  POST createCustomerPortalSession with subscriptionId only
+  redirect to returned Stripe portal URL
+```
+
+## Frontend Files
+
+- `src/views/manage/ManageEmailScreen.tsx`
+  Sends the magic-link request.
+
+- `src/views/manage/ManageCheckEmailScreen.tsx`
+  Confirms that the donor should check their inbox and supports resend.
+
+- `app/link/[token]/page.tsx`
+  Tries subscription-management token verification first. If that fails, it falls back to the existing Gift Aid magic-link validation.
+
+- `src/views/manage/ManageDashboardScreen.tsx`
+  Requires a signed-in Firebase user, fetches subscriptions, and creates Stripe portal sessions.
+
+- `src/features/subscription-management/ui/SubscriptionCard.tsx`
+  Renders each subscription as an independent flat-list item.
+
+## Backend Files
+
+- `backend/functions/handlers/subscriptionManagement.js`
+  Contains the five HTTPS handlers:
+  - `sendSubscriptionMagicLink`
+  - `verifySubscriptionMagicLink`
+  - `getSubscriptionsByEmail`
+  - `createCustomerPortalSession`
+  - `getPaymentHistory`
+
+- `backend/functions/utils/tokenManager.js`
+  Generates, hashes, stores, verifies, consumes, and cleans up magic-link tokens.
+
+- `backend/functions/services/email.js`
+  Sends the subscription-management magic-link email.
+
+- `backend/functions/entities/subscription.js`
+  Writes subscription documents, including normalized donor email fields for lookup.
+
+- `backend/functions/handlers/subscriptionManagement.test.js`
+  63 tests covering all five endpoints: token flow, subscription listing, ownership validation, portal-session creation, payment history, and rate limiting.
+
+## Firebase Functions
+
+Production base URL:
+
+```text
+https://us-central1-swiftcause-app.cloudfunctions.net
+```
+
+Local emulator base URL:
+
+```text
+http://localhost:5001/swiftcause-app/us-central1
+```
+
+The frontend uses:
+
+```text
+NEXT_PUBLIC_FIREBASE_FUNCTIONS_URL
+```
+
+If the env var is absent, it falls back to the production Firebase Functions URL.
+
+## API Reference
+
+### sendSubscriptionMagicLink
+
+```text
+POST /sendSubscriptionMagicLink
+```
+
+Request:
+
+```json
+{
+  "email": "donor@example.com"
+}
+```
+
+Behavior:
+
+- Validates email format.
+- Normalizes the email to lowercase.
+- Checks whether matching subscriptions exist.
+- Always returns a generic success response for unknown emails to avoid email enumeration.
+- Stores a hashed one-time token in `subscriptionMagicLinkTokens`.
+- Sends a magic-link email through SendGrid.
+
+Success response:
+
+```json
+{
+  "success": true,
+  "message": "If this email has active donations, you will receive a link shortly."
+}
+```
+
+Development response may include:
+
+```json
+{
+  "devLink": "http://localhost:3000/link/<token>"
+}
+```
+
+### verifySubscriptionMagicLink
+
+```text
+POST /verifySubscriptionMagicLink
+```
+
+Request:
+
+```json
+{
+  "token": "<plain magic-link token>"
+}
+```
+
+Behavior:
+
+- Hashes the supplied token.
+- Fetches the token document.
+- Rejects missing, expired, consumed, or invalid tokens.
+- Consumes valid tokens in a Firestore transaction.
+- Creates a Firebase custom token with donor subscription-management claims.
+
+Success response:
+
+```json
+{
+  "success": true,
+  "email": "donor@example.com",
+  "token": "<firebase custom token>"
+}
+```
+
+The frontend must exchange this custom token with `signInWithCustomToken`, then use the resulting Firebase ID token for authenticated API calls.
+
+### getSubscriptionsByEmail
+
+```text
+GET /getSubscriptionsByEmail
+```
+
+Authentication:
+
+```text
+Authorization: Bearer <Firebase ID token>
+```
+
+Behavior:
+
+- Requires a valid Firebase ID token.
+- Requires donor magic-link claims:
+  - `purpose === "subscription_management"`
+  - `type === "donor"`
+- Uses the authenticated token email, not an email from query params or request body.
+- Returns only subscriptions belonging to that email.
+- Sorts active subscriptions first, then newest first by `createdAt`.
+- Enriches campaign title and organization display name where campaign data is available.
+
+Response:
+
+```json
+{
+  "subscriptions": [
+    {
+      "id": "sub_123",
+      "customerId": "cus_123",
+      "campaignId": "campaign_123",
+      "organizationId": "org_123",
+      "amount": 3200,
+      "currency": "gbp",
+      "status": "active",
+      "interval": "month",
+      "intervalCount": 1,
+      "currentPeriodEnd": {
+        "seconds": 1770000000
+      },
+      "metadata": {
+        "campaignTitle": "Example Campaign",
+        "organizationName": "Example Charity"
+      }
+    }
+  ],
+  "count": 1
+}
+```
+
+### createCustomerPortalSession
+
+```text
+POST /createCustomerPortalSession
+```
+
+Authentication:
+
+```text
+Authorization: Bearer <Firebase ID token>
+```
+
+Request:
+
+```json
+{
+  "subscriptionId": "sub_123"
+}
+```
+
+Behavior:
+
+- Requires a valid donor subscription-management Firebase ID token.
+- Accepts only `subscriptionId` from the frontend.
+- Fetches the subscription document from Firestore.
+- Extracts `customerId`, `organizationId`, and donor email from the subscription document.
+- Validates that the authenticated email owns the subscription.
+- Rejects ownership mismatch with `403`.
+- Rejects missing subscription with `404`.
+- Rejects data inconsistencies such as missing `customerId` with `500`.
+- Creates a Stripe Customer Portal session and returns the portal URL.
+
+Response:
+
+```json
+{
+  "success": true,
+  "url": "https://billing.stripe.com/session/..."
+}
+```
+
+### getPaymentHistory
+
+```text
+POST /getPaymentHistory
+```
+
+Authentication:
+
+```text
+Authorization: Bearer <Firebase ID token>
+```
+
+Request:
+
+```json
+{
+  "subscriptionId": "sub_123"
+}
+```
+
+Behavior:
+
+- Requires a valid donor subscription-management Firebase ID token.
+- Validates ownership: authenticated email must match the subscription's donor email.
+- Queries donations in two ways and merges results:
+  1. `subscriptionId` field match — covers all Stripe invoice-linked donations.
+  2. `donorEmail + campaignId` match — fallback for legacy or kiosk donations not linked by `subscriptionId`.
+- Deduplicates by donation document ID.
+- Sorts newest first by `createdAt`.
+- The frontend further deduplicates across multiple subscriptions to prevent duplicate React keys when a donor has multiple subscriptions to the same campaign.
+
+Response:
+
+```json
+{
+  "payments": [
+    {
+      "id": "don_123",
+      "amount": 3200,
+      "currency": "gbp",
+      "status": "success",
+      "campaignTitle": "Example Campaign",
+      "createdAt": "2025-01-15T10:00:00.000Z",
+      "isGiftAid": false
+    }
+  ],
+  "count": 1,
+  "subscriptionId": "sub_123"
+}
+```
+
+## Stripe Account Model
+
+Current subscription creation uses platform Stripe customers and subscriptions with `transfer_data.destination` for the connected organization account.
+
+That means:
+
+- `customerId` lives on the platform Stripe account.
+- Customer Portal sessions must be created on the platform account.
+- The portal-session call does not pass a `stripeAccount` option.
+- `organizationId` is still validated and the organization's Stripe account ID is checked as a data-integrity guard.
+
+If the Stripe architecture changes so customers are created directly on connected accounts, this portal-session logic must change to pass the connected account context to Stripe.
+
+## Firestore Data
+
+### subscriptions
+
+Relevant fields:
+
+```javascript
+{
+  stripeSubscriptionId: string,
+  customerId: string,
+  campaignId: string,
+  organizationId: string,
+  amount: number,
+  currency: string,
+  status: string,
+  interval: "month" | "year",
+  intervalCount: number,
+  donorEmail: string | null,
+  donorEmailNormalized: string | null,
+  currentPeriodEnd: Timestamp,
+  startedAt: Timestamp,
+  createdAt: Timestamp,
+  updatedAt: Timestamp,
+  metadata: {
+    donorEmail?: string,
+    donorEmailNormalized?: string,
+    campaignTitle?: string,
+    organizationName?: string
+  }
+}
+```
+
+`donorEmailNormalized` should be used for reliable lookup. Existing legacy records may only have mixed-case `donorEmail`; those should be backfilled.
+
+### subscriptionMagicLinkTokens
+
+Document ID is the SHA-256 hash of the plain token.
+
+```javascript
+{
+  email: string,
+  purpose: "subscription_management",
+  status: "active" | "consumed" | "expired",
+  expiresAt: Timestamp,
+  createdAt: Timestamp,
+  consumedAt: Timestamp | null
+}
+```
+
+Firestore rules deny client read/write access to this collection. Only backend functions should access it.
+
+### rate_limits
+
+Used exclusively by the Firestore-backed sliding-window rate limiter on `createCustomerPortalSession`. Document ID is the donor's normalized email.
+
+```javascript
+{
+  userId: string,           // normalized email
+  timestamps: number[],     // ms timestamps of requests within current window
+  updatedAt: number         // ms timestamp of last write
+}
+```
+
+- Window: 60 seconds, max 10 requests per window.
+- Read and write occur inside a Firestore transaction to prevent race conditions across Cloud Function instances.
+- Timestamps older than the window are pruned on every write.
+- Written with `merge: true` to preserve any extra fields.
+- Fails open on Firestore errors so legitimate donors are never blocked by infra issues.
+- No cleanup needed — old timestamps are pruned inline on each request.
+
+## Security Requirements
+
+- Do not trust email from the frontend for subscription listing or portal creation.
+- Do not accept `customerId` from the frontend.
+- Always fetch the subscription by `subscriptionId` on the backend before portal creation.
+- Always validate ownership by comparing authenticated donor email to subscription donor email.
+- Require donor magic-link custom claims for donor APIs.
+- Return `401` for missing or invalid authentication.
+- Return `403` for authenticated users attempting to manage someone else's subscription.
+- Store only hashed magic-link tokens.
+- Keep magic-link tokens one-time-use and time-limited.
+- Keep token documents backend-only in Firestore rules.
+
+## Deployment
+
+### Required Firebase secrets
+
+```bash
+cd backend
+firebase functions:secrets:set SENDGRID_API_KEY
+firebase functions:secrets:set SENDGRID_FROM_EMAIL
+firebase functions:secrets:set SENDGRID_FROM_NAME
+firebase functions:secrets:set STRIPE_SECRET_KEY
+```
+
+### Required frontend env
+
+Production:
+
+```env
+NEXT_PUBLIC_APP_URL=https://your-production-domain
+NEXT_PUBLIC_FIREBASE_FUNCTIONS_URL=https://us-central1-swiftcause-app.cloudfunctions.net
+```
+
+Local emulator:
+
+```env
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_FIREBASE_FUNCTIONS_URL=http://localhost:5001/swiftcause-app/us-central1
+```
+
+Keep local values in `.env.local`, not in committed `.env`.
+
+### Deploy Firestore config
+
+```bash
+cd backend
+firebase deploy --only firestore:indexes,firestore:rules
+```
+
+### Deploy functions
+
+```bash
+cd backend
+firebase deploy --only functions:sendSubscriptionMagicLink,functions:verifySubscriptionMagicLink,functions:getSubscriptionsByEmail,functions:createCustomerPortalSession,functions:getPaymentHistory
+```
+
+## Verification
+
+Run the focused backend test suite:
+
+```bash
+npm --prefix backend/functions test -- subscriptionManagement.test.js
+```
+
+Run backend lint:
+
+```bash
+npm --prefix backend/functions run lint
+```
+
+Run targeted frontend lint for donor portal files:
+
+```bash
+npx eslint src/features/subscription-management/ui/SubscriptionCard.tsx src/views/manage/ManageDashboardScreen.tsx app/link/[token]/page.tsx src/views/manage/ManageEmailScreen.tsx src/views/manage/ManageCheckEmailScreen.tsx
+```
+
+Run the Next.js build:
+
+```bash
+npm run build
+```
+
+## Manual QA Checklist
+
+- Enter a malformed email at `/manage`; validation should block or show an error.
+- Enter an email with no subscriptions; response should be generic and should not reveal account existence.
+- Enter an email with subscriptions; donor should receive a magic link.
+- Open the magic link within 15 minutes; user should land on `/manage/dashboard`.
+- Reopen the same magic link; it should fail because the token was consumed.
+- Wait beyond token expiry; token should fail.
+- Dashboard should show only subscriptions for the authenticated donor.
+- Active subscriptions should appear before inactive subscriptions.
+- Every subscription should render as a separate item.
+- Each item should show campaign title, organization, amount, interval, status, and a Manage button.
+- Manage should send only `subscriptionId`.
+- Managing a subscription owned by another donor should return `403`.
+- Missing or invalid auth should return `401`.
+- Missing subscription should return `404`.
+- Missing `customerId` should log a data inconsistency and return an error.
+- A valid Manage action should redirect to Stripe Customer Portal.
+
+## Known Follow-Ups
+
+- Backfill `donorEmailNormalized` and `metadata.donorEmailNormalized` for existing subscription records that were created before this feature.
+- Remove the `devLink` field from the `sendSubscriptionMagicLink` production response once SendGrid is functional. Currently, when email delivery fails, the magic link is returned in the response body so the flow remains testable. This is a security risk in production.
+- Add a scheduled cleanup Cloud Function for old consumed/expired `subscriptionMagicLinkTokens` documents (`tokenManager.js` already exports `cleanupExpiredTokens` and `deleteOldTokens` for this purpose).
+- Billing dates (`currentPeriodEnd`, `nextPaymentAt`) are intentionally not displayed on the dashboard because the current Firestore data is incorrect. Re-enable once data quality is confirmed.
+
+## Retired Temporary Docs
+
+The following temporary root-level docs were consolidated into this file and should not be kept as source-of-truth documentation:
+
+- `MIGRATION_COMPLETE.md`
+- `MIGRATION_PROGRESS.md`
+- `PHASE_2_COMPLETE.md`
+- `QUICK_START.md`
+- `SECURITY_FIXES.md`
+- `STRIPE_PORTAL_IMPLEMENTATION.md`
+- `SUBSCRIPTION_MANAGEMENT_SETUP.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@radix-ui/react-toggle": "^1.1.2",
         "@radix-ui/react-toggle-group": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.3",
+        "@sendgrid/mail": "^8.1.6",
         "@stripe/react-stripe-js": "^3.7.0",
         "@stripe/stripe-js": "^4.8.0",
         "@tanstack/react-query": "^5.95.2",
@@ -4018,6 +4019,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -5601,6 +5637,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5625,6 +5666,16 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -5735,7 +5786,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5979,6 +6029,17 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -6259,6 +6320,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -6293,6 +6362,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -6350,7 +6427,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6503,7 +6579,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6513,7 +6588,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6558,7 +6632,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6571,7 +6644,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7281,6 +7353,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7295,6 +7386,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -7316,7 +7422,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7399,7 +7504,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7433,7 +7537,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7521,7 +7624,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7593,7 +7695,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7606,7 +7707,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7622,7 +7722,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -9080,7 +9179,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9108,6 +9206,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-function": {
@@ -9684,6 +9801,14 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@radix-ui/react-toggle": "^1.1.2",
     "@radix-ui/react-toggle-group": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.3",
+    "@sendgrid/mail": "^8.1.6",
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^4.8.0",
     "@tanstack/react-query": "^5.95.2",

--- a/src/features/subscription-management/index.ts
+++ b/src/features/subscription-management/index.ts
@@ -1,0 +1,2 @@
+// Public API for subscription-management feature
+export { SubscriptionCard } from './ui/SubscriptionCard';

--- a/src/features/subscription-management/ui/SubscriptionCard.tsx
+++ b/src/features/subscription-management/ui/SubscriptionCard.tsx
@@ -1,8 +1,9 @@
 'use client';
+
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent } from '@/shared/ui/card';
-import { Calendar, CheckCircle } from 'lucide-react';
-import type { Subscription } from '@/shared/types/subscription';
+import { CheckCircle } from 'lucide-react';
+import type { Subscription, SubscriptionStatus } from '@/shared/types/subscription';
 
 interface SubscriptionCardProps {
   subscription: Subscription;
@@ -10,132 +11,72 @@ interface SubscriptionCardProps {
 }
 
 export function SubscriptionCard({ subscription, onManage }: SubscriptionCardProps) {
-  // Helper to safely get campaign title from metadata
   const getCampaignTitle = () => {
     const title = subscription.metadata?.campaignTitle;
     return typeof title === 'string' ? title : 'Recurring Donation';
   };
 
-  // Helper to safely get organization name from metadata
   const getOrganizationName = () => {
     const name = subscription.metadata?.organizationName;
     return typeof name === 'string' ? name : subscription.organizationId;
   };
 
   const formatAmount = (amount: number, currency: string) => {
-    const symbol = currency === 'gbp' ? '£' : currency === 'usd' ? '$' : currency.toUpperCase();
-    return `${symbol}${(amount / 100).toFixed(0)}`;
+    return new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: currency.toUpperCase(),
+      maximumFractionDigits: 0,
+    }).format(amount / 100);
   };
 
-  const formatInterval = (interval: string) => {
-    return interval;
+  const formatInterval = (interval: string, intervalCount = 1) => {
+    if (intervalCount <= 1) return interval;
+    return `${intervalCount} ${interval}s`;
   };
 
-  const formatDate = (
-    timestamp: string | Date | { seconds: number; nanoseconds?: number } | undefined,
-  ) => {
-    if (!timestamp) return 'N/A';
-
-    let date: Date;
-    if (typeof timestamp === 'string') {
-      date = new Date(timestamp);
-    } else if (timestamp instanceof Date) {
-      date = timestamp;
-    } else if (typeof timestamp === 'object' && 'seconds' in timestamp) {
-      date = new Date(timestamp.seconds * 1000);
-    } else {
-      return 'N/A';
-    }
-
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  };
-
-  const getDaysUntil = (
-    timestamp: string | Date | { seconds: number; nanoseconds?: number } | undefined,
-  ) => {
-    if (!timestamp) return null;
-
-    let date: Date;
-    if (typeof timestamp === 'string') {
-      date = new Date(timestamp);
-    } else if (timestamp instanceof Date) {
-      date = timestamp;
-    } else if (typeof timestamp === 'object' && 'seconds' in timestamp) {
-      date = new Date(timestamp.seconds * 1000);
-    } else {
-      return null;
-    }
-
-    const today = new Date();
-    const diffTime = date.getTime() - today.getTime();
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    return diffDays;
+  const getStatusLabel = (status: SubscriptionStatus) => {
+    return status
+      .split('_')
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ');
   };
 
   const isActive = subscription.status === 'active';
-  const isCanceled = subscription.status === 'canceled';
-  const daysUntilCharge =
-    isActive && subscription.nextPaymentAt ? getDaysUntil(subscription.nextPaymentAt) : null;
+  const isTrialing = subscription.status === 'trialing';
+  const canManage = isActive || isTrialing;
 
   return (
     <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)] overflow-hidden hover:shadow-[0_2px_4px_rgba(0,0,0,0.06)] transition-shadow">
       <CardContent className="p-4">
         <div className="space-y-3.5">
-          {/* Header with Title and Status Badge */}
           <div className="flex items-start justify-between gap-3">
             <div className="flex-1 min-w-0">
               <h3 className="text-base font-semibold text-[#111827] mb-1 leading-tight">
                 {getCampaignTitle()}
               </h3>
-              <p className="text-sm text-[#6B7280]">{getOrganizationName()}</p>
+              <p className="text-sm text-[#6B7280]">Organization: {getOrganizationName()}</p>
             </div>
-            {isActive && (
-              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-[#E6F4EA] text-[#137333] shrink-0">
-                <CheckCircle className="w-3.5 h-3.5" />
-                Active
-              </span>
-            )}
-            {isCanceled && (
-              <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-[#F3F4F6] text-[#6B7280] shrink-0">
-                Canceled
-              </span>
-            )}
+            <span
+              className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium shrink-0 ${
+                isActive ? 'bg-[#E6F4EA] text-[#137333]' : 'bg-[#F3F4F6] text-[#6B7280]'
+              }`}
+            >
+              {isActive && <CheckCircle className="w-3.5 h-3.5" />}
+              {getStatusLabel(subscription.status)}
+            </span>
           </div>
 
-          {/* Amount */}
           <div className="text-3xl font-bold text-[#111827]">
             {formatAmount(subscription.amount, subscription.currency)}
             <span className="text-base font-normal text-[#6B7280]">
               {' '}
-              / {formatInterval(subscription.interval)}
+              / {formatInterval(subscription.interval, subscription.intervalCount)}
             </span>
           </div>
 
-          {isActive && (
-            <>
-              {/* Next Charge - Clean, No Box */}
-              {subscription.nextPaymentAt && (
-                <div className="flex items-center gap-2 text-sm">
-                  <Calendar className="w-4 h-4 text-[#6B7280]" />
-                  <span className="text-[#374151]">
-                    Next charge:{' '}
-                    <span className="font-medium">{formatDate(subscription.nextPaymentAt)}</span>
-                    {daysUntilCharge !== null && daysUntilCharge <= 7 && (
-                      <span className="text-[#6B7280]">
-                        {' '}
-                        · in {daysUntilCharge} {daysUntilCharge === 1 ? 'day' : 'days'}
-                      </span>
-                    )}
-                  </span>
-                </div>
-              )}
-
-              {/* Action Button - Outlined Style */}
-              <div className="flex flex-col items-center pt-1">
+          <div className="flex flex-col items-center pt-1">
+            {canManage ? (
+              <>
                 <Button
                   variant="outline"
                   size="sm"
@@ -147,33 +88,11 @@ export function SubscriptionCard({ subscription, onManage }: SubscriptionCardPro
                 <p className="text-xs text-[#6B7280] text-center mt-2.5">
                   You can update or cancel your donation anytime
                 </p>
-              </div>
-            </>
-          )}
-
-          {isCanceled && (
-            <>
-              {/* Canceled State - Clean */}
-              <div className="flex items-center gap-2 text-sm">
-                <Calendar className="w-4 h-4 text-[#6B7280]" />
-                <span className="text-[#374151]">
-                  Last payment:{' '}
-                  <span className="font-medium">{formatDate(subscription.currentPeriodEnd)}</span>
-                </span>
-              </div>
-
-              {/* Restart Button */}
-              <div className="flex flex-col items-center pt-1">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="w-full border-[1.5px]! border-[#0F7A5C]! text-[#0F7A5C]! bg-white! hover:bg-[#0F7A5C]! hover:text-white! hover:border-[#0F7A5C]! active:bg-[#0D6B4E]! active:border-[#0D6B4E]! active:text-white! h-11 font-medium rounded-xl text-base transition-all"
-                >
-                  Restart donation
-                </Button>
-              </div>
-            </>
-          )}
+              </>
+            ) : (
+              <p className="text-xs text-[#6B7280] text-center py-1">This subscription has ended</p>
+            )}
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/features/subscription-management/ui/SubscriptionCard.tsx
+++ b/src/features/subscription-management/ui/SubscriptionCard.tsx
@@ -1,0 +1,181 @@
+'use client';
+import { Button } from '@/shared/ui/button';
+import { Card, CardContent } from '@/shared/ui/card';
+import { Calendar, CheckCircle } from 'lucide-react';
+import type { Subscription } from '@/shared/types/subscription';
+
+interface SubscriptionCardProps {
+  subscription: Subscription;
+  onManage: (subscriptionId: string) => void;
+}
+
+export function SubscriptionCard({ subscription, onManage }: SubscriptionCardProps) {
+  // Helper to safely get campaign title from metadata
+  const getCampaignTitle = () => {
+    const title = subscription.metadata?.campaignTitle;
+    return typeof title === 'string' ? title : 'Recurring Donation';
+  };
+
+  // Helper to safely get organization name from metadata
+  const getOrganizationName = () => {
+    const name = subscription.metadata?.organizationName;
+    return typeof name === 'string' ? name : subscription.organizationId;
+  };
+
+  const formatAmount = (amount: number, currency: string) => {
+    const symbol = currency === 'gbp' ? '£' : currency === 'usd' ? '$' : currency.toUpperCase();
+    return `${symbol}${(amount / 100).toFixed(0)}`;
+  };
+
+  const formatInterval = (interval: string) => {
+    return interval;
+  };
+
+  const formatDate = (
+    timestamp: string | Date | { seconds: number; nanoseconds?: number } | undefined,
+  ) => {
+    if (!timestamp) return 'N/A';
+
+    let date: Date;
+    if (typeof timestamp === 'string') {
+      date = new Date(timestamp);
+    } else if (timestamp instanceof Date) {
+      date = timestamp;
+    } else if (typeof timestamp === 'object' && 'seconds' in timestamp) {
+      date = new Date(timestamp.seconds * 1000);
+    } else {
+      return 'N/A';
+    }
+
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const getDaysUntil = (
+    timestamp: string | Date | { seconds: number; nanoseconds?: number } | undefined,
+  ) => {
+    if (!timestamp) return null;
+
+    let date: Date;
+    if (typeof timestamp === 'string') {
+      date = new Date(timestamp);
+    } else if (timestamp instanceof Date) {
+      date = timestamp;
+    } else if (typeof timestamp === 'object' && 'seconds' in timestamp) {
+      date = new Date(timestamp.seconds * 1000);
+    } else {
+      return null;
+    }
+
+    const today = new Date();
+    const diffTime = date.getTime() - today.getTime();
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    return diffDays;
+  };
+
+  const isActive = subscription.status === 'active';
+  const isCanceled = subscription.status === 'canceled';
+  const daysUntilCharge =
+    isActive && subscription.nextPaymentAt ? getDaysUntil(subscription.nextPaymentAt) : null;
+
+  return (
+    <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)] overflow-hidden hover:shadow-[0_2px_4px_rgba(0,0,0,0.06)] transition-shadow">
+      <CardContent className="p-4">
+        <div className="space-y-3.5">
+          {/* Header with Title and Status Badge */}
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1 min-w-0">
+              <h3 className="text-base font-semibold text-[#111827] mb-1 leading-tight">
+                {getCampaignTitle()}
+              </h3>
+              <p className="text-sm text-[#6B7280]">{getOrganizationName()}</p>
+            </div>
+            {isActive && (
+              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-[#E6F4EA] text-[#137333] shrink-0">
+                <CheckCircle className="w-3.5 h-3.5" />
+                Active
+              </span>
+            )}
+            {isCanceled && (
+              <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-[#F3F4F6] text-[#6B7280] shrink-0">
+                Canceled
+              </span>
+            )}
+          </div>
+
+          {/* Amount */}
+          <div className="text-3xl font-bold text-[#111827]">
+            {formatAmount(subscription.amount, subscription.currency)}
+            <span className="text-base font-normal text-[#6B7280]">
+              {' '}
+              / {formatInterval(subscription.interval)}
+            </span>
+          </div>
+
+          {isActive && (
+            <>
+              {/* Next Charge - Clean, No Box */}
+              {subscription.nextPaymentAt && (
+                <div className="flex items-center gap-2 text-sm">
+                  <Calendar className="w-4 h-4 text-[#6B7280]" />
+                  <span className="text-[#374151]">
+                    Next charge:{' '}
+                    <span className="font-medium">{formatDate(subscription.nextPaymentAt)}</span>
+                    {daysUntilCharge !== null && daysUntilCharge <= 7 && (
+                      <span className="text-[#6B7280]">
+                        {' '}
+                        · in {daysUntilCharge} {daysUntilCharge === 1 ? 'day' : 'days'}
+                      </span>
+                    )}
+                  </span>
+                </div>
+              )}
+
+              {/* Action Button - Outlined Style */}
+              <div className="flex flex-col items-center pt-1">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full border-[1.5px]! border-[#0F7A5C]! text-[#0F7A5C]! bg-white! hover:bg-[#0F7A5C]! hover:text-white! hover:border-[#0F7A5C]! active:bg-[#0D6B4E]! active:border-[#0D6B4E]! active:text-white! h-11 font-medium rounded-xl text-base transition-all"
+                  onClick={() => onManage(subscription.id)}
+                >
+                  Manage Subscription
+                </Button>
+                <p className="text-xs text-[#6B7280] text-center mt-2.5">
+                  You can update or cancel your donation anytime
+                </p>
+              </div>
+            </>
+          )}
+
+          {isCanceled && (
+            <>
+              {/* Canceled State - Clean */}
+              <div className="flex items-center gap-2 text-sm">
+                <Calendar className="w-4 h-4 text-[#6B7280]" />
+                <span className="text-[#374151]">
+                  Last payment:{' '}
+                  <span className="font-medium">{formatDate(subscription.currentPeriodEnd)}</span>
+                </span>
+              </div>
+
+              {/* Restart Button */}
+              <div className="flex flex-col items-center pt-1">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full border-[1.5px]! border-[#0F7A5C]! text-[#0F7A5C]! bg-white! hover:bg-[#0F7A5C]! hover:text-white! hover:border-[#0F7A5C]! active:bg-[#0D6B4E]! active:border-[#0D6B4E]! active:text-white! h-11 font-medium rounded-xl text-base transition-all"
+                >
+                  Restart donation
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/shared/config/functions.ts
+++ b/src/shared/config/functions.ts
@@ -28,6 +28,14 @@ export const FUNCTION_URLS = {
   updateUser: getFunctionUrl('updateUser'),
   deleteUser: getFunctionUrl('deleteUser'),
   updateOrganizationSettings: getFunctionUrl('updateOrganizationSettings'),
+  // Subscription management (donor self-service portal)
+  sendSubscriptionMagicLink: getFunctionUrl('sendSubscriptionMagicLink'),
+  verifySubscriptionMagicLink: getFunctionUrl('verifySubscriptionMagicLink'),
+  getSubscriptionsByEmail: getFunctionUrl('getSubscriptionsByEmail'),
+  createCustomerPortalSession: getFunctionUrl('createCustomerPortalSession'),
+  getPaymentHistory: getFunctionUrl('getPaymentHistory'),
+  // Gift Aid magic link validation
+  validateMagicLinkToken: getFunctionUrl('validateMagicLinkToken'),
 } as const;
 
 export default FUNCTION_URLS;

--- a/src/shared/types/subscription.ts
+++ b/src/shared/types/subscription.ts
@@ -1,13 +1,23 @@
-export type SubscriptionInterval = "month" | "year";
+export type SubscriptionInterval = 'month' | 'year';
 
 export type SubscriptionStatus =
-  | "active"
-  | "past_due"
-  | "canceled"
-  | "incomplete"
-  | "incomplete_expired"
-  | "trialing"
-  | "unpaid";
+  | 'active'
+  | 'past_due'
+  | 'canceled'
+  | 'incomplete'
+  | 'incomplete_expired'
+  | 'trialing'
+  | 'unpaid';
+
+export interface Payment {
+  id: string;
+  amount: number;
+  currency: string;
+  status: string;
+  campaignTitle: string | null;
+  createdAt: string | Date | { seconds: number; nanoseconds?: number } | null;
+  isGiftAid: boolean;
+}
 
 export interface Subscription {
   id: string;

--- a/src/views/manage/ManageCheckEmailScreen.tsx
+++ b/src/views/manage/ManageCheckEmailScreen.tsx
@@ -1,87 +1,122 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import { Button } from '@/shared/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
-import { Mail, ArrowLeft, Info } from 'lucide-react';
+import { Mail, ArrowLeft, Lock, CheckCircle, Loader2 } from 'lucide-react';
+import { FUNCTION_URLS } from '@/shared/config/functions';
 
 export function ManageCheckEmailScreen() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const email = searchParams.get('email') || '';
   const [resending, setResending] = useState(false);
+  const [resent, setResent] = useState(false);
+  const [error, setError] = useState('');
 
-  // Mask email for privacy (show first 4 chars and domain)
-  const maskEmail = (email: string) => {
-    if (!email) return '';
-    const [local, domain] = email.split('@');
-    if (!domain) return email;
-    const maskedLocal = local.length > 4 ? local.substring(0, 4) + '***' : local;
-    return `${maskedLocal}@${domain}`;
+  const maskEmail = (raw: string) => {
+    if (!raw) return '';
+    const [local, domain] = raw.split('@');
+    if (!domain) return raw;
+    const masked = local.length > 4 ? local.substring(0, 4) + '***' : local;
+    return `${masked}@${domain}`;
   };
 
   const handleResend = async () => {
     setResending(true);
+    setError('');
     try {
-      // TODO: Call API to resend magic link
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const response = await fetch(FUNCTION_URLS.sendSubscriptionMagicLink, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to resend link');
+      }
+
+      if (data.devLink) {
+        console.warn('Development Magic Link:', data.devLink);
+      }
+
+      setResent(true);
     } catch (err) {
       console.error('Error resending magic link:', err);
+      setError('Could not resend the link. Please try again.');
     } finally {
       setResending(false);
     }
   };
 
   return (
-    <div className="min-h-screen bg-[#f5f5f5] flex items-center justify-center px-4 py-6 sm:p-4">
+    <div className="min-h-screen bg-[#EEEFF3] flex items-center justify-center p-4">
       <div className="w-full max-w-md">
-        {/* Main Card */}
-        <Card className="shadow-sm bg-white">
-          <CardHeader className="text-center space-y-3 sm:space-y-4 pb-5 sm:pb-6 px-4 sm:px-6 pt-5 sm:pt-6">
-            <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-blue-100 mx-auto">
-              <Mail className="w-7 h-7 sm:w-8 sm:h-8 text-blue-600" />
+        {/* Card */}
+        <div className="bg-white rounded-2xl shadow-[0_2px_8px_rgba(0,0,0,0.08)] px-8 py-10">
+          {/* Icon */}
+          <div className="flex justify-center mb-7">
+            <div className="w-16 h-16 rounded-full bg-[#D1FAE5] flex items-center justify-center">
+              <Mail className="w-8 h-8 text-[#047857]" />
             </div>
-            <div>
-              <CardTitle className="text-xl sm:text-2xl font-bold mb-1.5 sm:mb-2 text-gray-900">
-                Check your email
-              </CardTitle>
-              <CardDescription className="text-sm sm:text-base text-gray-600">
-                We've sent a secure link to
-                <br />
-                <span className="font-medium text-gray-900">{maskEmail(email)}</span>
-              </CardDescription>
-            </div>
-          </CardHeader>
-          <CardContent className="space-y-4 sm:space-y-6 px-4 sm:px-6 pb-4 sm:pb-6">
-            {/* Info Notice */}
-            <div className="flex items-start gap-2.5 sm:gap-3 p-3 sm:p-4 bg-gray-50 rounded-lg border border-gray-200">
-              <Info className="w-4 h-4 sm:w-5 sm:h-5 text-gray-400 shrink-0 mt-0.5" />
-              <p className="text-xs sm:text-sm text-gray-600">
-                The link expires in 15 minutes and can be used once.
-              </p>
-            </div>
+          </div>
 
-            {/* Resend Button */}
-            <Button
-              variant="outline"
-              className="w-full h-11 sm:h-12 text-base"
-              onClick={handleResend}
-              disabled={resending}
-            >
-              {resending ? 'Sending...' : 'Resend link'}
-            </Button>
+          {/* Heading */}
+          <div className="text-center mb-8">
+            <h1 className="text-[28px] font-bold text-[#111827] leading-tight mb-3">
+              Check your email
+            </h1>
+            <p className="text-base text-[#6B7280] leading-relaxed">We sent a secure link to</p>
+            <p className="text-base font-semibold text-[#111827] mt-1">{maskEmail(email)}</p>
+          </div>
 
-            {/* Back to Login */}
+          {/* Actions */}
+          <div className="space-y-3">
+            {/* Resend / Sent state */}
+            {resent ? (
+              <div className="w-full h-14 flex items-center justify-center gap-2.5 rounded-xl bg-[#D1FAE5] border border-[#6EE7B7] text-[#047857] font-semibold text-base">
+                <CheckCircle className="w-5 h-5" />
+                Link sent — check your inbox
+              </div>
+            ) : (
+              <button
+                onClick={handleResend}
+                disabled={resending}
+                className="w-full h-14 flex items-center justify-center gap-2 border-2 border-[#047857] text-[#047857] hover:bg-[#047857] hover:text-white disabled:opacity-50 font-semibold text-base rounded-xl transition-colors"
+              >
+                {resending ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Sending…
+                  </>
+                ) : (
+                  'Resend link'
+                )}
+              </button>
+            )}
+
+            {error && <p className="text-sm text-red-600 text-center">{error}</p>}
+
+            {/* Back */}
             <button
               onClick={() => router.push('/manage')}
-              className="w-full flex items-center justify-center gap-2 text-sm text-emerald-600 hover:underline font-medium"
+              className="w-full h-12 flex items-center justify-center gap-2 text-sm font-medium text-[#6B7280] hover:text-[#111827] transition-colors"
             >
               <ArrowLeft className="w-4 h-4" />
               Back to login
             </button>
-          </CardContent>
-        </Card>
+          </div>
+
+          {/* Divider */}
+          <div className="my-7 border-t border-[#F3F4F6]" />
+
+          {/* Security note */}
+          <div className="flex items-start gap-3 text-sm text-[#9CA3AF]">
+            <Lock className="w-4 h-4 shrink-0 mt-0.5" />
+            <span>The link expires after 15 minutes and can only be used once.</span>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/views/manage/ManageCheckEmailScreen.tsx
+++ b/src/views/manage/ManageCheckEmailScreen.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Button } from '@/shared/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
+import { Mail, ArrowLeft, Info } from 'lucide-react';
+
+export function ManageCheckEmailScreen() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const email = searchParams.get('email') || '';
+  const [resending, setResending] = useState(false);
+
+  // Mask email for privacy (show first 4 chars and domain)
+  const maskEmail = (email: string) => {
+    if (!email) return '';
+    const [local, domain] = email.split('@');
+    if (!domain) return email;
+    const maskedLocal = local.length > 4 ? local.substring(0, 4) + '***' : local;
+    return `${maskedLocal}@${domain}`;
+  };
+
+  const handleResend = async () => {
+    setResending(true);
+    try {
+      // TODO: Call API to resend magic link
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    } catch (err) {
+      console.error('Error resending magic link:', err);
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f5f5f5] flex items-center justify-center px-4 py-6 sm:p-4">
+      <div className="w-full max-w-md">
+        {/* Main Card */}
+        <Card className="shadow-sm bg-white">
+          <CardHeader className="text-center space-y-3 sm:space-y-4 pb-5 sm:pb-6 px-4 sm:px-6 pt-5 sm:pt-6">
+            <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-blue-100 mx-auto">
+              <Mail className="w-7 h-7 sm:w-8 sm:h-8 text-blue-600" />
+            </div>
+            <div>
+              <CardTitle className="text-xl sm:text-2xl font-bold mb-1.5 sm:mb-2 text-gray-900">
+                Check your email
+              </CardTitle>
+              <CardDescription className="text-sm sm:text-base text-gray-600">
+                We've sent a secure link to
+                <br />
+                <span className="font-medium text-gray-900">{maskEmail(email)}</span>
+              </CardDescription>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4 sm:space-y-6 px-4 sm:px-6 pb-4 sm:pb-6">
+            {/* Info Notice */}
+            <div className="flex items-start gap-2.5 sm:gap-3 p-3 sm:p-4 bg-gray-50 rounded-lg border border-gray-200">
+              <Info className="w-4 h-4 sm:w-5 sm:h-5 text-gray-400 shrink-0 mt-0.5" />
+              <p className="text-xs sm:text-sm text-gray-600">
+                The link expires in 15 minutes and can be used once.
+              </p>
+            </div>
+
+            {/* Resend Button */}
+            <Button
+              variant="outline"
+              className="w-full h-11 sm:h-12 text-base"
+              onClick={handleResend}
+              disabled={resending}
+            >
+              {resending ? 'Sending...' : 'Resend link'}
+            </Button>
+
+            {/* Back to Login */}
+            <button
+              onClick={() => router.push('/manage')}
+              className="w-full flex items-center justify-center gap-2 text-sm text-emerald-600 hover:underline font-medium"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back to login
+            </button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/views/manage/ManageCheckEmailScreen.tsx
+++ b/src/views/manage/ManageCheckEmailScreen.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { Mail, ArrowLeft, Lock, CheckCircle, Loader2 } from 'lucide-react';
 import { FUNCTION_URLS } from '@/shared/config/functions';
 
 export function ManageCheckEmailScreen() {
-  const searchParams = useSearchParams();
   const router = useRouter();
-  const email = searchParams.get('email') || '';
+  const [email, setEmail] = useState('');
 
   useEffect(() => {
-    if (!email) router.replace('/manage');
-  }, [email, router]);
+    const stored = sessionStorage.getItem('pending_magic_link_email') || '';
+    if (!stored) {
+      router.replace('/manage');
+      return;
+    }
+    setEmail(stored);
+  }, [router]);
   const [resending, setResending] = useState(false);
   const [resent, setResent] = useState(false);
   const [error, setError] = useState('');

--- a/src/views/manage/ManageCheckEmailScreen.tsx
+++ b/src/views/manage/ManageCheckEmailScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { Mail, ArrowLeft, Lock, CheckCircle, Loader2 } from 'lucide-react';
 import { FUNCTION_URLS } from '@/shared/config/functions';
@@ -9,6 +9,10 @@ export function ManageCheckEmailScreen() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const email = searchParams.get('email') || '';
+
+  useEffect(() => {
+    if (!email) router.replace('/manage');
+  }, [email, router]);
   const [resending, setResending] = useState(false);
   const [resent, setResent] = useState(false);
   const [error, setError] = useState('');

--- a/src/views/manage/ManageDashboardScreen.tsx
+++ b/src/views/manage/ManageDashboardScreen.tsx
@@ -104,7 +104,7 @@ export function ManageDashboardScreen() {
 
       if (!auth.currentUser) {
         await new Promise((resolve, reject) => {
-          const timeout = setTimeout(() => reject(new Error('Auth timeout')), 5000);
+          const timeout = setTimeout(() => reject(new Error('Auth timeout')), 10000);
           const unsubscribe = auth.onAuthStateChanged((user) => {
             clearTimeout(timeout);
             unsubscribe();

--- a/src/views/manage/ManageDashboardScreen.tsx
+++ b/src/views/manage/ManageDashboardScreen.tsx
@@ -166,7 +166,14 @@ export function ManageDashboardScreen() {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${idToken}` },
             body: JSON.stringify({ subscriptionId: sub.id }),
-          }).then((r) => (r.ok ? r.json() : { payments: [] })),
+          }).then((r) => {
+            if (r.status === 401 || r.status === 403) {
+              const err = new Error('SESSION_EXPIRED');
+              err.cause = r.status;
+              throw err;
+            }
+            return r.ok ? r.json() : { payments: [] };
+          }),
         ),
       );
 
@@ -187,8 +194,12 @@ export function ManageDashboardScreen() {
 
       setPayments(all);
       setHistoryLoaded(true);
-    } catch {
-      setHistoryError('Could not load payment history. Please try again.');
+    } catch (err) {
+      if (err instanceof Error && err.message === 'SESSION_EXPIRED') {
+        setError('Session expired. Please request a new link.');
+      } else {
+        setHistoryError('Could not load payment history. Please try again.');
+      }
     } finally {
       setHistoryLoading(false);
     }
@@ -229,10 +240,13 @@ export function ManageDashboardScreen() {
       }
 
       const data = await res.json();
-      if (data.url) {
-        // Keep the overlay up until the browser has navigated away
-        window.location.href = data.url;
+      if (typeof data?.url !== 'string' || !data.url.trim()) {
+        setError('Failed to open subscription management. Please try again.');
+        setManagingId(null);
+        return;
       }
+      // Keep the overlay up until the browser has navigated away
+      window.location.href = data.url;
     } catch {
       setError('Failed to open subscription management. Please try again.');
       setManagingId(null);

--- a/src/views/manage/ManageDashboardScreen.tsx
+++ b/src/views/manage/ManageDashboardScreen.tsx
@@ -1,136 +1,244 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent } from '@/shared/ui/card';
-import { HandHeart, Loader2, ArrowLeft, Heart, FileText, Shield } from 'lucide-react';
+import { HandHeart, Loader2, ArrowLeft, Shield, CheckCircle, Heart, FileText } from 'lucide-react';
 import { SubscriptionCard } from '@/features/subscription-management/ui/SubscriptionCard';
-import type { Subscription } from '@/shared/types/subscription';
+import type { Subscription, Payment } from '@/shared/types/subscription';
+import { FUNCTION_URLS } from '@/shared/config/functions';
+
+// ---------------------------------------------------------------------------
+// SummaryCard
+// ---------------------------------------------------------------------------
+
+interface SummaryCardProps {
+  subscriptions: Subscription[];
+}
+
+function SummaryCard({ subscriptions }: SummaryCardProps) {
+  const active = subscriptions.filter((s) => s.status === 'active' || s.status === 'trialing');
+  const currency = subscriptions[0]?.currency?.toUpperCase() || 'GBP';
+
+  const intervals = [...new Set(active.map((s) => s.interval))];
+  const label =
+    intervals.length === 1 && intervals[0] === 'year'
+      ? 'Total yearly donations'
+      : intervals.length === 1 && intervals[0] === 'month'
+        ? 'Total monthly donations'
+        : 'Total active donations';
+
+  const total = active.reduce((sum, s) => sum + s.amount, 0);
+  const formatted = new Intl.NumberFormat('en-GB', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0,
+  }).format(total / 100);
+
+  return (
+    <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
+      <CardContent className="p-5 space-y-1">
+        <p className="text-xs text-[#6B7280] uppercase tracking-wide font-medium">{label}</p>
+        <p className="text-4xl font-bold text-[#111827]">{formatted}</p>
+        <p className="text-xs text-[#6B7280] pt-1">
+          {active.length} active {active.length === 1 ? 'subscription' : 'subscriptions'}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const getIdToken = async () => {
+  const { getAuth } = await import('firebase/auth');
+  const auth = getAuth();
+  if (!auth.currentUser) throw new Error('Not authenticated');
+  return auth.currentUser.getIdToken();
+};
+
+const formatPaymentDate = (
+  ts: string | Date | { seconds: number; nanoseconds?: number } | null | undefined,
+) => {
+  if (!ts) return null;
+  let date: Date;
+  if (typeof ts === 'string') date = new Date(ts);
+  else if (ts instanceof Date) date = ts;
+  else if (typeof ts === 'object' && 'seconds' in ts) date = new Date(ts.seconds * 1000);
+  else return null;
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+};
+
+// ---------------------------------------------------------------------------
+// ManageDashboardScreen
+// ---------------------------------------------------------------------------
 
 export function ManageDashboardScreen() {
   const router = useRouter();
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [userEmail] = useState('r***@gmail.com'); // TODO: Get from auth
+  const [userEmail, setUserEmail] = useState('');
+  const [activeTab, setActiveTab] = useState<'donations' | 'history'>('donations');
 
-  useEffect(() => {
-    loadSubscriptions();
-  }, []);
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState('');
+  const [historyLoaded, setHistoryLoaded] = useState(false);
 
-  const loadSubscriptions = async () => {
+  // -------------------------------------------------------------------------
+  // Load subscriptions
+  // -------------------------------------------------------------------------
+  const loadSubscriptions = useCallback(async () => {
     try {
       setLoading(true);
       setError('');
 
-      // TODO: Replace with actual API endpoint
-      const response = await fetch('/api/subscriptions', {
+      const { getAuth } = await import('firebase/auth');
+      const auth = getAuth();
+
+      if (!auth.currentUser) {
+        await new Promise((resolve, reject) => {
+          const timeout = setTimeout(() => reject(new Error('Auth timeout')), 5000);
+          const unsubscribe = auth.onAuthStateChanged((user) => {
+            clearTimeout(timeout);
+            unsubscribe();
+            if (user) resolve(user);
+            else reject(new Error('Not authenticated'));
+          });
+        });
+      }
+
+      const idToken = await auth.currentUser!.getIdToken();
+      setUserEmail(auth.currentUser!.email || sessionStorage.getItem('donor_email') || '');
+
+      const res = await fetch(FUNCTION_URLS.getSubscriptionsByEmail, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${idToken}` },
       });
 
-      if (!response.ok) {
+      if (!res.ok) {
+        if (res.status === 401) {
+          setError('Session expired. Please request a new link.');
+          sessionStorage.removeItem('donor_auth_token');
+          sessionStorage.removeItem('donor_email');
+          return;
+        }
         throw new Error('Failed to fetch subscriptions');
       }
 
-      const data = await response.json();
+      const data = await res.json();
       setSubscriptions(data.subscriptions || []);
     } catch (err) {
-      setError('Failed to load subscriptions. Please try again.');
-      console.error('Error loading subscriptions:', err);
+      if (err instanceof Error && err.message === 'Not authenticated') {
+        setError('Session expired. Please request a new link.');
+        sessionStorage.removeItem('donor_auth_token');
+        sessionStorage.removeItem('donor_email');
+      } else {
+        setError('Failed to load subscriptions. Please try again.');
+      }
     } finally {
       setLoading(false);
     }
+  }, []);
+
+  useEffect(() => {
+    loadSubscriptions();
+  }, [loadSubscriptions]);
+
+  // -------------------------------------------------------------------------
+  // Load payment history
+  // -------------------------------------------------------------------------
+  const loadPaymentHistory = useCallback(async (subs: Subscription[]) => {
+    if (subs.length === 0) return;
+    setHistoryLoading(true);
+    setHistoryError('');
+    try {
+      const idToken = await getIdToken();
+      const results = await Promise.all(
+        subs.map((sub) =>
+          fetch(FUNCTION_URLS.getPaymentHistory, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${idToken}` },
+            body: JSON.stringify({ subscriptionId: sub.id }),
+          }).then((r) => (r.ok ? r.json() : { payments: [] })),
+        ),
+      );
+
+      const seen = new Set<string>();
+      const all: Payment[] = results
+        .flatMap((r) => r.payments || [])
+        .filter((p) => (seen.has(p.id) ? false : (seen.add(p.id), true)));
+      all.sort((a, b) => {
+        const toMs = (ts: Payment['createdAt']) => {
+          if (!ts) return 0;
+          if (typeof ts === 'string') return new Date(ts).getTime();
+          if (ts instanceof Date) return ts.getTime();
+          if ('seconds' in ts) return ts.seconds * 1000;
+          return 0;
+        };
+        return toMs(b.createdAt) - toMs(a.createdAt);
+      });
+
+      setPayments(all);
+      setHistoryLoaded(true);
+    } catch {
+      setHistoryError('Could not load payment history. Please try again.');
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, []);
+
+  const handleTabChange = (tab: 'donations' | 'history') => {
+    setActiveTab(tab);
+    if (tab === 'history' && !historyLoaded && subscriptions.length > 0) {
+      loadPaymentHistory(subscriptions);
+    }
   };
 
+  // -------------------------------------------------------------------------
+  // Manage subscription → Stripe portal
+  // -------------------------------------------------------------------------
   const handleManageSubscription = async (subscriptionId: string) => {
     try {
-      // Call API to create Stripe portal session
-      const response = await fetch('/api/subscriptions/portal', {
+      const idToken = await getIdToken();
+      const res = await fetch(FUNCTION_URLS.createCustomerPortalSession, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${idToken}` },
         body: JSON.stringify({ subscriptionId }),
       });
 
-      if (!response.ok) {
+      if (!res.ok) {
+        if (res.status === 401) {
+          setError('Session expired. Please request a new link.');
+          return;
+        }
+        if (res.status === 403) {
+          setError('You do not have permission to manage this subscription.');
+          return;
+        }
         throw new Error('Failed to create portal session');
       }
 
-      const data = await response.json();
-
-      // Redirect to Stripe portal
-      if (data.url) {
-        window.location.href = data.url;
-      }
-    } catch (err) {
-      console.error('Error creating portal session:', err);
+      const data = await res.json();
+      if (data.url) window.location.href = data.url;
+    } catch {
       setError('Failed to open subscription management. Please try again.');
     }
   };
 
-  // Calculate total monthly donations
-  const calculateMonthlyTotal = () => {
-    const activeSubscriptions = subscriptions.filter((sub) => sub.status === 'active');
-    const total = activeSubscriptions.reduce((sum, sub) => sum + sub.amount, 0);
-    return total;
-  };
-
-  // Get next charge date
-  const getNextChargeDate = () => {
-    const activeSubscriptions = subscriptions.filter(
-      (sub) => sub.status === 'active' && sub.nextPaymentAt,
-    );
-    if (activeSubscriptions.length === 0) return null;
-
-    const nextDates = activeSubscriptions
-      .map((sub) => {
-        if (
-          sub.nextPaymentAt &&
-          typeof sub.nextPaymentAt === 'object' &&
-          'seconds' in sub.nextPaymentAt
-        ) {
-          return new Date(sub.nextPaymentAt.seconds * 1000);
-        }
-        return null;
-      })
-      .filter((date) => date !== null) as Date[];
-
-    if (nextDates.length === 0) return null;
-    return new Date(Math.min(...nextDates.map((d) => d.getTime())));
-  };
-
-  const formatCurrency = (amount: number) => {
-    return `£${(amount / 100).toFixed(0)}`;
-  };
-
-  const formatDate = (date: Date) => {
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  };
-
-  const getDaysUntil = (date: Date) => {
-    const today = new Date();
-    const diffTime = date.getTime() - today.getTime();
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    return diffDays;
-  };
-
-  const monthlyTotal = calculateMonthlyTotal();
-  const nextChargeDate = getNextChargeDate();
-
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
   return (
-    <div className="min-h-screen bg-[#EEEFF3] pb-24">
-      {/* Header - Material Design Style */}
+    <div className="min-h-screen bg-[#EEEFF3] pb-24 lg:pb-12">
+      {/* Header */}
       <div className="bg-white border-b border-[#e0e0e0] sticky top-0 z-10">
-        <div className="max-w-2xl mx-auto px-4 pt-4 pb-3">
+        <div className="max-w-7xl mx-auto px-4 lg:px-10 pt-4 pb-3">
           <div className="flex items-center gap-3 mb-1">
             <button
               onClick={() => router.push('/manage')}
@@ -140,106 +248,275 @@ export function ManageDashboardScreen() {
               <ArrowLeft className="w-5 h-5" />
             </button>
             <h1 className="text-[20px] font-medium text-[#202124] leading-tight">Your donations</h1>
+            {/* Email in header on desktop */}
+            <p className="hidden lg:block text-sm text-[#5f6368] ml-auto">{userEmail}</p>
           </div>
-          <p className="text-[13px] text-[#5f6368] ml-11">{userEmail}</p>
+          {/* Email below title on mobile */}
+          <p className="lg:hidden text-[13px] text-[#5f6368] ml-11">{userEmail}</p>
         </div>
       </div>
 
-      {/* Main Content */}
-      <div className="max-w-2xl mx-auto px-4 pt-6 pb-6">
+      {/* Body */}
+      <div className="max-w-7xl mx-auto px-4 lg:px-10 pt-6">
         {loading ? (
-          <div className="flex items-center justify-center py-12">
+          <div className="flex items-center justify-center py-24">
             <Loader2 className="w-8 h-8 animate-spin text-emerald-600" />
           </div>
         ) : error ? (
-          <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
-            <CardContent className="pt-6 px-6 pb-6">
-              <div className="text-center space-y-4">
-                <p className="text-sm text-red-600">{error}</p>
+          <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 max-w-md mx-auto">
+            <CardContent className="pt-6 px-6 pb-6 text-center space-y-4">
+              <p className="text-sm text-red-600">{error}</p>
+              {error.includes('Session expired') ? (
+                <Button
+                  onClick={() => router.push('/manage')}
+                  className="h-11 bg-[#047857] hover:bg-[#065f46] text-white"
+                >
+                  Request new link
+                </Button>
+              ) : (
                 <Button onClick={loadSubscriptions} variant="outline" className="h-11">
                   Try Again
                 </Button>
-              </div>
+              )}
             </CardContent>
           </Card>
         ) : subscriptions.length === 0 ? (
-          <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
-            <CardContent className="pt-8 px-6 pb-8">
-              <div className="text-center space-y-6">
-                <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gray-100">
-                  <HandHeart className="w-10 h-10 text-gray-300" />
-                </div>
-                <div>
-                  <h3 className="text-xl font-bold text-gray-900 mb-2">
-                    No active donations found
-                  </h3>
-                  <p className="text-sm text-gray-600 max-w-sm mx-auto">
-                    If you've donated before, try using a different email address or contact support
-                    for assistance in locating your records.
-                  </p>
-                </div>
+          <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 max-w-md mx-auto">
+            <CardContent className="pt-8 px-6 pb-8 text-center space-y-6">
+              <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gray-100">
+                <HandHeart className="w-10 h-10 text-gray-300" />
+              </div>
+              <div>
+                <h3 className="text-xl font-bold text-gray-900 mb-2">No subscriptions found</h3>
+                <p className="text-sm text-gray-600 max-w-sm mx-auto">
+                  If you've donated before, try a different email address or contact support.
+                </p>
               </div>
             </CardContent>
           </Card>
         ) : (
-          <>
-            {/* Summary Card */}
-            <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)] mb-4">
-              <CardContent className="p-4">
-                <div className="space-y-2">
-                  <p className="text-xs text-[#6B7280] uppercase tracking-wide font-medium">
-                    Total monthly donations
-                  </p>
-                  <p className="text-4xl font-bold text-[#111827]">
-                    {formatCurrency(monthlyTotal)}
-                  </p>
-                  {nextChargeDate && (
-                    <p className="text-sm text-[#374151] pt-2">
-                      Next total charge:{' '}
-                      <span className="font-medium">{formatDate(nextChargeDate)}</span>
-                      {getDaysUntil(nextChargeDate) <= 7 && (
-                        <span className="text-[#6B7280]">
-                          {' '}
-                          · in {getDaysUntil(nextChargeDate)} days
-                        </span>
-                      )}
-                    </p>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
+          /* ----------------------------------------------------------------
+             Main layout: sidebar (desktop) + content
+          ---------------------------------------------------------------- */
+          <div className="lg:flex lg:gap-8 lg:items-start">
+            {/* ---- Sidebar (desktop only) ---- */}
+            <aside className="hidden lg:flex lg:flex-col lg:w-72 xl:w-80 shrink-0 gap-4 sticky top-24">
+              <SummaryCard subscriptions={subscriptions} />
 
-            {/* Subscription Cards */}
-            <div className="space-y-3">
-              {subscriptions.map((subscription) => (
-                <SubscriptionCard
-                  key={subscription.id}
-                  subscription={subscription}
-                  onManage={handleManageSubscription}
-                />
-              ))}
-            </div>
+              {/* Desktop tab nav */}
+              <nav className="bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)] overflow-hidden">
+                <button
+                  onClick={() => handleTabChange('donations')}
+                  className={`w-full flex items-center gap-3 px-5 py-4 text-sm font-medium transition-colors border-b border-gray-100 ${
+                    activeTab === 'donations'
+                      ? 'bg-[#E8F5F1] text-[#047857]'
+                      : 'text-[#374151] hover:bg-gray-50'
+                  }`}
+                >
+                  <Heart className={`w-4 h-4 ${activeTab === 'donations' ? 'fill-current' : ''}`} />
+                  Donations
+                  <span className="ml-auto text-xs font-semibold bg-[#F3F4F6] text-[#6B7280] px-2 py-0.5 rounded-full">
+                    {subscriptions.length}
+                  </span>
+                </button>
+                <button
+                  onClick={() => handleTabChange('history')}
+                  className={`w-full flex items-center gap-3 px-5 py-4 text-sm font-medium transition-colors ${
+                    activeTab === 'history'
+                      ? 'bg-[#E8F5F1] text-[#047857]'
+                      : 'text-[#374151] hover:bg-gray-50'
+                  }`}
+                >
+                  <FileText className="w-4 h-4" />
+                  Payment History
+                </button>
+              </nav>
 
-            {/* Trust Indicator */}
-            <div className="mt-6 text-center">
-              <div className="inline-flex items-center gap-2 text-xs text-gray-500">
-                <Shield className="w-4 h-4" />
+              <div className="flex items-center gap-2 text-xs text-gray-400 px-1">
+                <Shield className="w-3.5 h-3.5 shrink-0" />
                 <span>Donations are securely processed by Stripe</span>
               </div>
+            </aside>
+
+            {/* ---- Main content ---- */}
+            <div className="flex-1 min-w-0 space-y-3">
+              {/* Summary card — mobile only (shown inline above cards) */}
+              <div className="lg:hidden">
+                <SummaryCard subscriptions={subscriptions} />
+              </div>
+
+              {activeTab === 'donations' ? (
+                <>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    {subscriptions.map((sub) => (
+                      <SubscriptionCard
+                        key={sub.id}
+                        subscription={sub}
+                        onManage={handleManageSubscription}
+                      />
+                    ))}
+                  </div>
+
+                  {/* Stripe badge — mobile only (desktop has it in sidebar) */}
+                  <div className="mt-4 text-center lg:hidden">
+                    <div className="inline-flex items-center gap-2 text-xs text-gray-400">
+                      <Shield className="w-4 h-4" />
+                      <span>Donations are securely processed by Stripe</span>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                /* Payment History */
+                <div className="space-y-3">
+                  {historyLoading ? (
+                    <div className="flex items-center justify-center py-16">
+                      <Loader2 className="w-8 h-8 animate-spin text-emerald-600" />
+                    </div>
+                  ) : historyError ? (
+                    <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200">
+                      <CardContent className="pt-6 px-6 pb-6 text-center space-y-3">
+                        <p className="text-sm text-red-600">{historyError}</p>
+                        <Button
+                          onClick={() => loadPaymentHistory(subscriptions)}
+                          variant="outline"
+                          className="h-10"
+                        >
+                          Try Again
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  ) : payments.length === 0 ? (
+                    <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200">
+                      <CardContent className="pt-8 px-6 pb-8 text-center space-y-3">
+                        <FileText className="w-10 h-10 text-gray-300 mx-auto" />
+                        <p className="text-sm text-gray-600">No payments recorded yet.</p>
+                      </CardContent>
+                    </Card>
+                  ) : (
+                    <>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-[#6B7280] px-1">
+                        {payments.length} {payments.length === 1 ? 'payment' : 'payments'}
+                      </p>
+
+                      {/* Mobile: stacked cards — Desktop: table-style card */}
+                      <div className="hidden lg:block bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)] overflow-hidden">
+                        <div className="grid grid-cols-[1fr_auto_auto] text-xs font-semibold uppercase tracking-wide text-[#6B7280] px-6 py-3 border-b border-gray-100 bg-gray-50">
+                          <span>Campaign</span>
+                          <span className="text-right pr-8">Date</span>
+                          <span className="text-right">Amount</span>
+                        </div>
+                        {payments.map((payment) => (
+                          <div
+                            key={payment.id}
+                            className="grid grid-cols-[1fr_auto_auto] items-center px-6 py-4 border-b border-gray-100 last:border-0 hover:bg-gray-50 transition-colors"
+                          >
+                            <div className="min-w-0 pr-4">
+                              <p className="text-sm font-medium text-[#111827] truncate">
+                                {payment.campaignTitle || 'Donation'}
+                              </p>
+                              {payment.isGiftAid && (
+                                <span className="text-[11px] text-[#047857] font-medium">
+                                  + Gift Aid
+                                </span>
+                              )}
+                            </div>
+                            <p className="text-sm text-[#6B7280] pr-8 tabular-nums">
+                              {formatPaymentDate(payment.createdAt) ?? 'N/A'}
+                            </p>
+                            <div className="text-right">
+                              <p className="text-sm font-bold text-[#111827] tabular-nums">
+                                {new Intl.NumberFormat('en-GB', {
+                                  style: 'currency',
+                                  currency: payment.currency?.toUpperCase() || 'GBP',
+                                  maximumFractionDigits: 2,
+                                }).format(payment.amount / 100)}
+                              </p>
+                              <span className="inline-flex items-center gap-1 text-xs text-[#137333]">
+                                <CheckCircle className="w-3 h-3" />
+                                Paid
+                              </span>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+
+                      {/* Mobile stacked cards */}
+                      <div className="lg:hidden space-y-2">
+                        {payments.map((payment) => (
+                          <div
+                            key={payment.id}
+                            className="flex items-center justify-between px-4 py-3.5 gap-3 bg-white rounded-2xl border border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
+                          >
+                            <div className="min-w-0 flex-1">
+                              <p className="text-sm font-medium text-[#111827]">
+                                {formatPaymentDate(payment.createdAt) ?? 'N/A'}
+                              </p>
+                              {payment.campaignTitle && (
+                                <p className="text-xs text-[#6B7280] truncate mt-0.5">
+                                  {payment.campaignTitle}
+                                </p>
+                              )}
+                            </div>
+                            <div className="text-right shrink-0 space-y-0.5">
+                              <p className="text-sm font-bold text-[#111827] tabular-nums">
+                                {new Intl.NumberFormat('en-GB', {
+                                  style: 'currency',
+                                  currency: payment.currency?.toUpperCase() || 'GBP',
+                                  maximumFractionDigits: 2,
+                                }).format(payment.amount / 100)}
+                              </p>
+                              <div className="flex items-center justify-end gap-1.5">
+                                <span className="inline-flex items-center gap-1 text-xs text-[#137333]">
+                                  <CheckCircle className="w-3 h-3" />
+                                  Paid
+                                </span>
+                                {payment.isGiftAid && (
+                                  <span className="text-[10px] text-[#6B7280]">· Gift Aid</span>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+
+                      <div className="mt-4 text-center lg:hidden">
+                        <div className="inline-flex items-center gap-2 text-xs text-gray-400">
+                          <Shield className="w-4 h-4" />
+                          <span>Donations are securely processed by Stripe</span>
+                        </div>
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
             </div>
-          </>
+          </div>
         )}
       </div>
 
-      {/* Bottom Navigation */}
-      <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">
+      {/* Bottom nav — mobile only */}
+      <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">
         <div className="max-w-2xl mx-auto px-4">
           <div className="grid grid-cols-2 gap-1 py-2">
-            <button className="flex flex-col items-center gap-1 py-2 px-4 rounded-lg bg-[#E8F5F1] text-[#047857]">
-              <Heart className="w-5 h-5 fill-current" />
+            <button
+              onClick={() => handleTabChange('donations')}
+              className={`flex flex-col items-center gap-1 py-2 px-4 rounded-lg transition-colors ${
+                activeTab === 'donations'
+                  ? 'bg-[#E8F5F1] text-[#047857]'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              <Heart className={`w-5 h-5 ${activeTab === 'donations' ? 'fill-current' : ''}`} />
               <span className="text-xs font-medium">Donations</span>
             </button>
-            <button className="flex flex-col items-center gap-1 py-2 px-4 text-gray-500 hover:text-gray-700">
+            <button
+              onClick={() => handleTabChange('history')}
+              className={`flex flex-col items-center gap-1 py-2 px-4 rounded-lg transition-colors ${
+                activeTab === 'history'
+                  ? 'bg-[#E8F5F1] text-[#047857]'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
               <FileText className="w-5 h-5" />
               <span className="text-xs font-medium">Payment History</span>
             </button>

--- a/src/views/manage/ManageDashboardScreen.tsx
+++ b/src/views/manage/ManageDashboardScreen.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/shared/ui/button';
+import { Card, CardContent } from '@/shared/ui/card';
+import { HandHeart, Loader2, ArrowLeft, Heart, FileText, Shield } from 'lucide-react';
+import { SubscriptionCard } from '@/features/subscription-management/ui/SubscriptionCard';
+import type { Subscription } from '@/shared/types/subscription';
+
+export function ManageDashboardScreen() {
+  const router = useRouter();
+  const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [userEmail] = useState('r***@gmail.com'); // TODO: Get from auth
+
+  useEffect(() => {
+    loadSubscriptions();
+  }, []);
+
+  const loadSubscriptions = async () => {
+    try {
+      setLoading(true);
+      setError('');
+
+      // TODO: Replace with actual API endpoint
+      const response = await fetch('/api/subscriptions', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch subscriptions');
+      }
+
+      const data = await response.json();
+      setSubscriptions(data.subscriptions || []);
+    } catch (err) {
+      setError('Failed to load subscriptions. Please try again.');
+      console.error('Error loading subscriptions:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleManageSubscription = async (subscriptionId: string) => {
+    try {
+      // Call API to create Stripe portal session
+      const response = await fetch('/api/subscriptions/portal', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ subscriptionId }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to create portal session');
+      }
+
+      const data = await response.json();
+
+      // Redirect to Stripe portal
+      if (data.url) {
+        window.location.href = data.url;
+      }
+    } catch (err) {
+      console.error('Error creating portal session:', err);
+      setError('Failed to open subscription management. Please try again.');
+    }
+  };
+
+  // Calculate total monthly donations
+  const calculateMonthlyTotal = () => {
+    const activeSubscriptions = subscriptions.filter((sub) => sub.status === 'active');
+    const total = activeSubscriptions.reduce((sum, sub) => sum + sub.amount, 0);
+    return total;
+  };
+
+  // Get next charge date
+  const getNextChargeDate = () => {
+    const activeSubscriptions = subscriptions.filter(
+      (sub) => sub.status === 'active' && sub.nextPaymentAt,
+    );
+    if (activeSubscriptions.length === 0) return null;
+
+    const nextDates = activeSubscriptions
+      .map((sub) => {
+        if (
+          sub.nextPaymentAt &&
+          typeof sub.nextPaymentAt === 'object' &&
+          'seconds' in sub.nextPaymentAt
+        ) {
+          return new Date(sub.nextPaymentAt.seconds * 1000);
+        }
+        return null;
+      })
+      .filter((date) => date !== null) as Date[];
+
+    if (nextDates.length === 0) return null;
+    return new Date(Math.min(...nextDates.map((d) => d.getTime())));
+  };
+
+  const formatCurrency = (amount: number) => {
+    return `£${(amount / 100).toFixed(0)}`;
+  };
+
+  const formatDate = (date: Date) => {
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const getDaysUntil = (date: Date) => {
+    const today = new Date();
+    const diffTime = date.getTime() - today.getTime();
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    return diffDays;
+  };
+
+  const monthlyTotal = calculateMonthlyTotal();
+  const nextChargeDate = getNextChargeDate();
+
+  return (
+    <div className="min-h-screen bg-[#EEEFF3] pb-24">
+      {/* Header - Material Design Style */}
+      <div className="bg-white border-b border-[#e0e0e0] sticky top-0 z-10">
+        <div className="max-w-2xl mx-auto px-4 pt-4 pb-3">
+          <div className="flex items-center gap-3 mb-1">
+            <button
+              onClick={() => router.push('/manage')}
+              className="flex items-center justify-center w-10 h-10 -ml-2 text-[#5f6368] hover:bg-gray-100 rounded-full transition-colors"
+              aria-label="Go back"
+            >
+              <ArrowLeft className="w-5 h-5" />
+            </button>
+            <h1 className="text-[20px] font-medium text-[#202124] leading-tight">Your donations</h1>
+          </div>
+          <p className="text-[13px] text-[#5f6368] ml-11">{userEmail}</p>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="max-w-2xl mx-auto px-4 pt-6 pb-6">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="w-8 h-8 animate-spin text-emerald-600" />
+          </div>
+        ) : error ? (
+          <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
+            <CardContent className="pt-6 px-6 pb-6">
+              <div className="text-center space-y-4">
+                <p className="text-sm text-red-600">{error}</p>
+                <Button onClick={loadSubscriptions} variant="outline" className="h-11">
+                  Try Again
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ) : subscriptions.length === 0 ? (
+          <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
+            <CardContent className="pt-8 px-6 pb-8">
+              <div className="text-center space-y-6">
+                <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gray-100">
+                  <HandHeart className="w-10 h-10 text-gray-300" />
+                </div>
+                <div>
+                  <h3 className="text-xl font-bold text-gray-900 mb-2">
+                    No active donations found
+                  </h3>
+                  <p className="text-sm text-gray-600 max-w-sm mx-auto">
+                    If you've donated before, try using a different email address or contact support
+                    for assistance in locating your records.
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            {/* Summary Card */}
+            <Card className="bg-white rounded-2xl border-[1.5px] border-gray-200 shadow-[0_1px_2px_rgba(0,0,0,0.04)] mb-4">
+              <CardContent className="p-4">
+                <div className="space-y-2">
+                  <p className="text-xs text-[#6B7280] uppercase tracking-wide font-medium">
+                    Total monthly donations
+                  </p>
+                  <p className="text-4xl font-bold text-[#111827]">
+                    {formatCurrency(monthlyTotal)}
+                  </p>
+                  {nextChargeDate && (
+                    <p className="text-sm text-[#374151] pt-2">
+                      Next total charge:{' '}
+                      <span className="font-medium">{formatDate(nextChargeDate)}</span>
+                      {getDaysUntil(nextChargeDate) <= 7 && (
+                        <span className="text-[#6B7280]">
+                          {' '}
+                          · in {getDaysUntil(nextChargeDate)} days
+                        </span>
+                      )}
+                    </p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Subscription Cards */}
+            <div className="space-y-3">
+              {subscriptions.map((subscription) => (
+                <SubscriptionCard
+                  key={subscription.id}
+                  subscription={subscription}
+                  onManage={handleManageSubscription}
+                />
+              ))}
+            </div>
+
+            {/* Trust Indicator */}
+            <div className="mt-6 text-center">
+              <div className="inline-flex items-center gap-2 text-xs text-gray-500">
+                <Shield className="w-4 h-4" />
+                <span>Donations are securely processed by Stripe</span>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Bottom Navigation */}
+      <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">
+        <div className="max-w-2xl mx-auto px-4">
+          <div className="grid grid-cols-2 gap-1 py-2">
+            <button className="flex flex-col items-center gap-1 py-2 px-4 rounded-lg bg-[#E8F5F1] text-[#047857]">
+              <Heart className="w-5 h-5 fill-current" />
+              <span className="text-xs font-medium">Donations</span>
+            </button>
+            <button className="flex flex-col items-center gap-1 py-2 px-4 text-gray-500 hover:text-gray-700">
+              <FileText className="w-5 h-5" />
+              <span className="text-xs font-medium">Payment History</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/views/manage/ManageDashboardScreen.tsx
+++ b/src/views/manage/ManageDashboardScreen.tsx
@@ -84,6 +84,7 @@ export function ManageDashboardScreen() {
   const [error, setError] = useState('');
   const [userEmail, setUserEmail] = useState('');
   const [activeTab, setActiveTab] = useState<'donations' | 'history'>('donations');
+  const [managingId, setManagingId] = useState<string | null>(null);
 
   const [payments, setPayments] = useState<Payment[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
@@ -204,6 +205,7 @@ export function ManageDashboardScreen() {
   // Manage subscription → Stripe portal
   // -------------------------------------------------------------------------
   const handleManageSubscription = async (subscriptionId: string) => {
+    setManagingId(subscriptionId);
     try {
       const idToken = await getIdToken();
       const res = await fetch(FUNCTION_URLS.createCustomerPortalSession, {
@@ -215,19 +217,25 @@ export function ManageDashboardScreen() {
       if (!res.ok) {
         if (res.status === 401) {
           setError('Session expired. Please request a new link.');
+          setManagingId(null);
           return;
         }
         if (res.status === 403) {
           setError('You do not have permission to manage this subscription.');
+          setManagingId(null);
           return;
         }
         throw new Error('Failed to create portal session');
       }
 
       const data = await res.json();
-      if (data.url) window.location.href = data.url;
+      if (data.url) {
+        // Keep the overlay up until the browser has navigated away
+        window.location.href = data.url;
+      }
     } catch {
       setError('Failed to open subscription management. Please try again.');
+      setManagingId(null);
     }
   };
 
@@ -493,6 +501,19 @@ export function ManageDashboardScreen() {
           </div>
         )}
       </div>
+
+      {/* Full-screen loading overlay — shown while opening Stripe portal */}
+      {managingId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#EEEFF3]">
+          <div className="text-center">
+            <Loader2 className="w-12 h-12 animate-spin text-emerald-600 mx-auto mb-4" />
+            <h2 className="text-2xl font-bold text-gray-800 mb-2">Redirecting to Stripe…</h2>
+            <p className="text-gray-500">
+              You'll be taken to a secure page to manage your donation
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Bottom nav — mobile only */}
       <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">

--- a/src/views/manage/ManageDashboardScreen.tsx
+++ b/src/views/manage/ManageDashboardScreen.tsx
@@ -172,7 +172,10 @@ export function ManageDashboardScreen() {
               err.cause = r.status;
               throw err;
             }
-            return r.ok ? r.json() : { payments: [] };
+            if (!r.ok) {
+              throw new Error(`PAYMENT_HISTORY_${r.status}`);
+            }
+            return r.json();
           }),
         ),
       );

--- a/src/views/manage/ManageEmailScreen.tsx
+++ b/src/views/manage/ManageEmailScreen.tsx
@@ -1,12 +1,30 @@
 'use client';
 
 import React, { useState } from 'react';
+import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
 import { Label } from '@/shared/ui/label';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
-import { Mail, HandHeart, ArrowRight, Lock } from 'lucide-react';
+import { Mail, ArrowRight, Lock, ShieldCheck, Zap, HeartHandshake, Loader2 } from 'lucide-react';
+import { FUNCTION_URLS } from '@/shared/config/functions';
+
+const FEATURES = [
+  {
+    icon: ShieldCheck,
+    title: 'Secure & private',
+    description: 'One-time link expires after 15 minutes. No password ever stored.',
+  },
+  {
+    icon: Zap,
+    title: 'Instant access',
+    description: 'Click the link in your email to see all your active donations instantly.',
+  },
+  {
+    icon: HeartHandshake,
+    title: 'Full control',
+    description: 'Update payment details or cancel any subscription directly from your dashboard.',
+  },
+];
 
 export function ManageEmailScreen() {
   const router = useRouter();
@@ -20,12 +38,22 @@ export function ManageEmailScreen() {
     setLoading(true);
 
     try {
-      // TODO: Call API to send magic link
+      const response = await fetch(FUNCTION_URLS.sendSubscriptionMagicLink, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
 
-      // Simulate API call
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const data = await response.json();
 
-      // Redirect to confirmation page
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to send access link');
+      }
+
+      if (data.devLink) {
+        console.warn('Development Magic Link:', data.devLink);
+      }
+
       router.push(`/manage/check-email?email=${encodeURIComponent(email)}`);
     } catch (err) {
       setError('Failed to send access link. Please try again.');
@@ -36,80 +64,154 @@ export function ManageEmailScreen() {
   };
 
   return (
-    <div className="min-h-screen bg-[#EEEFF3] flex items-center justify-center px-4 py-8">
-      <div className="w-full max-w-md">
-        {/* Main Card */}
-        <Card className="shadow-lg border-0 bg-white rounded-2xl">
-          <CardHeader className="text-center space-y-4 pb-6 px-6 pt-12">
-            {/* Icon */}
-            <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-[#7FDBCA] mx-auto">
-              <HandHeart className="w-10 h-10 text-gray-800" strokeWidth={1.5} />
+    <div className="min-h-screen bg-[#EEEFF3] flex items-center justify-center p-4 lg:p-0">
+      {/* ----------------------------------------------------------------
+          Mobile: single centered card
+          Desktop: full-height split panel
+      ---------------------------------------------------------------- */}
+      <div className="w-full max-w-sm lg:max-w-none lg:w-full lg:min-h-screen lg:flex">
+        {/* ---- Left panel (desktop only) ---- */}
+        <div className="hidden lg:flex lg:w-[38%] bg-[#064E3B] flex-col justify-between px-16 py-14">
+          {/* Logo / brand */}
+          <div>
+            <div className="flex items-center gap-3 mb-20">
+              <Image
+                src="/logo.png"
+                alt="SwiftCause"
+                width={36}
+                height={36}
+                className="rounded-xl"
+              />
+              <span className="text-white font-semibold text-lg tracking-tight">SwiftCause</span>
             </div>
 
-            {/* Title and Description */}
-            <div className="space-y-2">
-              <CardTitle className="text-2xl font-bold text-gray-900">
-                Manage Your Donations
-              </CardTitle>
-              <CardDescription className="text-base text-gray-600 leading-relaxed">
-                We'll email you a one-time secure link to access your donations.
-              </CardDescription>
-            </div>
-          </CardHeader>
+            {/* Hero copy */}
+            <h1 className="text-4xl xl:text-5xl font-bold text-white leading-tight mb-5">
+              Your donations,
+              <br />
+              always in reach.
+            </h1>
+            <p className="text-[#6EE7B7] text-lg leading-relaxed max-w-md">
+              Access and manage every recurring donation you've made, securely, in seconds, with no
+              password needed.
+            </p>
+          </div>
 
-          <CardContent className="px-6 pb-8">
-            <form onSubmit={handleSubmit} className="space-y-5">
-              <div className="space-y-2">
-                <Label
-                  htmlFor="email"
-                  className="text-xs font-semibold text-gray-700 uppercase tracking-wide"
-                >
-                  Email Address
-                </Label>
-                <div className="relative">
-                  <Mail className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-                  <Input
-                    id="email"
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="name@example.com"
-                    className="pl-12 h-14 bg-[#E8EAF6] border-0 text-base placeholder:text-gray-400 rounded-lg focus-visible:ring-2 focus-visible:ring-emerald-500"
-                    required
-                    disabled={loading}
-                  />
+          {/* Feature list */}
+          <div className="space-y-7">
+            {FEATURES.map(({ icon: Icon, title, description }) => (
+              <div key={title} className="flex items-start gap-4">
+                <div className="w-10 h-10 rounded-xl bg-white/10 flex items-center justify-center shrink-0 mt-0.5">
+                  <Icon className="w-5 h-5 text-[#6EE7B7]" />
+                </div>
+                <div>
+                  <p className="text-white font-semibold text-sm mb-0.5">{title}</p>
+                  <p className="text-white/60 text-sm leading-relaxed">{description}</p>
                 </div>
               </div>
+            ))}
 
-              {error && (
-                <div className="text-sm text-red-600 bg-red-50 p-3 rounded-lg">{error}</div>
-              )}
+            {/* Footer note */}
+            <p className="text-white/30 text-xs pt-4 border-t border-white/10">
+              © {new Date().getFullYear()} SwiftCause · Payments secured by Stripe
+            </p>
+          </div>
+        </div>
 
-              <Button
-                type="submit"
-                className="w-full h-14 bg-[#047857] hover:bg-[#065f46] text-white font-semibold text-base rounded-full shadow-md"
-                disabled={loading}
-              >
-                {loading ? (
-                  'Sending...'
-                ) : (
-                  <>
-                    Send secure access link
-                    <ArrowRight className="w-5 h-5 ml-2" />
-                  </>
+        {/* ---- Right panel (form) ---- */}
+        <div className="lg:w-[62%] lg:min-h-screen lg:bg-white lg:flex lg:flex-col">
+          {/* Centered form area */}
+          <div className="flex-1 flex items-center justify-center px-6 py-10 lg:px-16 xl:px-24">
+            <div className="w-full max-w-md">
+              {/* Icon — mobile only */}
+              <div className="flex justify-center mb-8 lg:hidden">
+                <Image
+                  src="/logo.png"
+                  alt="SwiftCause"
+                  width={72}
+                  height={72}
+                  className="rounded-full"
+                />
+              </div>
+
+              {/* Heading */}
+              <div className="mb-9">
+                <h2 className="text-[32px] lg:text-[36px] font-bold text-[#111827] leading-tight mb-4">
+                  Access your donations
+                </h2>
+                <p className="text-[#6B7280] text-base leading-relaxed">
+                  Enter your email address and we'll send a one-time secure link to your inbox.
+                </p>
+              </div>
+
+              {/* Form */}
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-2">
+                  <Label
+                    htmlFor="email"
+                    className="text-sm font-semibold text-[#374151] uppercase tracking-wider"
+                  >
+                    Email address
+                  </Label>
+                  <div className="relative">
+                    <Mail className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[#9CA3AF] pointer-events-none" />
+                    <Input
+                      id="email"
+                      type="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      placeholder="name@example.com"
+                      className="pl-11 h-14 text-base bg-white border-[#D1D5DB] rounded-xl focus-visible:ring-2 focus-visible:ring-[#047857] focus-visible:border-[#047857] placeholder:text-[#D1D5DB]"
+                      required
+                      disabled={loading}
+                      autoComplete="email"
+                    />
+                  </div>
+                </div>
+
+                {error && (
+                  <div className="text-sm text-red-600 bg-red-50 border border-red-100 px-4 py-3 rounded-xl">
+                    {error}
+                  </div>
                 )}
-              </Button>
-            </form>
 
-            {/* Security Notice */}
-            <div className="mt-6 text-center">
-              <div className="flex items-center justify-center gap-2 text-sm text-gray-500">
-                <Lock className="w-4 h-4" />
-                <span>No password required. Powered by secure authentication.</span>
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="w-full h-14 flex items-center justify-center gap-2.5 bg-[#047857] hover:bg-[#065f46] active:bg-[#064e3b] disabled:opacity-60 text-white font-semibold text-lg rounded-xl shadow-sm transition-colors"
+                >
+                  {loading ? (
+                    <>
+                      <Loader2 className="w-5 h-5 animate-spin" />
+                      Sending link…
+                    </>
+                  ) : (
+                    <>
+                      Send secure access link
+                      <ArrowRight className="w-5 h-5" />
+                    </>
+                  )}
+                </button>
+              </form>
+
+              {/* Divider */}
+              <div className="my-7 border-t border-[#F3F4F6]" />
+
+              {/* Security note */}
+              <div className="flex items-start gap-3 text-sm text-[#9CA3AF]">
+                <Lock className="w-4 h-4 shrink-0 mt-0.5" />
+                <span>
+                  No password required. The link expires after 15 minutes and can only be used once.
+                </span>
               </div>
             </div>
-          </CardContent>
-        </Card>
+          </div>
+
+          {/* Bottom bar — desktop only */}
+          <div className="hidden lg:flex items-center justify-center px-10 py-6">
+            <p className="text-xs text-[#D1D5DB]">© {new Date().getFullYear()} SwiftCause</p>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/views/manage/ManageEmailScreen.tsx
+++ b/src/views/manage/ManageEmailScreen.tsx
@@ -121,25 +121,26 @@ export function ManageEmailScreen() {
         {/* ---- Right panel (form) ---- */}
         <div className="lg:w-[62%] lg:min-h-screen lg:bg-white lg:flex lg:flex-col">
           {/* Centered form area */}
-          <div className="flex-1 flex items-center justify-center px-6 py-10 lg:px-16 xl:px-24">
-            <div className="w-full max-w-md">
+          <div className="flex-1 flex items-center justify-center px-4 py-8 lg:px-16 xl:px-24">
+            {/* White card on mobile, transparent on desktop */}
+            <div className="w-full max-w-md bg-white rounded-2xl shadow-[0_2px_8px_rgba(0,0,0,0.08)] px-6 py-8 lg:bg-transparent lg:shadow-none lg:px-0 lg:py-0">
               {/* Icon — mobile only */}
-              <div className="flex justify-center mb-8 lg:hidden">
+              <div className="flex justify-center mb-6 lg:hidden">
                 <Image
                   src="/logo.png"
                   alt="SwiftCause"
-                  width={72}
-                  height={72}
+                  width={64}
+                  height={64}
                   className="rounded-full"
                 />
               </div>
 
               {/* Heading */}
-              <div className="mb-9">
-                <h2 className="text-[32px] lg:text-[36px] font-bold text-[#111827] leading-tight mb-4">
+              <div className="mb-7 lg:mb-9">
+                <h2 className="text-[28px] lg:text-[36px] font-bold text-[#111827] leading-tight mb-3">
                   Access your donations
                 </h2>
-                <p className="text-[#6B7280] text-base leading-relaxed">
+                <p className="text-[#6B7280] text-sm lg:text-base leading-relaxed">
                   Enter your email address and we'll send a one-time secure link to your inbox.
                 </p>
               </div>

--- a/src/views/manage/ManageEmailScreen.tsx
+++ b/src/views/manage/ManageEmailScreen.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/shared/ui/button';
+import { Input } from '@/shared/ui/input';
+import { Label } from '@/shared/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card';
+import { Mail, HandHeart, ArrowRight, Lock } from 'lucide-react';
+
+export function ManageEmailScreen() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      // TODO: Call API to send magic link
+
+      // Simulate API call
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      // Redirect to confirmation page
+      router.push(`/manage/check-email?email=${encodeURIComponent(email)}`);
+    } catch (err) {
+      setError('Failed to send access link. Please try again.');
+      console.error('Error sending magic link:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#EEEFF3] flex items-center justify-center px-4 py-8">
+      <div className="w-full max-w-md">
+        {/* Main Card */}
+        <Card className="shadow-lg border-0 bg-white rounded-2xl">
+          <CardHeader className="text-center space-y-4 pb-6 px-6 pt-12">
+            {/* Icon */}
+            <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-[#7FDBCA] mx-auto">
+              <HandHeart className="w-10 h-10 text-gray-800" strokeWidth={1.5} />
+            </div>
+
+            {/* Title and Description */}
+            <div className="space-y-2">
+              <CardTitle className="text-2xl font-bold text-gray-900">
+                Manage Your Donations
+              </CardTitle>
+              <CardDescription className="text-base text-gray-600 leading-relaxed">
+                We'll email you a one-time secure link to access your donations.
+              </CardDescription>
+            </div>
+          </CardHeader>
+
+          <CardContent className="px-6 pb-8">
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div className="space-y-2">
+                <Label
+                  htmlFor="email"
+                  className="text-xs font-semibold text-gray-700 uppercase tracking-wide"
+                >
+                  Email Address
+                </Label>
+                <div className="relative">
+                  <Mail className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+                  <Input
+                    id="email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="name@example.com"
+                    className="pl-12 h-14 bg-[#E8EAF6] border-0 text-base placeholder:text-gray-400 rounded-lg focus-visible:ring-2 focus-visible:ring-emerald-500"
+                    required
+                    disabled={loading}
+                  />
+                </div>
+              </div>
+
+              {error && (
+                <div className="text-sm text-red-600 bg-red-50 p-3 rounded-lg">{error}</div>
+              )}
+
+              <Button
+                type="submit"
+                className="w-full h-14 bg-[#047857] hover:bg-[#065f46] text-white font-semibold text-base rounded-full shadow-md"
+                disabled={loading}
+              >
+                {loading ? (
+                  'Sending...'
+                ) : (
+                  <>
+                    Send secure access link
+                    <ArrowRight className="w-5 h-5 ml-2" />
+                  </>
+                )}
+              </Button>
+            </form>
+
+            {/* Security Notice */}
+            <div className="mt-6 text-center">
+              <div className="flex items-center justify-center gap-2 text-sm text-gray-500">
+                <Lock className="w-4 h-4" />
+                <span>No password required. Powered by secure authentication.</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/views/manage/ManageEmailScreen.tsx
+++ b/src/views/manage/ManageEmailScreen.tsx
@@ -54,9 +54,12 @@ export function ManageEmailScreen() {
         console.warn('Development Magic Link:', data.devLink);
       }
 
-      router.push(`/manage/check-email?email=${encodeURIComponent(email)}`);
+      sessionStorage.setItem('pending_magic_link_email', email);
+      router.push('/manage/check-email');
     } catch (err) {
-      setError('Failed to send access link. Please try again.');
+      setError(
+        err instanceof Error ? err.message : 'Failed to send access link. Please try again.',
+      );
       console.error('Error sending magic link:', err);
     } finally {
       setLoading(false);

--- a/src/views/manage/index.ts
+++ b/src/views/manage/index.ts
@@ -1,0 +1,4 @@
+// Public API for manage views
+export { ManageEmailScreen } from './ManageEmailScreen';
+export { ManageDashboardScreen } from './ManageDashboardScreen';
+export { ManageCheckEmailScreen } from './ManageCheckEmailScreen';


### PR DESCRIPTION
## Summary

Implements the donor self-service subscription management portal end-to-end ([#695](#695)). Donors can access, view, and cancel their recurring donations without a password  via a one-time magic link sent to their email  and open the Stripe Billing Portal directly from their personal dashboard.

---

## Changes

###  Backend — 5 new Cloud Functions

**`backend/functions/handlers/subscriptionManagement.js`**

| Function | Description |
|---|---|
| `sendSubscriptionMagicLink` | Generates and emails a one-time 15-minute access link. Returns the same `200` response whether the email has subscriptions or not (anti-enumeration). |
| `verifySubscriptionMagicLink` | Validates the token and issues a Firebase custom token for the donor session. |
| `getSubscriptionsByEmail` | Returns all subscriptions for the authenticated donor. Runs 4 parallel Firestore queries to cover both root and `metadata` email storage patterns; enriches results with live campaign/org names. |
| `createCustomerPortalSession` | Creates a Stripe Billing Portal session with full auth, ownership validation, rate limiting, and structured audit logging. |
| `getPaymentHistory` | Returns donations for a subscription using two query strategies: direct `subscriptionId` link and a `donorEmail + campaignId` fallback for legacy docs. |

**`backend/functions/utils/tokenManager.js`**

- Generates, stores, and verifies single-use tokens in the `subscriptionMagicLinkTokens` Firestore collection
- Automatic 15-minute expiry and a consumed-flag to prevent replay attacks

**Firestore-backed rate limiter**

- Sliding-window limiter: **10 requests / 60 s per email** on `createCustomerPortalSession`
- Uses Firestore transactions writing to a `rate_limits` collection
- Fails open on Firestore errors so legitimate users are never blocked

---

###  Frontend — `/manage` route screens

**`ManageEmailScreen`**
- Entry point for the donor portal collects email and triggers the magic link flow
- Handles loading, error, and success states; redirects to `/manage/check-email` on submission

**`ManageCheckEmailScreen`**
- Confirms the magic link was sent and lets donors request a new one without starting over
- Tracks resend state independently so the button gives clear feedback without a full page reload

**`ManageDashboardScreen`**
- Displays all active subscriptions for the authenticated donor and opens the Stripe Billing Portal on demand
- Deduplicates payment history across multiple subscriptions so each payment appears exactly once
- Detects expired donor sessions and routes to `/manage` for re-authentication instead of failing silently

---

###  Docs

- `docs/DONOR_SUBSCRIPTION_MANAGEMENT.md` updated with full `getPaymentHistory` API reference, `rate_limits` collection documentation, and corrected deployment command

---

## Testing

- [x] `npm run build`
- [x] `npm run lint`
- [x] Manual verification completed

**Backend:** 63 Jest tests passing across `subscriptionManagement.test.js` and `tokenManager.test.js` — covering all 5 handlers, auth failures, token expiry/replay, rate limiting, data integrity, email mismatch (403), Stripe error mapping, payment dedup, and sort order.

**Manual:** Magic link flow tested end-to-end in staging (email → link → dashboard → Stripe portal). Rate limiter verified by hitting `createCustomerPortalSession` across multiple subscriptions and confirming the `rate_limits` document grows; `429` returned after 10 requests within 60 s. No duplicate React key warnings in console after dedup fix.

---

## Risks

**`devLink` in production response**
 When SendGrid fails, the magic link is returned in the JSON response body as a fallback. Marked as `TODO` in code — should be removed once the email provider is stable.

 **Legacy mixed-case email docs**
 Subscriptions with `donorEmail` stored in mixed case (e.g. `Donor@Example.com`) won't be found by the normalised queries until a backfill is run. Known trade-off — a full collection scan is not acceptable at scale. Documented in code comments.

 **Firebase custom token lifetime**
 The donor session is a short-lived Firebase custom token. If a tab is left open for an extended period and the ID token refresh fails silently, the user will see "Session expired — Request new link."

---

## Deployment Notes

1. Deploy the 5 new Cloud Functions:

```bash
firebase deploy --only \
  functions:sendSubscriptionMagicLink,\
  functions:verifySubscriptionMagicLink,\
  functions:getSubscriptionsByEmail,\
  functions:createCustomerPortalSession,\
  functions:getPaymentHistory
```
---

## Closes
Closes #695 