### PR TITLE
[Feature] Implement GASDS CSV Export (Org-level, Tax Year Based)

### DIFF
--- a/backend/functions/handlers/giftAid.gasds.formatting.test.js
+++ b/backend/functions/handlers/giftAid.gasds.formatting.test.js
@@ -1,0 +1,96 @@
+const {
+  resolveCampaignMode,
+  resolveGasdsIneligibilityReason,
+  resolveLocationSnapshot,
+  buildGasdsCsv,
+  escapeCsvValue,
+} = require('./giftAid');
+
+describe('GASDS formatting and eligibility helpers', () => {
+  it('resolves campaign mode from supported field fallbacks', () => {
+    expect(resolveCampaignMode({ campaign_mode: 'activity' })).toBe('ACTIVITY');
+    expect(resolveCampaignMode({ campaignMode: 'donation' })).toBe('DONATION');
+    expect(resolveCampaignMode({ metadata: { campaign_mode: 'activity' } })).toBe('ACTIVITY');
+    expect(resolveCampaignMode({ metadata: { campaignMode: 'donation' } })).toBe('DONATION');
+    expect(resolveCampaignMode({})).toBe('DONATION');
+  });
+
+  it('computes ineligibility reasons correctly', () => {
+    expect(resolveGasdsIneligibilityReason({ amountMajor: 31, campaignMode: 'DONATION' })).toBe(
+      'over_30',
+    );
+    expect(resolveGasdsIneligibilityReason({ amountMajor: 20, campaignMode: 'ACTIVITY' })).toBe(
+      'non_donation_mode',
+    );
+    expect(resolveGasdsIneligibilityReason({ amountMajor: 31, campaignMode: 'ACTIVITY' })).toBe(
+      'over_30_and_non_donation_mode',
+    );
+    expect(resolveGasdsIneligibilityReason({ amountMajor: 20, campaignMode: 'DONATION' })).toBe('');
+  });
+
+  it('resolves location snapshot with addressLine1 fallback to city', () => {
+    expect(
+      resolveLocationSnapshot({
+        location_snapshot: {
+          name: 'Hall',
+          postcode: 'AB12',
+          addressLine1: '1 High Street',
+          city: 'London',
+        },
+      }),
+    ).toEqual({
+      name: 'Hall',
+      postcode: 'AB12',
+      addressLine1: '1 High Street',
+    });
+
+    expect(
+      resolveLocationSnapshot({
+        location_snapshot: {
+          name: 'Hall',
+          postcode: 'AB12',
+          city: 'London',
+        },
+      }),
+    ).toEqual({
+      name: 'Hall',
+      postcode: 'AB12',
+      addressLine1: 'London',
+    });
+  });
+
+  it('guards spreadsheet formulas and escapes CSV safely', () => {
+    expect(escapeCsvValue('=SUM(A1:A2)')).toBe("'=SUM(A1:A2)");
+    expect(escapeCsvValue('+cmd')).toBe("'+cmd");
+    expect(escapeCsvValue('-1+2')).toBe("'-1+2");
+    expect(escapeCsvValue('@A1')).toBe("'@A1");
+    expect(escapeCsvValue('normal,text')).toBe('"normal,text"');
+    expect(escapeCsvValue('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it('builds GASDS CSV with expected headers and row values', () => {
+    const csv = buildGasdsCsv([
+      {
+        donation_id: 'pi_1',
+        amount: '25.00',
+        date: '2026-04-05T00:00:00.000Z',
+        method: 'kiosk',
+        location_name: 'My Hall',
+        postcode: 'AB12',
+        address_line1: '1 Street',
+        tax_year: '2025-2026',
+        campaign_mode: 'DONATION',
+        is_gasds_eligible: 'true',
+        gift_aid_matched_in_same_year: 'true',
+        reason_not_eligible: '',
+      },
+    ]);
+
+    const lines = csv.split('\n');
+    expect(lines[0]).toContain('donation_id');
+    expect(lines[0]).toContain('reason_not_eligible');
+    expect(lines[1]).toContain('pi_1');
+    expect(lines[1]).toContain('25.00');
+    expect(lines[1]).toContain('DONATION');
+  });
+});

--- a/backend/functions/handlers/giftAid.gasds.test.js
+++ b/backend/functions/handlers/giftAid.gasds.test.js
@@ -1,0 +1,25 @@
+const { buildUkTaxYearLabel, resolveUkTaxYearRange } = require('./giftAid');
+
+describe('GASDS UK tax year boundary helpers', () => {
+  it('buildUkTaxYearLabel keeps 5 April in previous tax year', () => {
+    const date = new Date(Date.UTC(2026, 3, 5, 23, 59, 59, 999));
+    expect(buildUkTaxYearLabel(date)).toBe('2025-2026');
+  });
+
+  it('buildUkTaxYearLabel moves 6 April into next tax year', () => {
+    const date = new Date(Date.UTC(2026, 3, 6, 0, 0, 0, 0));
+    expect(buildUkTaxYearLabel(date)).toBe('2026-2027');
+  });
+
+  it('resolveUkTaxYearRange returns exact UK boundaries', () => {
+    const range = resolveUkTaxYearRange('2025-2026');
+    expect(range).not.toBeNull();
+    expect(range.start.toISOString()).toBe('2025-04-06T00:00:00.000Z');
+    expect(range.end.toISOString()).toBe('2026-04-05T23:59:59.999Z');
+  });
+
+  it('resolveUkTaxYearRange rejects invalid labels', () => {
+    expect(resolveUkTaxYearRange('2025-2027')).toBeNull();
+    expect(resolveUkTaxYearRange('2025/2026')).toBeNull();
+  });
+});

--- a/backend/functions/handlers/giftAid.gasds.timestamps.test.js
+++ b/backend/functions/handlers/giftAid.gasds.timestamps.test.js
@@ -1,0 +1,32 @@
+const { resolveDonationDate } = require('./giftAid');
+
+describe('GASDS donation date resolution with mixed timestamp fields', () => {
+  it('prefers paymentCompletedAt over timestamp and createdAt', () => {
+    const donation = {
+      paymentCompletedAt: '2026-04-05T12:00:00.000Z',
+      timestamp: '2026-04-04T12:00:00.000Z',
+      createdAt: '2026-04-03T12:00:00.000Z',
+    };
+    expect(resolveDonationDate(donation)?.toISOString()).toBe('2026-04-05T12:00:00.000Z');
+  });
+
+  it('falls back to timestamp when createdAt is missing', () => {
+    const donation = {
+      timestamp: '2026-04-04T12:00:00.000Z',
+    };
+    expect(resolveDonationDate(donation)?.toISOString()).toBe('2026-04-04T12:00:00.000Z');
+  });
+
+  it('handles Firestore-like Timestamp objects via toDate()', () => {
+    const donation = {
+      createdAt: {
+        toDate: () => new Date('2026-04-02T12:00:00.000Z'),
+      },
+    };
+    expect(resolveDonationDate(donation)?.toISOString()).toBe('2026-04-02T12:00:00.000Z');
+  });
+
+  it('returns null when no parseable date exists', () => {
+    expect(resolveDonationDate({ createdAt: 'not-a-date' })).toBeNull();
+  });
+});

--- a/backend/functions/handlers/giftAid.js
+++ b/backend/functions/handlers/giftAid.js
@@ -154,6 +154,43 @@ const chunkArray = (items, size) => {
   return chunks;
 };
 
+const fetchDonationsForGasdsExport = async ({ organizationId, requestedLocationIds }) => {
+  const db = admin.firestore();
+  const selectedChunks = chunkArray(requestedLocationIds, 10);
+  const byId = new Map();
+
+  try {
+    for (const locationChunk of selectedChunks) {
+      const snapshot = await db
+        .collection('donations')
+        .where('organizationId', '==', organizationId)
+        .where('location_id', 'in', locationChunk)
+        .get();
+
+      snapshot.docs.forEach((doc) => {
+        byId.set(doc.id, doc);
+      });
+    }
+  } catch (error) {
+    // Fallback for environments missing composite indexes.
+    // We preserve correctness via later in-memory filtering.
+    const code = error?.code;
+    if (code !== 9 && code !== 'failed-precondition') {
+      throw error;
+    }
+
+    const snapshot = await db
+      .collection('donations')
+      .where('organizationId', '==', organizationId)
+      .get();
+    snapshot.docs.forEach((doc) => {
+      byId.set(doc.id, doc);
+    });
+  }
+
+  return [...byId.values()];
+};
+
 const updateDeclarationsAsExported = async ({ declarationIds, batchId, actorId, exportedAt }) => {
   const db = admin.firestore();
   const chunks = chunkArray(declarationIds, WRITE_BATCH_SIZE);
@@ -271,10 +308,16 @@ const resolveLocationSnapshot = (donation) => {
   const snapshot =
     donation && typeof donation.location_snapshot === 'object' ? donation.location_snapshot : null;
   if (!snapshot) return null;
+  const addressLine1 =
+    typeof snapshot.addressLine1 === 'string' && snapshot.addressLine1.trim()
+      ? snapshot.addressLine1.trim()
+      : typeof snapshot.city === 'string'
+        ? snapshot.city.trim()
+        : '';
   return {
     name: typeof snapshot.name === 'string' ? snapshot.name.trim() : '',
     postcode: typeof snapshot.postcode === 'string' ? snapshot.postcode.trim() : '',
-    addressLine1: typeof snapshot.addressLine1 === 'string' ? snapshot.addressLine1.trim() : '',
+    addressLine1,
   };
 };
 
@@ -290,6 +333,8 @@ const buildGasdsCsv = (rows) => {
     'tax_year',
     'campaign_mode',
     'is_gasds_eligible',
+    'gift_aid_matched_in_same_year',
+    'reason_not_eligible',
   ];
 
   const csvRows = rows.map((row) =>
@@ -304,12 +349,62 @@ const buildGasdsCsv = (rows) => {
       row.tax_year,
       row.campaign_mode,
       row.is_gasds_eligible,
+      row.gift_aid_matched_in_same_year,
+      row.reason_not_eligible,
     ]
       .map(escapeCsvValue)
       .join(','),
   );
 
   return [headers.join(','), ...csvRows].join('\n');
+};
+
+const buildGasdsSummaryCsv = (rows) => {
+  const headers = [
+    'location_id',
+    'location_name',
+    'postcode',
+    'total_collected',
+    'eligible',
+    'cap',
+    'status',
+    'community_building_note',
+  ];
+
+  const csvRows = rows.map((row) =>
+    [
+      row.location_id,
+      row.location_name,
+      row.postcode,
+      row.total_collected,
+      row.eligible,
+      row.cap,
+      row.status,
+      row.community_building_note,
+    ]
+      .map(escapeCsvValue)
+      .join(','),
+  );
+
+  return [headers.join(','), ...csvRows].join('\n');
+};
+
+const resolveGasdsIneligibilityReason = ({ amountMajor, campaignMode }) => {
+  if (amountMajor > 30 && campaignMode !== 'DONATION') return 'over_30_and_non_donation_mode';
+  if (amountMajor > 30) return 'over_30';
+  if (campaignMode !== 'DONATION') return 'non_donation_mode';
+  return '';
+};
+
+const resolveFileNameToken = (timestamp, prefix) => {
+  const timestampToken = buildTimestampToken(timestamp);
+  return `${prefix}-${timestampToken}.csv`;
+};
+
+const resolveGasdsBatchFile = (batchData, fileKind) => {
+  if (fileKind === 'detailed') return batchData.detailedFile || null;
+  if (fileKind === 'summary') return batchData.summaryFile || null;
+  return null;
 };
 
 const fetchCapturedDeclarations = async (organizationId) => {
@@ -573,6 +668,7 @@ const downloadGiftAidExportBatchFile = (req, res) => {
 
 const exportGasdsCsv = (req, res) => {
   cors(req, res, async () => {
+    let batchRef = null;
     try {
       if (req.method !== 'POST') {
         return res.status(405).send({ error: 'Method not allowed' });
@@ -598,16 +694,42 @@ const exportGasdsCsv = (req, res) => {
       if (requestedLocationIds.length === 0) {
         return res.status(400).send({ error: 'At least one location must be selected' });
       }
+      const strictMode = req.body?.strictMode === true;
 
-      const snapshot = await admin
-        .firestore()
-        .collection('donations')
-        .where('organizationId', '==', organizationId)
-        .get();
+      const donationDocs = await fetchDonationsForGasdsExport({
+        organizationId,
+        requestedLocationIds,
+      });
 
       const selectedLocationIds = new Set(requestedLocationIds);
+      const locationSnapshot = await admin
+        .firestore()
+        .collection('locations')
+        .where('orgId', '==', organizationId)
+        .get()
+        .catch(() => null);
+      const locationMeta = new Map();
+      if (locationSnapshot && locationSnapshot.docs) {
+        locationSnapshot.docs.forEach((doc) => {
+          const data = doc.data() || {};
+          if (!selectedLocationIds.has(doc.id)) return;
+          locationMeta.set(doc.id, {
+            name: typeof data.name === 'string' ? data.name.trim() : '',
+            postcode: typeof data.postcode === 'string' ? data.postcode.trim() : '',
+            isCommunityBuilding: Boolean(data.isCommunityBuilding),
+          });
+        });
+      }
+
       const rows = [];
-      for (const doc of snapshot.docs) {
+      const summaryByLocation = new Map();
+      const reasonCounts = {
+        over_30: 0,
+        non_donation_mode: 0,
+        over_30_and_non_donation_mode: 0,
+      };
+
+      for (const doc of donationDocs) {
         const donation = doc.data() || {};
         const locationId =
           typeof donation.location_id === 'string' ? donation.location_id.trim() : null;
@@ -621,38 +743,211 @@ const exportGasdsCsv = (req, res) => {
         if (!taxYearLabel || taxYearLabel !== resolvedTaxYear.label) continue;
 
         const campaignMode = resolveCampaignMode(donation);
-        const amount = Number(donation.amount);
-        const amountMajor = Number.isFinite(amount) ? amount : 0;
+        const amountMinor = Number(donation.amount);
+        const amountMajor = Number.isFinite(amountMinor) ? amountMinor / 100 : 0;
         const isEligible = amountMajor <= 30 && campaignMode === 'DONATION';
+        const reasonNotEligible = isEligible
+          ? ''
+          : resolveGasdsIneligibilityReason({ amountMajor, campaignMode });
+        if (reasonNotEligible && reasonCounts[reasonNotEligible] !== undefined) {
+          reasonCounts[reasonNotEligible] += 1;
+        }
         const locationSnapshot = resolveLocationSnapshot(donation);
+        const locationRecord = locationMeta.get(locationId) || {};
+        const resolvedLocationName = locationSnapshot?.name || locationRecord.name || '';
+        const resolvedPostcode = locationSnapshot?.postcode || locationRecord.postcode || '';
+
+        const currentSummary = summaryByLocation.get(locationId) || {
+          location_id: locationId,
+          location_name: resolvedLocationName || 'Unknown',
+          postcode: resolvedPostcode,
+          total_collected: 0,
+          eligible: 0,
+          cap: '8000.00',
+          status: 'OK',
+          community_building_note: locationRecord.isCommunityBuilding
+            ? 'Potential £16k cap (subject to eligibility)'
+            : '',
+        };
+        currentSummary.total_collected += amountMajor;
+        if (isEligible) currentSummary.eligible += amountMajor;
+        currentSummary.status = currentSummary.eligible > 8000 ? 'Exceeds' : 'OK';
+        summaryByLocation.set(locationId, currentSummary);
+        if (strictMode && !isEligible) continue;
 
         rows.push({
+          location_id: locationId,
           donation_id: donation.transactionId || donation.stripePaymentIntentId || doc.id,
           amount: amountMajor.toFixed(2),
           date: donationDate.toISOString(),
           method: donation.platform || 'unknown',
-          location_name: locationSnapshot?.name || '',
-          postcode: locationSnapshot?.postcode || '',
+          location_name: resolvedLocationName,
+          postcode: resolvedPostcode,
           address_line1: locationSnapshot?.addressLine1 || '',
           tax_year: resolvedTaxYear.label,
           campaign_mode: campaignMode,
           is_gasds_eligible: isEligible ? 'true' : 'false',
+          gift_aid_matched_in_same_year: donation.isGiftAid === true ? 'true' : 'false',
+          reason_not_eligible: reasonNotEligible,
         });
       }
 
       rows.sort((left, right) => left.date.localeCompare(right.date));
       const csvContent = buildGasdsCsv(rows);
-      const fileName = `gasds-${organizationId}-${resolvedTaxYear.label}.csv`;
+      const summaryRows = [...summaryByLocation.values()]
+        .map((row) => ({
+          ...row,
+          total_collected: Number(row.total_collected).toFixed(2),
+          eligible: Number(row.eligible).toFixed(2),
+        }))
+        .sort((left, right) => left.location_name.localeCompare(right.location_name));
+      const summaryCsv = buildGasdsSummaryCsv(summaryRows);
+
+      const exportedAt = admin.firestore.Timestamp.now();
+      const callerData = await getCallerProfile(auth.uid);
+      batchRef = await admin
+        .firestore()
+        .collection('gasdsExportBatches')
+        .add({
+          organizationId,
+          status: 'pending',
+          createdAt: exportedAt,
+          createdByUserId: auth.uid,
+          createdByEmail: auth.email || callerData.email || null,
+          createdByName: callerData.username || null,
+          taxYear: resolvedTaxYear.label,
+          strictMode,
+          locationIds: requestedLocationIds,
+          rowCount: rows.length,
+          reasonCounts,
+        });
+
+      const batchId = batchRef.id;
+      const storageBasePath = `gasdsExports/${organizationId}/${batchId}`;
+      const detailedFileName = resolveFileNameToken(
+        exportedAt,
+        `gasds-detailed-${resolvedTaxYear.label}`,
+      );
+      const summaryFileName = resolveFileNameToken(
+        exportedAt,
+        `gasds-summary-${resolvedTaxYear.label}`,
+      );
+      const bucket = admin.storage().bucket();
+      const detailedFile = await createCsvStorageFile({
+        bucket,
+        storagePath: `${storageBasePath}/${detailedFileName}`,
+        fileName: detailedFileName,
+        csvContent,
+      });
+      const summaryFile = await createCsvStorageFile({
+        bucket,
+        storagePath: `${storageBasePath}/${summaryFileName}`,
+        fileName: summaryFileName,
+        csvContent: summaryCsv,
+      });
+
+      await batchRef.set(
+        {
+          batchId,
+          status: 'completed',
+          completedAt: exportedAt,
+          detailedFile,
+          summaryFile,
+          rowCount: rows.length,
+          summaryRowCount: summaryRows.length,
+          updatedAt: exportedAt,
+        },
+        { merge: true },
+      );
+
+      return res.status(200).send({
+        success: true,
+        batchId,
+        rowCount: rows.length,
+        taxYear: resolvedTaxYear.label,
+        strictMode,
+        detailedFile,
+        summaryFile,
+        summary: {
+          byReason: reasonCounts,
+          summaryRowCount: summaryRows.length,
+        },
+      });
+    } catch (error) {
+      console.error('Error exporting GASDS csv:', error);
+      if (batchRef) {
+        try {
+          await batchRef.set(
+            {
+              status: 'failed',
+              failureMessage: error.message || 'GASDS export failed',
+              failedAt: admin.firestore.Timestamp.now(),
+            },
+            { merge: true },
+          );
+        } catch (batchError) {
+          console.error('Failed to update GASDS export batch status:', batchError);
+        }
+      }
+      const statusCode = Number.isInteger(error.code) ? error.code : 500;
+      return res.status(statusCode).send({
+        error: error.message || 'Failed to export GASDS csv',
+      });
+    }
+  });
+};
+
+const downloadGasdsExportBatchFile = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return res.status(405).send({ error: 'Method not allowed' });
+      }
+
+      const auth = await verifyAuth(req);
+      const batchId = typeof req.body?.batchId === 'string' ? req.body.batchId.trim() : '';
+      const fileKind = typeof req.body?.fileKind === 'string' ? req.body.fileKind.trim() : '';
+
+      if (!batchId) return res.status(400).send({ error: 'batchId is required' });
+      if (fileKind !== 'detailed' && fileKind !== 'summary') {
+        return res.status(400).send({ error: "fileKind must be 'detailed' or 'summary'" });
+      }
+
+      const batchSnapshot = await admin
+        .firestore()
+        .collection('gasdsExportBatches')
+        .doc(batchId)
+        .get();
+      if (!batchSnapshot.exists)
+        return res.status(404).send({ error: 'GASDS export batch not found' });
+
+      const batchData = batchSnapshot.data() || {};
+      const organizationId =
+        typeof batchData.organizationId === 'string' ? batchData.organizationId.trim() : '';
+      await ensureGiftAidBatchDownloadAccess(auth, organizationId);
+
+      const fileMeta = resolveGasdsBatchFile(batchData, fileKind);
+      const storagePath =
+        typeof fileMeta?.storagePath === 'string' ? fileMeta.storagePath.trim() : '';
+      const fileName = typeof fileMeta?.fileName === 'string' ? fileMeta.fileName.trim() : '';
+      if (!storagePath || !fileName)
+        return res.status(404).send({ error: 'Requested GASDS export file is unavailable' });
+
+      const storageFile = admin.storage().bucket().file(storagePath);
+      const [exists] = await storageFile.exists();
+      if (!exists)
+        return res.status(404).send({ error: 'GASDS export file could not be found in storage' });
+      const [buffer] = await storageFile.download();
 
       res.set('Content-Type', 'text/csv; charset=utf-8');
       res.set('Content-Disposition', `attachment; filename="${fileName}"`);
       res.set('Cache-Control', 'private, no-store, max-age=0');
-      return res.status(200).send(csvContent);
+      return res.status(200).send(buffer);
     } catch (error) {
-      console.error('Error exporting GASDS csv:', error);
+      console.error('Error downloading GASDS export batch file:', error);
       const statusCode = Number.isInteger(error.code) ? error.code : 500;
       return res.status(statusCode).send({
-        error: error.message || 'Failed to export GASDS csv',
+        error: error.message || 'Failed to download GASDS export batch file',
       });
     }
   });
@@ -662,4 +957,14 @@ module.exports = {
   exportGiftAidDeclarations,
   downloadGiftAidExportBatchFile,
   exportGasdsCsv,
+  downloadGasdsExportBatchFile,
+  resolveUkTaxYearRange,
+  buildUkTaxYearLabel,
+  resolveCampaignMode,
+  resolveGasdsIneligibilityReason,
+  resolveLocationSnapshot,
+  resolveDonationDate,
+  buildGasdsCsv,
+  escapeCsvValue,
+  sanitizeSpreadsheetFormula,
 };

--- a/backend/functions/handlers/giftAid.js
+++ b/backend/functions/handlers/giftAid.js
@@ -179,6 +179,139 @@ const updateDeclarationsAsExported = async ({ declarationIds, batchId, actorId, 
   }
 };
 
+const sanitizeSpreadsheetFormula = (value) => {
+  if (typeof value !== 'string') return value;
+  if (/^[\t\r\n ]*[=+\-@]/.test(value)) {
+    return `'${value}`;
+  }
+  return value;
+};
+
+const escapeCsvValue = (value) => {
+  if (value === undefined || value === null) return '';
+  const stringValue = String(sanitizeSpreadsheetFormula(value));
+  if (
+    stringValue.includes('"') ||
+    stringValue.includes(',') ||
+    stringValue.includes('\n') ||
+    stringValue.includes('\r')
+  ) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+  return stringValue;
+};
+
+const toDate = (value) => {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  if (typeof value === 'object' && typeof value.toDate === 'function') return value.toDate();
+  if (typeof value === 'object' && typeof value.seconds === 'number') {
+    return new Date(value.seconds * 1000);
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const buildUkTaxYearLabel = (date) => {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null;
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth() + 1;
+  const day = date.getUTCDate();
+  const startYear = month > 4 || (month === 4 && day >= 6) ? year : year - 1;
+  return `${startYear}-${startYear + 1}`;
+};
+
+const resolveUkTaxYearRange = (taxYear) => {
+  const value = typeof taxYear === 'string' ? taxYear.trim() : '';
+  const match = /^(\d{4})-(\d{4})$/.exec(value);
+  if (!match) return null;
+  const startYear = Number(match[1]);
+  const endYear = Number(match[2]);
+  if (!Number.isInteger(startYear) || !Number.isInteger(endYear) || endYear !== startYear + 1) {
+    return null;
+  }
+
+  const start = new Date(Date.UTC(startYear, 3, 6, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(endYear, 3, 5, 23, 59, 59, 999));
+  return { start, end, label: value };
+};
+
+const resolveDonationDate = (donation) => {
+  return (
+    toDate(donation.paymentCompletedAt) ||
+    toDate(donation.timestamp) ||
+    toDate(donation.createdAt) ||
+    null
+  );
+};
+
+const resolveCampaignMode = (donation) => {
+  const direct = typeof donation.campaign_mode === 'string' ? donation.campaign_mode.trim() : '';
+  if (direct) return direct.toUpperCase();
+
+  const camel = typeof donation.campaignMode === 'string' ? donation.campaignMode.trim() : '';
+  if (camel) return camel.toUpperCase();
+
+  const metadataSnake =
+    typeof donation?.metadata?.campaign_mode === 'string'
+      ? donation.metadata.campaign_mode.trim()
+      : '';
+  if (metadataSnake) return metadataSnake.toUpperCase();
+
+  const metadataCamel =
+    typeof donation?.metadata?.campaignMode === 'string'
+      ? donation.metadata.campaignMode.trim()
+      : '';
+  if (metadataCamel) return metadataCamel.toUpperCase();
+
+  return 'DONATION';
+};
+
+const resolveLocationSnapshot = (donation) => {
+  const snapshot =
+    donation && typeof donation.location_snapshot === 'object' ? donation.location_snapshot : null;
+  if (!snapshot) return null;
+  return {
+    name: typeof snapshot.name === 'string' ? snapshot.name.trim() : '',
+    postcode: typeof snapshot.postcode === 'string' ? snapshot.postcode.trim() : '',
+    addressLine1: typeof snapshot.addressLine1 === 'string' ? snapshot.addressLine1.trim() : '',
+  };
+};
+
+const buildGasdsCsv = (rows) => {
+  const headers = [
+    'donation_id',
+    'amount',
+    'date',
+    'method',
+    'location_name',
+    'postcode',
+    'address_line1',
+    'tax_year',
+    'campaign_mode',
+    'is_gasds_eligible',
+  ];
+
+  const csvRows = rows.map((row) =>
+    [
+      row.donation_id,
+      row.amount,
+      row.date,
+      row.method,
+      row.location_name,
+      row.postcode,
+      row.address_line1,
+      row.tax_year,
+      row.campaign_mode,
+      row.is_gasds_eligible,
+    ]
+      .map(escapeCsvValue)
+      .join(','),
+  );
+
+  return [headers.join(','), ...csvRows].join('\n');
+};
+
 const fetchCapturedDeclarations = async (organizationId) => {
   const snapshot = await admin
     .firestore()
@@ -438,7 +571,95 @@ const downloadGiftAidExportBatchFile = (req, res) => {
   });
 };
 
+const exportGasdsCsv = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return res.status(405).send({ error: 'Method not allowed' });
+      }
+
+      const auth = await verifyAuth(req);
+      const organizationId =
+        typeof req.body?.organizationId === 'string' ? req.body.organizationId.trim() : '';
+      await ensureGiftAidExportAccess(auth, organizationId);
+
+      const taxYear = typeof req.body?.taxYear === 'string' ? req.body.taxYear.trim() : '';
+      const resolvedTaxYear = resolveUkTaxYearRange(taxYear);
+      if (!resolvedTaxYear) {
+        return res.status(400).send({ error: 'taxYear must be in YYYY-YYYY format' });
+      }
+
+      const requestedLocationIds = Array.isArray(req.body?.locationIds)
+        ? req.body.locationIds
+            .map((value) => (typeof value === 'string' ? value.trim() : ''))
+            .filter(Boolean)
+        : [];
+
+      if (requestedLocationIds.length === 0) {
+        return res.status(400).send({ error: 'At least one location must be selected' });
+      }
+
+      const snapshot = await admin
+        .firestore()
+        .collection('donations')
+        .where('organizationId', '==', organizationId)
+        .get();
+
+      const selectedLocationIds = new Set(requestedLocationIds);
+      const rows = [];
+      for (const doc of snapshot.docs) {
+        const donation = doc.data() || {};
+        const locationId =
+          typeof donation.location_id === 'string' ? donation.location_id.trim() : null;
+        if (!locationId || !selectedLocationIds.has(locationId)) continue;
+
+        const donationDate = resolveDonationDate(donation);
+        if (!donationDate) continue;
+        if (donationDate < resolvedTaxYear.start || donationDate > resolvedTaxYear.end) continue;
+
+        const taxYearLabel = buildUkTaxYearLabel(donationDate);
+        if (!taxYearLabel || taxYearLabel !== resolvedTaxYear.label) continue;
+
+        const campaignMode = resolveCampaignMode(donation);
+        const amount = Number(donation.amount);
+        const amountMajor = Number.isFinite(amount) ? amount : 0;
+        const isEligible = amountMajor <= 30 && campaignMode === 'DONATION';
+        const locationSnapshot = resolveLocationSnapshot(donation);
+
+        rows.push({
+          donation_id: donation.transactionId || donation.stripePaymentIntentId || doc.id,
+          amount: amountMajor.toFixed(2),
+          date: donationDate.toISOString(),
+          method: donation.platform || 'unknown',
+          location_name: locationSnapshot?.name || '',
+          postcode: locationSnapshot?.postcode || '',
+          address_line1: locationSnapshot?.addressLine1 || '',
+          tax_year: resolvedTaxYear.label,
+          campaign_mode: campaignMode,
+          is_gasds_eligible: isEligible ? 'true' : 'false',
+        });
+      }
+
+      rows.sort((left, right) => left.date.localeCompare(right.date));
+      const csvContent = buildGasdsCsv(rows);
+      const fileName = `gasds-${organizationId}-${resolvedTaxYear.label}.csv`;
+
+      res.set('Content-Type', 'text/csv; charset=utf-8');
+      res.set('Content-Disposition', `attachment; filename="${fileName}"`);
+      res.set('Cache-Control', 'private, no-store, max-age=0');
+      return res.status(200).send(csvContent);
+    } catch (error) {
+      console.error('Error exporting GASDS csv:', error);
+      const statusCode = Number.isInteger(error.code) ? error.code : 500;
+      return res.status(statusCode).send({
+        error: error.message || 'Failed to export GASDS csv',
+      });
+    }
+  });
+};
+
 module.exports = {
   exportGiftAidDeclarations,
   downloadGiftAidExportBatchFile,
+  exportGasdsCsv,
 };

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -33,6 +33,7 @@ const {
   exportGiftAidDeclarations,
   downloadGiftAidExportBatchFile,
   exportGasdsCsv,
+  downloadGasdsExportBatchFile,
 } = require('./handlers/giftAid');
 const { exportDonations } = require('./handlers/donationsExport');
 const { exportSubscriptions } = require('./handlers/subscriptionsExport');
@@ -138,6 +139,7 @@ exports.createExpressDashboardLink = functions.https.onRequest(
 exports.exportGiftAidDeclarations = functions.https.onRequest(exportGiftAidDeclarations);
 exports.downloadGiftAidExportBatchFile = functions.https.onRequest(downloadGiftAidExportBatchFile);
 exports.exportGasdsCsv = functions.https.onRequest(exportGasdsCsv);
+exports.downloadGasdsExportBatchFile = functions.https.onRequest(downloadGasdsExportBatchFile);
 exports.exportDonations = functions.https.onRequest(exportDonations);
 exports.exportSubscriptions = functions.https.onRequest(exportSubscriptions);
 exports.exportKiosks = functions.https.onRequest(exportKiosks);

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -29,7 +29,11 @@ const {
   createPaymentIntent,
   createExpressDashboardLink,
 } = require('./handlers/payments');
-const { exportGiftAidDeclarations, downloadGiftAidExportBatchFile } = require('./handlers/giftAid');
+const {
+  exportGiftAidDeclarations,
+  downloadGiftAidExportBatchFile,
+  exportGasdsCsv,
+} = require('./handlers/giftAid');
 const { exportDonations } = require('./handlers/donationsExport');
 const { exportSubscriptions } = require('./handlers/subscriptionsExport');
 const { exportKiosks } = require('./handlers/kiosksExport');
@@ -133,6 +137,7 @@ exports.createExpressDashboardLink = functions.https.onRequest(
 );
 exports.exportGiftAidDeclarations = functions.https.onRequest(exportGiftAidDeclarations);
 exports.downloadGiftAidExportBatchFile = functions.https.onRequest(downloadGiftAidExportBatchFile);
+exports.exportGasdsCsv = functions.https.onRequest(exportGasdsCsv);
 exports.exportDonations = functions.https.onRequest(exportDonations);
 exports.exportSubscriptions = functions.https.onRequest(exportSubscriptions);
 exports.exportKiosks = functions.https.onRequest(exportKiosks);

--- a/docs/GASDS_EXPORT_FLOW.md
+++ b/docs/GASDS_EXPORT_FLOW.md
@@ -1,0 +1,302 @@
+# GASDS Export Flow
+
+## 1) Purpose
+
+This document explains the GASDS export flow end-to-end:
+
+- what the flow does
+- how tax year and location filtering work
+- how CSV rows are constructed
+- what security and permission controls are enforced
+
+This is the **GASDS CSV export** flow from Admin Gift Aid.
+
+---
+
+## 2) Scope
+
+### In Scope
+
+- Exporting donation-level GASDS CSV for a selected UK tax year
+- Optional location filtering (multi-select, default all selected)
+- Per-donation eligibility flag calculation:
+  - `is_gasds_eligible = (amount <= 30) AND (campaign_mode == "DONATION")`
+- CSV safety hardening (formula injection guard + escaping)
+
+### Out of Scope
+
+- HMRC submission integration
+- Cap enforcement in export output
+- 10:1 Gift Aid matching logic
+- Batch history persistence (not implemented for GASDS yet)
+
+---
+
+## 3) File Map
+
+### Backend
+
+- `backend/functions/handlers/giftAid.js`
+  - `exportGasdsCsv`
+  - auth + permission + org checks
+  - tax year/date filtering
+  - location filtering
+  - GASDS CSV generation
+
+- `backend/functions/index.js`
+  - function registration:
+    - `exportGasdsCsv`
+
+### Frontend
+
+- `src/entities/giftAid/api/giftAidExportApi.ts`
+  - `exportGasdsCsv(...)` API call
+  - authenticated request + browser download trigger
+
+- `src/views/admin/GiftAidManagement.tsx`
+  - GASDS section UI
+  - tax year selector
+  - location multi-select
+  - location summary table
+  - export action button
+
+- `src/shared/config/functions.ts`
+  - `FUNCTION_URLS.exportGasdsCsv`
+
+---
+
+## 4) High-Level Architecture
+
+```mermaid
+flowchart LR
+  A[Admin GiftAidManagement UI] --> B[giftAidExportApi.ts]
+  B --> C[CF: exportGasdsCsv]
+  C --> D[(Firestore: donations)]
+  C --> E[CSV builder in giftAid.js]
+  E --> F[CSV response stream]
+  F --> G[Browser file download]
+```
+
+---
+
+## 5) End-to-End Sequence
+
+```mermaid
+sequenceDiagram
+  actor Admin
+  participant UI as GiftAidManagement.tsx
+  participant API as giftAidExportApi.ts
+  participant FN as exportGasdsCsv
+  participant DB as Firestore
+
+  Admin->>UI: Select tax year + locations
+  Admin->>UI: Click "Export GASDS CSV"
+  UI->>API: exportGasdsCsv({ organizationId, taxYear, locationIds })
+  API->>FN: POST + Bearer token
+  FN->>FN: verifyAuth + permission + org scope
+  FN->>FN: validate taxYear + locationIds
+  FN->>DB: Query donations by organizationId
+  DB-->>FN: Donation docs
+  FN->>FN: Filter by UK tax year + selected locations
+  FN->>FN: Compute campaign_mode + is_gasds_eligible
+  FN-->>API: CSV bytes + attachment headers
+  API-->>UI: Blob download
+```
+
+---
+
+## 6) Request Contract
+
+Endpoint:
+
+- `POST /exportGasdsCsv`
+
+Body:
+
+```json
+{
+  "organizationId": "org_123",
+  "taxYear": "2025-2026",
+  "locationIds": ["loc_a", "loc_b"]
+}
+```
+
+Validation:
+
+- `organizationId` required
+- `taxYear` must be `YYYY-YYYY` and contiguous (example: `2025-2026`)
+- `locationIds` must include at least one location
+
+---
+
+## 7) Permission Model
+
+GASDS export uses the Gift Aid export permission gate:
+
+- required permission: `export_giftaid` (or `system_admin`)
+- organization scope:
+  - non-privileged users can export only their own organization
+  - privileged (`super_admin`) can cross organization boundaries
+
+---
+
+## 8) Tax Year Logic (UK)
+
+Tax year boundary:
+
+- start: `6 April 00:00:00.000 UTC`
+- end: `5 April 23:59:59.999 UTC` (next year)
+
+Example:
+
+- `2025-2026` means `2025-04-06` through `2026-04-05`
+
+Only donations within this range are exported.
+
+---
+
+## 9) Donation Selection Rules
+
+A donation is exported when all are true:
+
+1. `organizationId` matches request
+2. `location_id` exists and is in selected `locationIds`
+3. effective donation date is inside selected UK tax year range
+
+Effective date precedence:
+
+1. `paymentCompletedAt`
+2. `timestamp`
+3. `createdAt`
+
+---
+
+## 10) CSV Schema
+
+Header order:
+
+1. `donation_id`
+2. `amount`
+3. `date`
+4. `method`
+5. `location_name`
+6. `postcode`
+7. `address_line1`
+8. `tax_year`
+9. `campaign_mode`
+10. `is_gasds_eligible`
+
+Field sources:
+
+- `donation_id`: `transactionId` fallback `stripePaymentIntentId` fallback document id
+- `amount`: `donation.amount` (formatted to 2 decimal places)
+- `date`: ISO string from effective donation date
+- `method`: `donation.platform` fallback `unknown`
+- `location_name`, `postcode`, `address_line1`: `donation.location_snapshot`
+- `tax_year`: selected tax year label
+- `campaign_mode`: resolved from:
+  - `campaign_mode`
+  - `campaignMode`
+  - `metadata.campaign_mode`
+  - `metadata.campaignMode`
+  - fallback `DONATION`
+- `is_gasds_eligible`: `true|false`
+
+---
+
+## 11) Eligibility Logic
+
+Eligibility is flagged, not filtered:
+
+- `is_gasds_eligible = (amount <= 30) AND (campaign_mode == "DONATION")`
+
+All matched donations are included in CSV, regardless of eligibility.
+
+---
+
+## 12) UI Behavior (Admin Gift Aid)
+
+`GiftAidManagement.tsx` GASDS section provides:
+
+- tax year selector (recent tax years)
+- location checkbox list (all selected by default)
+- summary table by selected location:
+  - Total Collected
+  - Eligible
+  - Cap (`£8,000`)
+  - Status (`OK` / `Exceeds`)
+  - community building note for potential `£16k` cap
+
+Validation in UI before export:
+
+- tax year must be selected
+- at least one location must be selected
+
+---
+
+## 13) Security Controls
+
+### Auth and Authorization
+
+- Firebase token verification on backend
+- permission and org scope enforcement in cloud function
+
+### CSV Formula Injection Hardening
+
+Before CSV escaping:
+
+- if a cell starts (including leading whitespace/newline/tab) with `=`, `+`, `-`, or `@`
+- value is prefixed with `'`
+
+Then standard CSV escaping is applied for quotes, commas, and line breaks.
+
+---
+
+## 14) Error Handling
+
+Typical responses:
+
+- `400` invalid input (`taxYear`, missing location selection, missing organization id)
+- `403` permission or org scope violation
+- `405` method not allowed
+- `500` unhandled server failure
+
+On success:
+
+- returns CSV file bytes with:
+  - `Content-Type: text/csv; charset=utf-8`
+  - `Content-Disposition: attachment; filename="gasds-{organizationId}-{taxYear}.csv"`
+  - `Cache-Control: private, no-store, max-age=0`
+
+---
+
+## 15) Known Differences vs Gift Aid Export
+
+Current GASDS export is **on-demand streaming**:
+
+- no batch doc persisted
+- no Cloud Storage file persistence
+- no checksum (`sha256`) metadata
+- no re-download history endpoint
+
+This can be extended later if parity with Gift Aid batch governance is required.
+
+---
+
+## 16) Quick Reference
+
+Backend function:
+
+- `exportGasdsCsv` in `backend/functions/handlers/giftAid.js`
+
+Function registration:
+
+- `exports.exportGasdsCsv` in `backend/functions/index.js`
+
+Frontend API bridge:
+
+- `exportGasdsCsv(...)` in `src/entities/giftAid/api/giftAidExportApi.ts`
+
+Admin UI entry:
+
+- GASDS section in `src/views/admin/GiftAidManagement.tsx`

--- a/docs/GASDS_EXPORT_FLOW.md
+++ b/docs/GASDS_EXPORT_FLOW.md
@@ -6,10 +6,9 @@ This document explains the GASDS export flow end-to-end:
 
 - what the flow does
 - how tax year and location filtering work
-- how CSV rows are constructed
+- how detailed and summary CSVs are generated
+- how batch history and file re-download work
 - what security and permission controls are enforced
-
-This is the **GASDS CSV export** flow from Admin Gift Aid.
 
 ---
 
@@ -19,8 +18,10 @@ This is the **GASDS CSV export** flow from Admin Gift Aid.
 
 - Exporting donation-level GASDS CSV for a selected UK tax year
 - Optional location filtering (multi-select, default all selected)
-- Per-donation eligibility flag calculation:
-  - `is_gasds_eligible = (amount <= 30) AND (campaign_mode == "DONATION")`
+- Strict export mode (eligible rows only)
+- Eligibility flag + ineligibility reason classification
+- Per-location summary CSV
+- Batch history persistence and re-download
 - CSV safety hardening (formula injection guard + escaping)
 
 ### Out of Scope
@@ -28,7 +29,6 @@ This is the **GASDS CSV export** flow from Admin Gift Aid.
 - HMRC submission integration
 - Cap enforcement in export output
 - 10:1 Gift Aid matching logic
-- Batch history persistence (not implemented for GASDS yet)
 
 ---
 
@@ -38,30 +38,41 @@ This is the **GASDS CSV export** flow from Admin Gift Aid.
 
 - `backend/functions/handlers/giftAid.js`
   - `exportGasdsCsv`
+  - `downloadGasdsExportBatchFile`
   - auth + permission + org checks
   - tax year/date filtering
   - location filtering
-  - GASDS CSV generation
+  - detailed + summary CSV generation
+  - GASDS batch lifecycle persistence
 
 - `backend/functions/index.js`
-  - function registration:
+  - function registrations:
     - `exportGasdsCsv`
+    - `downloadGasdsExportBatchFile`
 
 ### Frontend
 
 - `src/entities/giftAid/api/giftAidExportApi.ts`
-  - `exportGasdsCsv(...)` API call
-  - authenticated request + browser download trigger
+  - `exportGasdsCsv(...)`
+  - GASDS export history fetch (paginated)
+  - GASDS batch file download
+
+- `src/shared/lib/hooks/useGasdsExportBatches.ts`
+  - paginated GASDS batch history hook
 
 - `src/views/admin/GiftAidManagement.tsx`
   - GASDS section UI
   - tax year selector
   - location multi-select
+  - strict mode toggle
+  - compliance note
   - location summary table
-  - export action button
+  - ineligibility summary display
+  - batch history with detailed/summary re-download
 
 - `src/shared/config/functions.ts`
   - `FUNCTION_URLS.exportGasdsCsv`
+  - `FUNCTION_URLS.downloadGasdsExportBatchFile`
 
 ---
 
@@ -72,14 +83,29 @@ flowchart LR
   A[Admin GiftAidManagement UI] --> B[giftAidExportApi.ts]
   B --> C[CF: exportGasdsCsv]
   C --> D[(Firestore: donations)]
-  C --> E[CSV builder in giftAid.js]
-  E --> F[CSV response stream]
-  F --> G[Browser file download]
+  C --> E[(Cloud Storage: gasdsExports/...)]
+  C --> F[(Firestore: gasdsExportBatches)]
+  A --> G[CF: downloadGasdsExportBatchFile]
+  G --> E
+  G --> H[Browser download]
 ```
 
 ---
 
-## 5) End-to-End Sequence
+## 5) Export Batch Lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending
+  pending --> completed: files saved + batch updated
+  pending --> failed: fatal error
+  failed --> [*]
+  completed --> [*]
+```
+
+---
+
+## 6) End-to-End Sequence
 
 ```mermaid
 sequenceDiagram
@@ -88,59 +114,87 @@ sequenceDiagram
   participant API as giftAidExportApi.ts
   participant FN as exportGasdsCsv
   participant DB as Firestore
+  participant ST as Cloud Storage
 
-  Admin->>UI: Select tax year + locations
+  Admin->>UI: Select tax year + locations (+ optional strict mode)
   Admin->>UI: Click "Export GASDS CSV"
-  UI->>API: exportGasdsCsv({ organizationId, taxYear, locationIds })
+  UI->>API: exportGasdsCsv(request)
   API->>FN: POST + Bearer token
   FN->>FN: verifyAuth + permission + org scope
-  FN->>FN: validate taxYear + locationIds
-  FN->>DB: Query donations by organizationId
+  FN->>FN: validate request payload
+  FN->>DB: Query donations for organization
   DB-->>FN: Donation docs
   FN->>FN: Filter by UK tax year + selected locations
-  FN->>FN: Compute campaign_mode + is_gasds_eligible
-  FN-->>API: CSV bytes + attachment headers
-  API-->>UI: Blob download
+  FN->>FN: Build detailed rows + location summary rows
+  FN->>DB: Create batch(status=pending)
+  FN->>ST: Save detailed CSV + summary CSV
+  FN->>DB: Update batch(status=completed, file metadata, counts)
+  FN-->>API: success payload with batch/files/summary
+  UI->>API: downloadGasdsExportFile(batchId, detailed)
+  UI->>API: downloadGasdsExportFile(batchId, summary)
 ```
 
 ---
 
-## 6) Request Contract
+## 7) Request Contract
 
-Endpoint:
+### Export Endpoint
 
 - `POST /exportGasdsCsv`
 
-Body:
+Request body:
 
 ```json
 {
   "organizationId": "org_123",
   "taxYear": "2025-2026",
-  "locationIds": ["loc_a", "loc_b"]
+  "locationIds": ["loc_a", "loc_b"],
+  "strictMode": false
 }
 ```
 
 Validation:
 
 - `organizationId` required
-- `taxYear` must be `YYYY-YYYY` and contiguous (example: `2025-2026`)
+- `taxYear` must be `YYYY-YYYY` and contiguous
 - `locationIds` must include at least one location
+- `strictMode` optional boolean
+
+### Download Endpoint
+
+- `POST /downloadGasdsExportBatchFile`
+
+Request body:
+
+```json
+{
+  "batchId": "batch_abc",
+  "fileKind": "detailed"
+}
+```
+
+`fileKind` must be:
+
+- `detailed`
+- `summary`
 
 ---
 
-## 7) Permission Model
+## 8) Permission Model
 
-GASDS export uses the Gift Aid export permission gate:
+GASDS export uses existing Gift Aid export permissions:
 
-- required permission: `export_giftaid` (or `system_admin`)
-- organization scope:
-  - non-privileged users can export only their own organization
-  - privileged (`super_admin`) can cross organization boundaries
+- create export: `export_giftaid` or `system_admin`
+- download export batch files: `download_giftaid_exports` or `system_admin`
+
+Org scope:
+
+- non-privileged users can only operate on their own organization
+- privileged (`super_admin`) can cross org boundary
 
 ---
 
-## 8) Tax Year Logic (UK)
+## 9) Tax Year Logic (UK)
 
 Tax year boundary:
 
@@ -151,17 +205,17 @@ Example:
 
 - `2025-2026` means `2025-04-06` through `2026-04-05`
 
-Only donations within this range are exported.
+Only donations in this range are considered.
 
 ---
 
-## 9) Donation Selection Rules
+## 10) Donation Selection Rules
 
-A donation is exported when all are true:
+A donation row is considered when all are true:
 
-1. `organizationId` matches request
+1. organization matches request
 2. `location_id` exists and is in selected `locationIds`
-3. effective donation date is inside selected UK tax year range
+3. effective donation date is within selected UK tax year range
 
 Effective date precedence:
 
@@ -171,7 +225,29 @@ Effective date precedence:
 
 ---
 
-## 10) CSV Schema
+## 11) Eligibility and Strict Mode
+
+Eligibility rule:
+
+- `is_gasds_eligible = (amount <= 30) AND (campaign_mode == "DONATION")`
+
+Mode behavior:
+
+- default mode: include all matched rows; ineligible rows carry a reason
+- strict mode: include only eligible rows in detailed CSV
+
+Ineligibility reason values:
+
+- `over_30`
+- `non_donation_mode`
+- `over_30_and_non_donation_mode`
+- empty string when eligible
+
+---
+
+## 12) CSV Schemas
+
+### 12.1 Detailed GASDS CSV
 
 Header order:
 
@@ -185,118 +261,132 @@ Header order:
 8. `tax_year`
 9. `campaign_mode`
 10. `is_gasds_eligible`
+11. `gift_aid_matched_in_same_year`
+12. `reason_not_eligible`
 
-Field sources:
+Field source note:
 
-- `donation_id`: `transactionId` fallback `stripePaymentIntentId` fallback document id
-- `amount`: `donation.amount` (formatted to 2 decimal places)
-- `date`: ISO string from effective donation date
-- `method`: `donation.platform` fallback `unknown`
-- `location_name`, `postcode`, `address_line1`: `donation.location_snapshot`
-- `tax_year`: selected tax year label
-- `campaign_mode`: resolved from:
-  - `campaign_mode`
-  - `campaignMode`
-  - `metadata.campaign_mode`
-  - `metadata.campaignMode`
-  - fallback `DONATION`
-- `is_gasds_eligible`: `true|false`
+- `amount` comes from `donation.amount` (stored in minor units) and is converted to major units for CSV output
+- `location_name` and `postcode` come from `donation.location_snapshot`
+- `address_line1` uses `location_snapshot.addressLine1` when present
+- fallback for legacy snapshots uses `location_snapshot.city` when `addressLine1` is absent
 
----
+### 12.2 Location Summary CSV
 
-## 11) Eligibility Logic
+Header order:
 
-Eligibility is flagged, not filtered:
-
-- `is_gasds_eligible = (amount <= 30) AND (campaign_mode == "DONATION")`
-
-All matched donations are included in CSV, regardless of eligibility.
+1. `location_id`
+2. `location_name`
+3. `postcode`
+4. `total_collected`
+5. `eligible`
+6. `cap`
+7. `status`
+8. `community_building_note`
 
 ---
 
-## 12) UI Behavior (Admin Gift Aid)
+## 13) Batch Storage and Metadata
 
-`GiftAidManagement.tsx` GASDS section provides:
+Collection:
 
-- tax year selector (recent tax years)
-- location checkbox list (all selected by default)
-- summary table by selected location:
-  - Total Collected
-  - Eligible
-  - Cap (`£8,000`)
-  - Status (`OK` / `Exceeds`)
-  - community building note for potential `£16k` cap
+- `gasdsExportBatches`
 
-Validation in UI before export:
+Stored files:
 
-- tax year must be selected
-- at least one location must be selected
+- `gasdsExports/{organizationId}/{batchId}/{fileName}.csv`
 
----
+Batch metadata includes:
 
-## 13) Security Controls
-
-### Auth and Authorization
-
-- Firebase token verification on backend
-- permission and org scope enforcement in cloud function
-
-### CSV Formula Injection Hardening
-
-Before CSV escaping:
-
-- if a cell starts (including leading whitespace/newline/tab) with `=`, `+`, `-`, or `@`
-- value is prefixed with `'`
-
-Then standard CSV escaping is applied for quotes, commas, and line breaks.
+- creator identity
+- tax year
+- strict mode
+- selected location IDs
+- row counts
+- reason counts
+- file metadata (`fileName`, `storagePath`, `sha256`, `sizeBytes`)
+- lifecycle status (`pending`, `completed`, `failed`)
 
 ---
 
-## 14) Error Handling
+## 14) UI Behavior
 
-Typical responses:
+`GiftAidManagement.tsx` GASDS section includes:
 
-- `400` invalid input (`taxYear`, missing location selection, missing organization id)
-- `403` permission or org scope violation
-- `405` method not allowed
-- `500` unhandled server failure
-
-On success:
-
-- returns CSV file bytes with:
-  - `Content-Type: text/csv; charset=utf-8`
-  - `Content-Disposition: attachment; filename="gasds-{organizationId}-{taxYear}.csv"`
-  - `Cache-Control: private, no-store, max-age=0`
+- UK tax year selector label clarified as scheme year
+- compliance note:
+  - eligibility is indicative; final HMRC checks still required
+- location multi-select (all selected by default)
+- strict mode toggle
+- per-location summary table with cap/status
+- ineligibility reason count summary
+- GASDS batch history with detailed/summary re-download actions
 
 ---
 
-## 15) Known Differences vs Gift Aid Export
+## 15) Security Controls
 
-Current GASDS export is **on-demand streaming**:
+### 15.1 Auth + Authorization
 
-- no batch doc persisted
-- no Cloud Storage file persistence
-- no checksum (`sha256`) metadata
-- no re-download history endpoint
+- Firebase token verification
+- permission checks
+- organization scope checks
 
-This can be extended later if parity with Gift Aid batch governance is required.
+### 15.2 CSV Formula Injection Hardening
+
+Before escaping CSV:
+
+- if a string starts (including leading whitespace/tab/newline) with `=`, `+`, `-`, or `@`
+- prefix with `'`
+
+Then apply normal CSV escaping for quotes/commas/newlines.
 
 ---
 
-## 16) Quick Reference
+## 16) Error Handling
 
-Backend function:
+Common errors:
 
-- `exportGasdsCsv` in `backend/functions/handlers/giftAid.js`
+- `400` invalid request payload
+- `403` permission/org scope violations
+- `404` batch/file not found during download
+- `405` wrong HTTP method
+- `500` unhandled server error
 
-Function registration:
+On export failure after batch creation:
 
-- `exports.exportGasdsCsv` in `backend/functions/index.js`
+- batch status is set to `failed`
+- `failureMessage` and `failedAt` are recorded
 
-Frontend API bridge:
+---
 
-- `exportGasdsCsv(...)` in `src/entities/giftAid/api/giftAidExportApi.ts`
+## 17) Tests
 
-Admin UI entry:
+Boundary coverage added for UK tax year logic:
 
-- GASDS section in `src/views/admin/GiftAidManagement.tsx`
+- `5 April 23:59:59.999` remains in previous tax year
+- `6 April 00:00:00.000` moves to next tax year
+- range parsing validates `YYYY-YYYY` contiguity
+
+Test file:
+
+- `backend/functions/handlers/giftAid.gasds.test.js`
+
+---
+
+## 18) Quick Reference
+
+Backend:
+
+- `exportGasdsCsv`
+- `downloadGasdsExportBatchFile`
+
+Frontend API:
+
+- `exportGasdsCsv(...)`
+- `fetchGasdsExportBatchesPaginated(...)`
+- `downloadGasdsExportFile(...)`
+
+UI:
+
+- GASDS panel in `src/views/admin/GiftAidManagement.tsx`

--- a/src/entities/giftAid/api/giftAidExportApi.ts
+++ b/src/entities/giftAid/api/giftAidExportApi.ts
@@ -63,6 +63,15 @@ export interface GiftAidExportBatchPage {
 }
 
 export type GiftAidExportFileKind = 'hmrc' | 'internal';
+export interface GasdsLocationSummaryRow {
+  locationId: string;
+  locationName: string;
+  postcode: string;
+  totalCollected: number;
+  eligible: number;
+  cap: number;
+  isCommunityBuilding: boolean;
+}
 
 interface GiftAidBatchTimestampFields {
   createdAt?: unknown;
@@ -153,6 +162,10 @@ const getGiftAidBatchDownloadFunctionUrl = () => {
   }
 
   return FUNCTION_URLS.downloadGiftAidExportBatchFile;
+};
+
+const getGasdsExportFunctionUrl = () => {
+  return FUNCTION_URLS.exportGasdsCsv;
 };
 
 const getCurrentUserToken = async () => {
@@ -388,4 +401,53 @@ export async function downloadGiftAidExportFile(
 
   const blob = await response.blob();
   triggerBlobDownload(blob, file.fileName);
+}
+
+const parseFileName = (contentDisposition: string | null, fallbackName: string) => {
+  if (!contentDisposition) return fallbackName;
+  const match = /filename="([^"]+)"/i.exec(contentDisposition);
+  if (!match || !match[1]) return fallbackName;
+  return match[1];
+};
+
+export async function exportGasdsCsv(params: {
+  organizationId: string;
+  taxYear: string;
+  locationIds: string[];
+}) {
+  const token = await getCurrentUserToken();
+  const url = getGasdsExportFunctionUrl();
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(params),
+    });
+  } catch {
+    throw new Error(`Could not reach GASDS export function at ${url}.`);
+  }
+
+  if (!response.ok) {
+    let errorMessage = 'Failed to export GASDS CSV.';
+    try {
+      const errorData = await response.json();
+      if (typeof errorData?.error === 'string' && errorData.error.trim()) {
+        errorMessage = errorData.error;
+      }
+    } catch {
+      const text = await response.text().catch(() => '');
+      if (text) errorMessage = text;
+    }
+    throw new Error(errorMessage);
+  }
+
+  const fallbackName = `gasds-${params.taxYear}.csv`;
+  const fileName = parseFileName(response.headers.get('content-disposition'), fallbackName);
+  const blob = await response.blob();
+  triggerBlobDownload(blob, fileName);
 }

--- a/src/entities/giftAid/api/giftAidExportApi.ts
+++ b/src/entities/giftAid/api/giftAidExportApi.ts
@@ -61,6 +61,42 @@ export interface GiftAidExportBatchPage {
   lastDoc: DocumentSnapshot | null;
   hasNextPage: boolean;
 }
+export interface GasdsExportResult {
+  success: true;
+  batchId: string;
+  rowCount: number;
+  taxYear: string;
+  strictMode: boolean;
+  detailedFile: GiftAidExportFile;
+  summaryFile: GiftAidExportFile;
+  summary: {
+    byReason: Record<string, number>;
+    summaryRowCount: number;
+  };
+}
+
+export interface GasdsExportBatch {
+  id: string;
+  batchId?: string;
+  organizationId: string;
+  taxYear: string;
+  strictMode: boolean;
+  status: string;
+  rowCount: number;
+  summaryRowCount?: number;
+  detailedFile?: GiftAidExportFile | null;
+  summaryFile?: GiftAidExportFile | null;
+  createdAt?: string;
+  completedAt?: string;
+  failedAt?: string;
+  failureMessage?: string;
+}
+
+export interface GasdsExportBatchPage {
+  batches: GasdsExportBatch[];
+  lastDoc: DocumentSnapshot | null;
+  hasNextPage: boolean;
+}
 
 export type GiftAidExportFileKind = 'hmrc' | 'internal';
 export interface GasdsLocationSummaryRow {
@@ -166,6 +202,10 @@ const getGiftAidBatchDownloadFunctionUrl = () => {
 
 const getGasdsExportFunctionUrl = () => {
   return FUNCTION_URLS.exportGasdsCsv;
+};
+
+const getGasdsBatchDownloadFunctionUrl = () => {
+  return FUNCTION_URLS.downloadGasdsExportBatchFile;
 };
 
 const getCurrentUserToken = async () => {
@@ -414,6 +454,7 @@ export async function exportGasdsCsv(params: {
   organizationId: string;
   taxYear: string;
   locationIds: string[];
+  strictMode?: boolean;
 }) {
   const token = await getCurrentUserToken();
   const url = getGasdsExportFunctionUrl();
@@ -446,7 +487,117 @@ export async function exportGasdsCsv(params: {
     throw new Error(errorMessage);
   }
 
-  const fallbackName = `gasds-${params.taxYear}.csv`;
+  return (await response.json()) as GasdsExportResult;
+}
+
+export async function fetchGasdsExportBatchesPaginated(
+  organizationId: string,
+  cursor: DocumentSnapshot | null,
+  pageSize: number,
+): Promise<GasdsExportBatchPage> {
+  const constraints: Parameters<typeof query>[1][] = [
+    where('organizationId', '==', organizationId),
+    orderBy('createdAt', 'desc'),
+    orderBy('__name__', 'desc'),
+    limit(pageSize + 1),
+  ];
+
+  if (cursor) constraints.push(startAfter(cursor));
+
+  const batchesQuery = query(collection(db, 'gasdsExportBatches'), ...constraints);
+
+  let snapshot;
+  try {
+    snapshot = await getDocs(batchesQuery);
+  } catch (err: unknown) {
+    const code = (err as { code?: string })?.code;
+    if (code !== 'failed-precondition') throw err;
+
+    const fallbackQuery = query(
+      collection(db, 'gasdsExportBatches'),
+      where('organizationId', '==', organizationId),
+    );
+    const fallbackSnapshot = await getDocs(fallbackQuery);
+    const sortedDocs = [...fallbackSnapshot.docs].sort((a, b) => {
+      const aTime = getBatchSortMillis(a.data() as GiftAidBatchTimestampFields);
+      const bTime = getBatchSortMillis(b.data() as GiftAidBatchTimestampFields);
+      if (aTime !== bTime) return bTime - aTime;
+      return b.id.localeCompare(a.id);
+    });
+
+    const startIndex = cursor ? sortedDocs.findIndex((docSnap) => docSnap.id === cursor.id) + 1 : 0;
+    const docs = sortedDocs.slice(startIndex, startIndex + pageSize);
+    const hasNextPage = startIndex + pageSize < sortedDocs.length;
+
+    return {
+      batches: docs.map(
+        (docSnapshot) =>
+          ({
+            id: docSnapshot.id,
+            ...docSnapshot.data(),
+          }) as GasdsExportBatch,
+      ),
+      lastDoc: docs[docs.length - 1] ?? null,
+      hasNextPage,
+    };
+  }
+
+  if (snapshot.empty) return { batches: [], lastDoc: null, hasNextPage: false };
+
+  const hasNextPage = snapshot.docs.length > pageSize;
+  const docs: QueryDocumentSnapshot[] = hasNextPage
+    ? snapshot.docs.slice(0, pageSize)
+    : snapshot.docs;
+
+  return {
+    batches: docs.map(
+      (docSnapshot) =>
+        ({
+          id: docSnapshot.id,
+          ...docSnapshot.data(),
+        }) as GasdsExportBatch,
+    ),
+    lastDoc: docs[docs.length - 1] ?? null,
+    hasNextPage,
+  };
+}
+
+export async function downloadGasdsExportFile(
+  batchId: string,
+  fileKind: 'detailed' | 'summary',
+  file: GiftAidExportFile,
+) {
+  const token = await getCurrentUserToken();
+  const url = getGasdsBatchDownloadFunctionUrl();
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ batchId, fileKind }),
+    });
+  } catch {
+    throw new Error(`Could not reach GASDS batch download function at ${url}.`);
+  }
+
+  if (!response.ok) {
+    let errorMessage = `Failed to download ${file.fileName}.`;
+    try {
+      const errorData = await response.json();
+      if (typeof errorData?.error === 'string' && errorData.error.trim()) {
+        errorMessage = errorData.error;
+      }
+    } catch {
+      // keep generic
+    }
+    throw new Error(errorMessage);
+  }
+
+  const fallbackName = `gasds-${batchId}-${fileKind}.csv`;
   const fileName = parseFileName(response.headers.get('content-disposition'), fallbackName);
   const blob = await response.blob();
   triggerBlobDownload(blob, fileName);

--- a/src/shared/config/functions.ts
+++ b/src/shared/config/functions.ts
@@ -19,6 +19,7 @@ export const FUNCTION_URLS = {
   createPaymentIntent: getFunctionUrl('createPaymentIntent'),
   exportGiftAidDeclarations: getFunctionUrl('exportGiftAidDeclarations'),
   exportGasdsCsv: getFunctionUrl('exportGasdsCsv'),
+  downloadGasdsExportBatchFile: getFunctionUrl('downloadGasdsExportBatchFile'),
   downloadGiftAidExportBatchFile: getFunctionUrl('downloadGiftAidExportBatchFile'),
   exportDonations: getFunctionUrl('exportDonations'),
   exportSubscriptions: getFunctionUrl('exportSubscriptions'),

--- a/src/shared/config/functions.ts
+++ b/src/shared/config/functions.ts
@@ -18,6 +18,7 @@ export const FUNCTION_URLS = {
   createOnboardingLink: getFunctionUrl('createOnboardingLink'),
   createPaymentIntent: getFunctionUrl('createPaymentIntent'),
   exportGiftAidDeclarations: getFunctionUrl('exportGiftAidDeclarations'),
+  exportGasdsCsv: getFunctionUrl('exportGasdsCsv'),
   downloadGiftAidExportBatchFile: getFunctionUrl('downloadGiftAidExportBatchFile'),
   exportDonations: getFunctionUrl('exportDonations'),
   exportSubscriptions: getFunctionUrl('exportSubscriptions'),

--- a/src/shared/lib/hooks/useGasdsExportBatches.ts
+++ b/src/shared/lib/hooks/useGasdsExportBatches.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchGasdsExportBatchesPaginated } from '../../../entities/giftAid/api';
+import { usePagination } from './usePagination';
+
+const DEFAULT_GASDS_EXPORT_HISTORY_PAGE_SIZE = 5;
+
+export function useGasdsExportBatches(
+  organizationId?: string,
+  pageSize = DEFAULT_GASDS_EXPORT_HISTORY_PAGE_SIZE,
+) {
+  const pagination = usePagination();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    pagination.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [organizationId]);
+
+  const queryKey = [
+    'gasds-export-batches',
+    organizationId,
+    pagination.currentCursor?.id ?? 'page-1',
+    pageSize,
+  ] as const;
+
+  const { data, isLoading, isFetching, error } = useQuery({
+    queryKey,
+    queryFn: () => {
+      if (!organizationId) throw new Error('organizationId is required');
+      return fetchGasdsExportBatchesPaginated(organizationId, pagination.currentCursor, pageSize);
+    },
+    enabled: !!organizationId,
+    placeholderData: (prev) => prev,
+    staleTime: 30_000,
+  });
+
+  useEffect(() => {
+    if (data) {
+      pagination.updatePage({ lastDoc: data.lastDoc, hasNextPage: data.hasNextPage });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  if (process.env.NODE_ENV !== 'production' && error) {
+    console.error('[useGasdsExportBatches]', error);
+  }
+
+  const refresh = useCallback(() => {
+    return queryClient.invalidateQueries({
+      predicate: (q) =>
+        q.queryKey[0] === 'gasds-export-batches' && q.queryKey[1] === organizationId,
+    });
+  }, [queryClient, organizationId]);
+
+  const goFirst = useCallback(() => {
+    pagination.reset();
+  }, [pagination]);
+
+  return {
+    exportBatches: data?.batches ?? [],
+    loading: isLoading,
+    fetching: isFetching,
+    error: error ? 'Failed to load GASDS export history. Please try again.' : null,
+    pageNumber: pagination.pageNumber,
+    canGoNext: pagination.canGoNext,
+    canGoPrev: pagination.canGoPrev,
+    goFirst,
+    goNext: pagination.goNext,
+    goPrev: pagination.goPrev,
+    pageSize,
+    refresh,
+  };
+}

--- a/src/views/admin/GiftAidManagement.tsx
+++ b/src/views/admin/GiftAidManagement.tsx
@@ -2,10 +2,12 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Screen, AdminSession, Permission } from '../../shared/types';
 import { GiftAidDeclaration } from '../../entities/giftAid/model/types';
 import {
+  downloadGasdsExportFile,
   downloadGiftAidExportFile,
   exportGiftAidDeclarations,
   exportGasdsCsv,
   giftAidApi,
+  type GasdsExportResult,
   type GiftAidExportFile,
 } from '../../entities/giftAid/api';
 import { AdminLayout } from './AdminLayout';
@@ -44,6 +46,7 @@ import { AdminStatsGrid } from './components/AdminStatsGrid';
 import { formatCurrency } from '../../shared/lib/currencyFormatter';
 import { useGiftAid } from '../../shared/lib/hooks/useGiftAid';
 import { useGiftAidExportBatches } from '../../shared/lib/hooks/useGiftAidExportBatches';
+import { useGasdsExportBatches } from '../../shared/lib/hooks/useGasdsExportBatches';
 import { PaginationControls } from '../../shared/ui/PaginationControls';
 import { useToast } from '../../shared/ui/ToastProvider';
 import { getAllCampaigns } from '../../shared/api';
@@ -97,6 +100,14 @@ const toDate = (value: unknown): Date | null => {
   return null;
 };
 
+const chunkArray = <T,>(items: T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+};
+
 export function GiftAidManagement({
   onNavigate,
   onLogout,
@@ -122,6 +133,10 @@ export function GiftAidManagement({
   const [locations, setLocations] = useState<Location[]>([]);
   const [selectedGasdsTaxYear, setSelectedGasdsTaxYear] = useState('');
   const [selectedGasdsLocationIds, setSelectedGasdsLocationIds] = useState<string[]>([]);
+  const [strictGasdsMode, setStrictGasdsMode] = useState(false);
+  const [gasdsExportSummary, setGasdsExportSummary] = useState<GasdsExportResult['summary'] | null>(
+    null,
+  );
   const [gasdsSummaryRows, setGasdsSummaryRows] = useState<
     Array<{
       locationId: string;
@@ -182,6 +197,22 @@ export function GiftAidManagement({
     pageSize: exportHistoryPageSize,
     refresh: refreshExportHistory,
   } = useGiftAidExportBatches(
+    canDownloadGiftAidBatchHistory ? userSession.user.organizationId : undefined,
+    EXPORT_HISTORY_PAGE_SIZE,
+  );
+  const {
+    exportBatches: gasdsExportBatches,
+    loading: gasdsExportHistoryLoading,
+    fetching: gasdsExportHistoryFetching,
+    pageNumber: gasdsExportHistoryPage,
+    canGoNext: canGoGasdsExportHistoryNext,
+    canGoPrev: canGoGasdsExportHistoryPrev,
+    goFirst: goToFirstGasdsExportHistoryPage,
+    goNext: goToNextGasdsExportHistoryPage,
+    goPrev: goToPrevGasdsExportHistoryPage,
+    pageSize: gasdsExportHistoryPageSize,
+    refresh: refreshGasdsExportHistory,
+  } = useGasdsExportBatches(
     canDownloadGiftAidBatchHistory ? userSession.user.organizationId : undefined,
     EXPORT_HISTORY_PAGE_SIZE,
   );
@@ -290,6 +321,10 @@ export function GiftAidManagement({
   }, [exportHistoryError, showToast]);
 
   useEffect(() => {
+    if (!canExportGiftAid) {
+      setGasdsSummaryRows([]);
+      return;
+    }
     const organizationId = userSession.user.organizationId;
     const taxYearRange = getTaxYearRange(selectedGasdsTaxYear);
     if (!organizationId || !taxYearRange) {
@@ -307,16 +342,39 @@ export function GiftAidManagement({
     const loadGasdsSummary = async () => {
       try {
         const donationsRef = collection(db, 'donations');
-        const donationsQuery = query(donationsRef, where('organizationId', '==', organizationId));
-        const donationSnapshot = await getDocs(donationsQuery);
+        const locationChunks = chunkArray(selectedGasdsLocationIds, 10);
+        const byId = new Map<string, Record<string, unknown>>();
+
+        try {
+          for (const locationChunk of locationChunks) {
+            const donationsQuery = query(
+              donationsRef,
+              where('organizationId', '==', organizationId),
+              where('location_id', 'in', locationChunk),
+            );
+            const donationSnapshot = await getDocs(donationsQuery);
+            donationSnapshot.docs.forEach((docSnap) => {
+              byId.set(docSnap.id, docSnap.data() as Record<string, unknown>);
+            });
+          }
+        } catch (err: unknown) {
+          const code = (err as { code?: string })?.code;
+          if (code !== 'failed-precondition') throw err;
+
+          // Fallback for missing composite index in lower environments.
+          const donationsQuery = query(donationsRef, where('organizationId', '==', organizationId));
+          const donationSnapshot = await getDocs(donationsQuery);
+          donationSnapshot.docs.forEach((docSnap) => {
+            byId.set(docSnap.id, docSnap.data() as Record<string, unknown>);
+          });
+        }
 
         const accumulator = new Map<
           string,
           { totalCollected: number; eligible: number; locationName: string; postcode: string }
         >();
 
-        donationSnapshot.docs.forEach((docSnap) => {
-          const donation = docSnap.data() as Record<string, unknown>;
+        byId.forEach((donation) => {
           const locationId =
             typeof donation.location_id === 'string' ? donation.location_id.trim() : '';
           if (!locationId || !selectedLocationIds.has(locationId)) return;
@@ -327,8 +385,8 @@ export function GiftAidManagement({
             toDate(donation.createdAt);
           if (!date || date < taxYearRange.start || date > taxYearRange.end) return;
 
-          const amount = Number(donation.amount);
-          const amountValue = Number.isFinite(amount) ? amount : 0;
+          const amountMinor = Number(donation.amount);
+          const amountValue = Number.isFinite(amountMinor) ? amountMinor : 0;
           const campaignModeRaw =
             typeof donation.campaign_mode === 'string'
               ? donation.campaign_mode
@@ -336,7 +394,7 @@ export function GiftAidManagement({
                 ? donation.campaignMode
                 : 'DONATION';
           const campaignMode = campaignModeRaw.trim().toUpperCase();
-          const isEligible = amountValue <= 30 && campaignMode === 'DONATION';
+          const isEligible = amountValue <= 3000 && campaignMode === 'DONATION';
 
           const snapshot =
             donation.location_snapshot && typeof donation.location_snapshot === 'object'
@@ -383,11 +441,17 @@ export function GiftAidManagement({
     return () => {
       isActive = false;
     };
-  }, [locations, selectedGasdsLocationIds, selectedGasdsTaxYear, userSession.user.organizationId]);
+  }, [
+    canExportGiftAid,
+    locations,
+    selectedGasdsLocationIds,
+    selectedGasdsTaxYear,
+    userSession.user.organizationId,
+  ]);
 
   const refreshGiftAidSection = useCallback(async () => {
-    await Promise.all([refresh(), refreshExportHistory()]);
-  }, [refresh, refreshExportHistory]);
+    await Promise.all([refresh(), refreshExportHistory(), refreshGasdsExportHistory()]);
+  }, [refresh, refreshExportHistory, refreshGasdsExportHistory]);
   const refreshExportHistorySection = useCallback(async () => {
     await refreshExportHistory();
   }, [refreshExportHistory]);
@@ -581,18 +645,66 @@ export function GiftAidManagement({
 
     setIsGasdsExporting(true);
     try {
-      await exportGasdsCsv({
+      const exportResult = await exportGasdsCsv({
         organizationId: userSession.user.organizationId,
         taxYear: selectedGasdsTaxYear,
         locationIds: selectedGasdsLocationIds,
+        strictMode: strictGasdsMode,
       });
-      showToast('GASDS CSV export started. Your download should begin shortly.', 'success');
+      setGasdsExportSummary(exportResult.summary);
+      try {
+        await downloadGasdsExportFile(exportResult.batchId, 'detailed', exportResult.detailedFile);
+      } catch (downloadError) {
+        console.error('Failed to download detailed GASDS export:', downloadError);
+        showToast('GASDS export succeeded, but detailed file download failed.', 'warning');
+      }
+      try {
+        await downloadGasdsExportFile(exportResult.batchId, 'summary', exportResult.summaryFile);
+      } catch (downloadError) {
+        console.error('Failed to download summary GASDS export:', downloadError);
+        showToast('GASDS export succeeded, but summary file download failed.', 'warning');
+      }
+      goToFirstGasdsExportHistoryPage();
+      await refreshGasdsExportHistory();
+      showToast(
+        `GASDS export completed. ${exportResult.rowCount} donation row(s) in batch ${exportResult.batchId}.`,
+        'success',
+      );
     } catch (error) {
       console.error('Failed to export GASDS CSV:', error);
       const message = error instanceof Error ? error.message : 'Failed to export GASDS CSV.';
       showToast(message, 'error');
     } finally {
       setIsGasdsExporting(false);
+    }
+  };
+
+  const handleDownloadGasdsBatchFile = async (
+    batchId: string,
+    fileKind: 'detailed' | 'summary',
+    file: GiftAidExportFile | null | undefined,
+  ) => {
+    if (!canDownloadGiftAidBatchHistory) {
+      showToast('You do not have permission to download GASDS export batches.', 'warning');
+      return;
+    }
+    if (!file) {
+      showToast('This GASDS export file is unavailable for download.', 'warning');
+      return;
+    }
+
+    const downloadKey = `${batchId}:${fileKind}`;
+    setActiveDownloadKey(downloadKey);
+    try {
+      await downloadGasdsExportFile(batchId, fileKind, file);
+    } catch (downloadError) {
+      console.error(`Failed to download ${fileKind} GASDS export:`, downloadError);
+      showToast(
+        'The stored GASDS export file could not be downloaded. It may have been removed from storage.',
+        'error',
+      );
+    } finally {
+      setActiveDownloadKey(null);
     }
   };
 
@@ -781,7 +893,11 @@ export function GiftAidManagement({
                 <div>
                   <h2 className="text-lg font-semibold text-slate-900">GASDS Export</h2>
                   <p className="text-sm text-gray-600">
-                    Export all donations for a UK tax year with GASDS eligibility flags.
+                    Export all donations for a UK tax year (used for both Gift Aid and GASDS) with
+                    eligibility flags.
+                  </p>
+                  <p className="text-xs text-amber-700 mt-1">
+                    Eligibility is indicative only. Final HMRC claim checks still apply.
                   </p>
                 </div>
                 <Button
@@ -801,7 +917,9 @@ export function GiftAidManagement({
 
               <div className="grid gap-4 md:grid-cols-2">
                 <div>
-                  <Label className="mb-1 block text-sm font-medium text-gray-700">Tax year</Label>
+                  <Label className="mb-1 block text-sm font-medium text-gray-700">
+                    UK tax year (scheme year)
+                  </Label>
                   <select
                     value={selectedGasdsTaxYear}
                     onChange={(event) => setSelectedGasdsTaxYear(event.target.value)}
@@ -838,8 +956,19 @@ export function GiftAidManagement({
                   </div>
                 </div>
               </div>
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  checked={strictGasdsMode}
+                  onChange={(event) => setStrictGasdsMode(event.target.checked)}
+                />
+                <span>
+                  Strict mode: export only rows currently marked as GASDS-eligible (summary still
+                  shown for transparency).
+                </span>
+              </label>
 
-              <div className="overflow-x-auto">
+              <div className="hidden md:block overflow-x-auto">
                 <Table>
                   <TableHeader>
                     <TableRow>
@@ -853,7 +982,8 @@ export function GiftAidManagement({
                   </TableHeader>
                   <TableBody>
                     {gasdsSummaryRows.map((row) => {
-                      const exceedsCap = row.eligible > 8000;
+                      const gasdsCapInPence = 800000;
+                      const exceedsCap = row.eligible > gasdsCapInPence;
                       return (
                         <TableRow key={row.locationId}>
                           <TableCell>{row.locationName}</TableCell>
@@ -886,6 +1016,146 @@ export function GiftAidManagement({
                   </TableBody>
                 </Table>
               </div>
+              <div className="md:hidden space-y-3">
+                {gasdsSummaryRows.map((row) => {
+                  const gasdsCapInPence = 800000;
+                  const exceedsCap = row.eligible > gasdsCapInPence;
+                  return (
+                    <Card key={row.locationId} className="border border-gray-200 shadow-sm">
+                      <CardContent className="p-3 space-y-2">
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="font-medium text-slate-900">{row.locationName}</p>
+                            <p className="text-xs text-gray-500">{row.postcode || 'N/A'}</p>
+                          </div>
+                          <Badge
+                            variant="outline"
+                            className={
+                              exceedsCap
+                                ? 'bg-red-50 text-red-700 border-red-200'
+                                : 'bg-emerald-50 text-emerald-700 border-emerald-200'
+                            }
+                          >
+                            {exceedsCap ? 'Exceeds' : 'OK'}
+                          </Badge>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2 text-sm">
+                          <div>
+                            <p className="text-gray-500">Total Collected</p>
+                            <p className="text-slate-900 font-medium">
+                              {formatCurrency(row.totalCollected)}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-gray-500">Eligible</p>
+                            <p className="text-slate-900 font-medium">
+                              {formatCurrency(row.eligible)}
+                            </p>
+                          </div>
+                          <div className="col-span-2">
+                            <p className="text-gray-500">Cap</p>
+                            <p className="text-slate-900 font-medium">£8,000</p>
+                            {row.isCommunityBuilding ? (
+                              <p className="text-xs text-gray-500">
+                                Potential £16k cap (subject to eligibility)
+                              </p>
+                            ) : null}
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
+              </div>
+              {gasdsExportSummary ? (
+                <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
+                  <p className="font-medium text-slate-900 mb-1">Ineligibility summary</p>
+                  <p>Over £30: {gasdsExportSummary.byReason.over_30 || 0}</p>
+                  <p>Non-DONATION mode: {gasdsExportSummary.byReason.non_donation_mode || 0}</p>
+                  <p>
+                    Both reasons: {gasdsExportSummary.byReason.over_30_and_non_donation_mode || 0}
+                  </p>
+                </div>
+              ) : null}
+              {canDownloadGiftAidBatchHistory ? (
+                <div className="rounded-xl border border-gray-200">
+                  <div className="border-b border-gray-200 px-3 py-2">
+                    <p className="text-sm font-medium text-slate-900">GASDS Export History</p>
+                  </div>
+                  <div className="divide-y divide-gray-100">
+                    {gasdsExportHistoryLoading ? (
+                      <div className="p-3 text-sm text-gray-500">Loading history...</div>
+                    ) : gasdsExportBatches.length === 0 ? (
+                      <div className="p-3 text-sm text-gray-500">No GASDS export batches yet.</div>
+                    ) : (
+                      gasdsExportBatches.map((batch) => (
+                        <div key={batch.id} className="p-3">
+                          <div className="flex items-center justify-between gap-3">
+                            <div>
+                              <p className="text-sm font-medium text-slate-900">
+                                {batch.taxYear} • {batch.strictMode ? 'Strict' : 'All rows'}
+                              </p>
+                              <p className="text-xs text-gray-500">
+                                {formatBatchTimestamp(batch.createdAt)} • {batch.rowCount} rows
+                              </p>
+                            </div>
+                            <div className="flex gap-2">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={
+                                  activeDownloadKey === `${batch.id}:detailed` ||
+                                  !batch.detailedFile
+                                }
+                                onClick={() =>
+                                  handleDownloadGasdsBatchFile(
+                                    batch.id,
+                                    'detailed',
+                                    batch.detailedFile,
+                                  )
+                                }
+                              >
+                                Detailed CSV
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                disabled={
+                                  activeDownloadKey === `${batch.id}:summary` || !batch.summaryFile
+                                }
+                                onClick={() =>
+                                  handleDownloadGasdsBatchFile(
+                                    batch.id,
+                                    'summary',
+                                    batch.summaryFile,
+                                  )
+                                }
+                              >
+                                Summary CSV
+                              </Button>
+                            </div>
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                  {!gasdsExportHistoryLoading &&
+                  (canGoGasdsExportHistoryPrev || canGoGasdsExportHistoryNext) ? (
+                    <div className="border-t border-gray-200 px-3 py-2">
+                      <PaginationControls
+                        pageNumber={gasdsExportHistoryPage}
+                        pageSize={gasdsExportHistoryPageSize}
+                        totalOnPage={gasdsExportBatches.length}
+                        canGoNext={canGoGasdsExportHistoryNext}
+                        canGoPrev={canGoGasdsExportHistoryPrev}
+                        onNext={goToNextGasdsExportHistoryPage}
+                        onPrev={goToPrevGasdsExportHistoryPage}
+                        loading={gasdsExportHistoryFetching}
+                      />
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
             </CardContent>
           </Card>
         ) : null}

--- a/src/views/admin/GiftAidManagement.tsx
+++ b/src/views/admin/GiftAidManagement.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Screen, AdminSession, Permission } from '../../shared/types';
 import { GiftAidDeclaration } from '../../entities/giftAid/model/types';
 import {
   downloadGiftAidExportFile,
   exportGiftAidDeclarations,
+  exportGasdsCsv,
   giftAidApi,
   type GiftAidExportFile,
 } from '../../entities/giftAid/api';
@@ -11,7 +12,14 @@ import { AdminLayout } from './AdminLayout';
 import { db } from '../../shared/lib/firebase';
 import { collection, query, where, getDocs } from 'firebase/firestore';
 import { Card, CardContent } from '../../shared/ui/card';
-import { Table, TableBody, TableCell, TableHeader, TableRow } from '../../shared/ui/table';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../shared/ui/table';
 import { Badge } from '../../shared/ui/badge';
 import { Button } from '../../shared/ui/button';
 import { Input } from '../../shared/ui/input';
@@ -39,6 +47,8 @@ import { useGiftAidExportBatches } from '../../shared/lib/hooks/useGiftAidExport
 import { PaginationControls } from '../../shared/ui/PaginationControls';
 import { useToast } from '../../shared/ui/ToastProvider';
 import { getAllCampaigns } from '../../shared/api';
+import { getLocationsByOrgId } from '../../entities/location/api/locationApi';
+import type { Location } from '../../entities/location/model/types';
 
 const EXPORT_HISTORY_PAGE_SIZE = 2;
 
@@ -54,6 +64,37 @@ const formatFilterDateKey = (value: Date): string => {
   const month = String(value.getMonth() + 1).padStart(2, '0');
   const day = String(value.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
+};
+
+const buildTaxYearLabel = (startYear: number) => `${startYear}-${startYear + 1}`;
+
+const getTaxYearRange = (taxYear: string): { start: Date; end: Date } | null => {
+  const match = /^(\d{4})-(\d{4})$/.exec(taxYear.trim());
+  if (!match) return null;
+  const startYear = Number(match[1]);
+  const endYear = Number(match[2]);
+  if (!Number.isInteger(startYear) || !Number.isInteger(endYear) || endYear !== startYear + 1) {
+    return null;
+  }
+
+  return {
+    start: new Date(Date.UTC(startYear, 3, 6, 0, 0, 0, 0)),
+    end: new Date(Date.UTC(endYear, 3, 5, 23, 59, 59, 999)),
+  };
+};
+
+const toDate = (value: unknown): Date | null => {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  if (typeof value === 'object' && value !== null && 'toDate' in value) {
+    const maybeTs = value as { toDate?: () => Date };
+    if (typeof maybeTs.toDate === 'function') return maybeTs.toDate();
+  }
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
 };
 
 export function GiftAidManagement({
@@ -73,10 +114,24 @@ export function GiftAidManagement({
   const [selectedDonation, setSelectedDonation] = useState<GiftAidDeclaration | null>(null);
   const [showDetailsDialog, setShowDetailsDialog] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const [isGasdsExporting, setIsGasdsExporting] = useState(false);
   const [isUpdatingPaid, setIsUpdatingPaid] = useState(false);
   const [activeDownloadKey, setActiveDownloadKey] = useState<string | null>(null);
   const [charitySubmittedReference, setCharitySubmittedReference] = useState('');
   const [unresolvedReconciliationCount, setUnresolvedReconciliationCount] = useState(0);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [selectedGasdsTaxYear, setSelectedGasdsTaxYear] = useState('');
+  const [selectedGasdsLocationIds, setSelectedGasdsLocationIds] = useState<string[]>([]);
+  const [gasdsSummaryRows, setGasdsSummaryRows] = useState<
+    Array<{
+      locationId: string;
+      locationName: string;
+      postcode: string;
+      totalCollected: number;
+      eligible: number;
+      isCommunityBuilding: boolean;
+    }>
+  >([]);
   const exportHistoryRef = useRef<HTMLDivElement | null>(null);
 
   const {
@@ -185,9 +240,150 @@ export function GiftAidManagement({
   }, [userSession.user.organizationId]);
 
   useEffect(() => {
+    const organizationId = userSession.user.organizationId;
+    if (!organizationId) {
+      setLocations([]);
+      setSelectedGasdsLocationIds([]);
+      return;
+    }
+
+    let isActive = true;
+    const loadLocations = async () => {
+      try {
+        const list = await getLocationsByOrgId(organizationId);
+        if (!isActive) return;
+        setLocations(list);
+        setSelectedGasdsLocationIds(list.map((location) => location.id));
+      } catch (error) {
+        console.error('Failed to load GASDS locations:', error);
+        if (!isActive) return;
+        setLocations([]);
+        setSelectedGasdsLocationIds([]);
+      }
+    };
+
+    void loadLocations();
+    return () => {
+      isActive = false;
+    };
+  }, [userSession.user.organizationId]);
+
+  const availableGasdsTaxYears = useMemo(() => {
+    const current = new Date();
+    const currentStartYear =
+      current.getUTCMonth() > 3 || (current.getUTCMonth() === 3 && current.getUTCDate() >= 6)
+        ? current.getUTCFullYear()
+        : current.getUTCFullYear() - 1;
+
+    return Array.from({ length: 6 }, (_, index) => buildTaxYearLabel(currentStartYear - index));
+  }, []);
+
+  useEffect(() => {
+    if (!selectedGasdsTaxYear && availableGasdsTaxYears.length > 0) {
+      setSelectedGasdsTaxYear(availableGasdsTaxYears[0]);
+    }
+  }, [availableGasdsTaxYears, selectedGasdsTaxYear]);
+
+  useEffect(() => {
     if (!exportHistoryError) return;
     showToast(exportHistoryError, 'warning');
   }, [exportHistoryError, showToast]);
+
+  useEffect(() => {
+    const organizationId = userSession.user.organizationId;
+    const taxYearRange = getTaxYearRange(selectedGasdsTaxYear);
+    if (!organizationId || !taxYearRange) {
+      setGasdsSummaryRows([]);
+      return;
+    }
+
+    const selectedLocationIds = new Set(selectedGasdsLocationIds);
+    if (selectedLocationIds.size === 0) {
+      setGasdsSummaryRows([]);
+      return;
+    }
+
+    let isActive = true;
+    const loadGasdsSummary = async () => {
+      try {
+        const donationsRef = collection(db, 'donations');
+        const donationsQuery = query(donationsRef, where('organizationId', '==', organizationId));
+        const donationSnapshot = await getDocs(donationsQuery);
+
+        const accumulator = new Map<
+          string,
+          { totalCollected: number; eligible: number; locationName: string; postcode: string }
+        >();
+
+        donationSnapshot.docs.forEach((docSnap) => {
+          const donation = docSnap.data() as Record<string, unknown>;
+          const locationId =
+            typeof donation.location_id === 'string' ? donation.location_id.trim() : '';
+          if (!locationId || !selectedLocationIds.has(locationId)) return;
+
+          const date =
+            toDate(donation.paymentCompletedAt) ||
+            toDate(donation.timestamp) ||
+            toDate(donation.createdAt);
+          if (!date || date < taxYearRange.start || date > taxYearRange.end) return;
+
+          const amount = Number(donation.amount);
+          const amountValue = Number.isFinite(amount) ? amount : 0;
+          const campaignModeRaw =
+            typeof donation.campaign_mode === 'string'
+              ? donation.campaign_mode
+              : typeof donation.campaignMode === 'string'
+                ? donation.campaignMode
+                : 'DONATION';
+          const campaignMode = campaignModeRaw.trim().toUpperCase();
+          const isEligible = amountValue <= 30 && campaignMode === 'DONATION';
+
+          const snapshot =
+            donation.location_snapshot && typeof donation.location_snapshot === 'object'
+              ? (donation.location_snapshot as Record<string, unknown>)
+              : null;
+          const locationName = typeof snapshot?.name === 'string' ? snapshot.name.trim() : '';
+          const postcode = typeof snapshot?.postcode === 'string' ? snapshot.postcode.trim() : '';
+
+          const current = accumulator.get(locationId) || {
+            totalCollected: 0,
+            eligible: 0,
+            locationName,
+            postcode,
+          };
+
+          current.totalCollected += amountValue;
+          if (isEligible) current.eligible += amountValue;
+          if (!current.locationName && locationName) current.locationName = locationName;
+          if (!current.postcode && postcode) current.postcode = postcode;
+          accumulator.set(locationId, current);
+        });
+
+        const rows = selectedGasdsLocationIds.map((locationId) => {
+          const location = locations.find((entry) => entry.id === locationId);
+          const totals = accumulator.get(locationId);
+          return {
+            locationId,
+            locationName: totals?.locationName || location?.name || 'Unknown',
+            postcode: totals?.postcode || location?.postcode || '',
+            totalCollected: totals?.totalCollected || 0,
+            eligible: totals?.eligible || 0,
+            isCommunityBuilding: Boolean(location?.isCommunityBuilding),
+          };
+        });
+
+        if (isActive) setGasdsSummaryRows(rows);
+      } catch (error) {
+        console.error('Failed to load GASDS summary:', error);
+        if (isActive) setGasdsSummaryRows([]);
+      }
+    };
+
+    void loadGasdsSummary();
+    return () => {
+      isActive = false;
+    };
+  }, [locations, selectedGasdsLocationIds, selectedGasdsTaxYear, userSession.user.organizationId]);
 
   const refreshGiftAidSection = useCallback(async () => {
     await Promise.all([refresh(), refreshExportHistory()]);
@@ -361,6 +557,42 @@ export function GiftAidManagement({
       showToast(message, 'error');
     } finally {
       setIsExporting(false);
+    }
+  };
+
+  const handleToggleGasdsLocation = (locationId: string) => {
+    setSelectedGasdsLocationIds((current) =>
+      current.includes(locationId)
+        ? current.filter((id) => id !== locationId)
+        : [...current, locationId],
+    );
+  };
+
+  const handleExportGasds = async () => {
+    if (!userSession.user.organizationId || !canExportGiftAid) return;
+    if (!selectedGasdsTaxYear) {
+      showToast('Select a tax year before exporting GASDS CSV.', 'warning');
+      return;
+    }
+    if (selectedGasdsLocationIds.length === 0) {
+      showToast('Select at least one location before exporting GASDS CSV.', 'warning');
+      return;
+    }
+
+    setIsGasdsExporting(true);
+    try {
+      await exportGasdsCsv({
+        organizationId: userSession.user.organizationId,
+        taxYear: selectedGasdsTaxYear,
+        locationIds: selectedGasdsLocationIds,
+      });
+      showToast('GASDS CSV export started. Your download should begin shortly.', 'success');
+    } catch (error) {
+      console.error('Failed to export GASDS CSV:', error);
+      const message = error instanceof Error ? error.message : 'Failed to export GASDS CSV.';
+      showToast(message, 'error');
+    } finally {
+      setIsGasdsExporting(false);
     }
   };
 
@@ -541,6 +773,122 @@ export function GiftAidManagement({
             </CardContent>
           </Card>
         )}
+
+        {canExportGiftAid ? (
+          <Card className="border border-emerald-100">
+            <CardContent className="p-4 sm:p-6 space-y-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">GASDS Export</h2>
+                  <p className="text-sm text-gray-600">
+                    Export all donations for a UK tax year with GASDS eligibility flags.
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  onClick={handleExportGasds}
+                  disabled={
+                    isGasdsExporting ||
+                    !selectedGasdsTaxYear ||
+                    selectedGasdsLocationIds.length === 0
+                  }
+                  className="border-[#064e3b] text-[#064e3b] hover:bg-emerald-50"
+                >
+                  <Download className="h-4 w-4 mr-2" />
+                  {isGasdsExporting ? 'Exporting...' : 'Export GASDS CSV'}
+                </Button>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <Label className="mb-1 block text-sm font-medium text-gray-700">Tax year</Label>
+                  <select
+                    value={selectedGasdsTaxYear}
+                    onChange={(event) => setSelectedGasdsTaxYear(event.target.value)}
+                    className="h-10 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm text-gray-700 focus:border-emerald-500 focus:outline-none"
+                  >
+                    {availableGasdsTaxYears.map((taxYear) => (
+                      <option key={taxYear} value={taxYear}>
+                        {taxYear}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <Label className="mb-1 block text-sm font-medium text-gray-700">Locations</Label>
+                  <div className="max-h-32 overflow-auto rounded-xl border border-gray-200 p-2 space-y-1">
+                    {locations.length === 0 ? (
+                      <p className="text-sm text-gray-500">No locations found.</p>
+                    ) : (
+                      locations.map((location) => (
+                        <label
+                          key={location.id}
+                          className="flex items-center gap-2 text-sm text-gray-700"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedGasdsLocationIds.includes(location.id)}
+                            onChange={() => handleToggleGasdsLocation(location.id)}
+                          />
+                          <span>{location.name}</span>
+                        </label>
+                      ))
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="font-semibold">Location</TableHead>
+                      <TableHead className="font-semibold">Postcode</TableHead>
+                      <TableHead className="font-semibold">Total Collected</TableHead>
+                      <TableHead className="font-semibold">Eligible</TableHead>
+                      <TableHead className="font-semibold">Cap</TableHead>
+                      <TableHead className="font-semibold">Status</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {gasdsSummaryRows.map((row) => {
+                      const exceedsCap = row.eligible > 8000;
+                      return (
+                        <TableRow key={row.locationId}>
+                          <TableCell>{row.locationName}</TableCell>
+                          <TableCell>{row.postcode || 'N/A'}</TableCell>
+                          <TableCell>{formatCurrency(row.totalCollected)}</TableCell>
+                          <TableCell>{formatCurrency(row.eligible)}</TableCell>
+                          <TableCell>
+                            £8,000
+                            {row.isCommunityBuilding ? (
+                              <p className="text-xs text-gray-500">
+                                Potential £16k cap (subject to eligibility)
+                              </p>
+                            ) : null}
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant="outline"
+                              className={
+                                exceedsCap
+                                  ? 'bg-red-50 text-red-700 border-red-200'
+                                  : 'bg-emerald-50 text-emerald-700 border-emerald-200'
+                              }
+                            >
+                              {exceedsCap ? 'Exceeds' : 'OK'}
+                            </Badge>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
 
         {/* Stats Cards */}
         <AdminStatsGrid className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6 mb-6">


### PR DESCRIPTION
## Summary
Implemented and hardened the full GASDS export flow end-to-end (backend, frontend API, admin UI, tests, and docs), including post-review fixes completed today.


Closes #696 


https://github.com/user-attachments/assets/e47e994f-973e-42be-9cc2-61d023cfa346


https://github.com/user-attachments/assets/5beb9bc4-fe2e-4a4e-b239-87f56ac76551


## What Was Delivered
- Added GASDS export backend endpoint with auth/org-scope checks, UK tax-year filtering (6 Apr–5 Apr), selected location filtering, strict mode support, and eligibility/reason flags.
- Added two GASDS outputs per export:
  - detailed donation-level CSV
  - location summary CSV
- Added GASDS batch history persistence (`pending/completed/failed`) with file metadata and re-download support.
- Added GASDS batch file download endpoint.
- Wired frontend API/config for export, batch history pagination, and file re-download.
- Upgraded Admin Gift Aid GASDS UI with:
  - UK tax-year selector
  - location multi-select (default all selected)
  - strict mode toggle
  - compliance note
  - ineligibility reason summary
  - GASDS export history
  - mobile-responsive summary layout
- Updated GASDS flow docs to match implemented behaviour.

## Review Fixes Completed
- Fixed amount-unit handling:
  - backend converts minor → major before `<= 30` check and CSV output
  - frontend summary eligibility uses `<= 3000` pence
- Fixed cap status check units in UI:
  - compares against `800000` pence (£8,000)
- Fixed strict-mode semantics:
  - strict mode filters detailed rows only
  - summary remains transparent
- Fixed `address_line1` mapping:
  - uses `location_snapshot.addressLine1` when present
  - falls back to `location_snapshot.city`
- Gated GASDS summary fetch by permission to avoid unnecessary reads.
- Improved prefetch robustness for mixed timestamp schemas while narrowing by org + location.

## Security/Compliance
- CSV formula injection hardening for leading `= + - @`
- CSV escaping for quotes/commas/newlines
- Batch audit trail + re-download for operational traceability

## Tests Added
- UK tax-year boundary tests
- GASDS formatting and eligibility reason tests
- CSV hardening tests
- Mixed timestamp resolution tests (`paymentCompletedAt`, `timestamp`, `createdAt`)

## Files Changed
- `backend/functions/handlers/giftAid.js`
- `backend/functions/index.js`
- `backend/functions/handlers/giftAid.gasds.test.js`
- `backend/functions/handlers/giftAid.gasds.formatting.test.js`
- `backend/functions/handlers/giftAid.gasds.timestamps.test.js`
- `src/entities/giftAid/api/giftAidExportApi.ts`
- `src/shared/config/functions.ts`
- `src/shared/lib/hooks/useGasdsExportBatches.ts`
- `src/views/admin/GiftAidManagement.tsx`
- `docs/GASDS_EXPORT_FLOW.md`

## Validation
- Backend lint passed (touched files)
- Frontend lint passed (touched files)
- GASDS test suites passed
- Production build passed

## Residual Risk
- No emulator-backed full end-to-end test yet for GASDS batch export + batch file download workflow.
