### PR TITLE
Fix and redesign recurring payment flow

### DIFF
--- a/android/app/src/main/java/com/example/swiftcause/MainActivity.kt
+++ b/android/app/src/main/java/com/example/swiftcause/MainActivity.kt
@@ -194,6 +194,7 @@ fun KioskMainContent(
     val uiState by viewModel.uiState.collectAsState()
     val paymentState by paymentViewModel.paymentState.collectAsState()
     val clientSecret by paymentViewModel.clientSecret.collectAsState()
+    val isSetupIntentFlow by paymentViewModel.isSetupIntentFlow.collectAsState()
     val tapToPayState by tapToPayViewModel.state.collectAsState()
     val isTapToPaySimulated by tapToPayViewModel.isSimulatedMode.collectAsState()
     val context = LocalContext.current
@@ -249,20 +250,37 @@ fun KioskMainContent(
                     when (selectedPaymentMethod) {
                         "card" -> {
                             // Show PaymentSheet for card entry
-                            paymentSheet.presentWithPaymentIntent(
-                                paymentIntentClientSecret = secret,
-                                configuration = PaymentSheet.Configuration(
-                                    merchantDisplayName = appName,
-                                    allowsDelayedPaymentMethods = false,
-                                    billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
-                                        name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
-                                        email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
-                                        phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
-                                        address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
-                                        attachDefaultsToPaymentMethod = false
+                            if (isSetupIntentFlow) {
+                                paymentSheet.presentWithSetupIntent(
+                                    setupIntentClientSecret = secret,
+                                    configuration = PaymentSheet.Configuration(
+                                        merchantDisplayName = appName,
+                                        allowsDelayedPaymentMethods = false,
+                                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                                            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                                            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                                            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                                            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                                            attachDefaultsToPaymentMethod = false
+                                        )
                                     )
                                 )
-                            )
+                            } else {
+                                paymentSheet.presentWithPaymentIntent(
+                                    paymentIntentClientSecret = secret,
+                                    configuration = PaymentSheet.Configuration(
+                                        merchantDisplayName = appName,
+                                        allowsDelayedPaymentMethods = false,
+                                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                                            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                                            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                                            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                                            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                                            attachDefaultsToPaymentMethod = false
+                                        )
+                                    )
+                                )
+                            }
                         }
                         "tap" -> {
                             if (tapToPayViewModel.isReaderReady()) {
@@ -430,8 +448,9 @@ fun KioskMainContent(
                         }
                     },
                     onDonateClick = { amount, isRecurring, interval, email ->
-                        // Auto-route payment method based on NFC capability:
-                        // NFC-capable device -> Tap to Pay, otherwise -> Card details.
+                        // MVP routing:
+                        // - Recurring donations -> PaymentSheet (card entry)
+                        // - One-time donations -> Tap to Pay when available, else PaymentSheet
                         pendingDonation = PendingDonation(
                             campaign = campaign,
                             amount = amount,
@@ -441,7 +460,13 @@ fun KioskMainContent(
                         )
 
                         val canUseTapToPay = hasNfcCapability && hasLocationPermission && tapToPayViewModel.isReaderReady()
-                        selectedPaymentMethod = if (canUseTapToPay) "tap" else "card"
+                        selectedPaymentMethod = if (isRecurring) {
+                            "card"
+                        } else if (canUseTapToPay) {
+                            "tap"
+                        } else {
+                            "card"
+                        }
                         handleDonation(
                             campaign = campaign,
                             amount = amount,
@@ -854,11 +879,20 @@ private fun handleDonation(
     val frequency = if (isRecurring) {
         when (interval) {
             "monthly" -> "month"
+            "quarterly" -> "month"
             "yearly" -> "year"
             else -> "month"
         }
     } else {
         null  // One-time donation
+    }
+    val intervalCount = if (isRecurring) {
+        when (interval) {
+            "quarterly" -> 3
+            else -> 1
+        }
+    } else {
+        null
     }
 
     android.util.Log.d("MainActivity", "Calling PaymentViewModel.preparePayment()")
@@ -873,6 +907,7 @@ private fun handleDonation(
         donorEmail = email,
         isAnonymous = email == null,  // Anonymous if no email provided
         frequency = frequency,
+        intervalCount = intervalCount,
         isGiftAid = campaign.isGiftAid,  // Pass Gift Aid flag for magic link generation
         kioskId = kioskSession?.kioskId
     )

--- a/android/app/src/main/java/com/example/swiftcause/data/models/PaymentModels.kt
+++ b/android/app/src/main/java/com/example/swiftcause/data/models/PaymentModels.kt
@@ -8,21 +8,30 @@ import com.google.gson.annotations.SerializedName
 data class CreatePaymentIntentRequest(
     @SerializedName("amount")
     val amount: Long,  // Amount in cents (e.g., 5000 = $50.00)
-    
+
     @SerializedName("currency")
     val currency: String,  // Lowercase currency code (e.g., "usd", "gbp")
-    
+
     @SerializedName("metadata")
     val metadata: PaymentMetadata,
-    
+
     @SerializedName("frequency")
     val frequency: String? = null,  // Optional: "once", "month", "year" for recurring
-    
+
+    @SerializedName("intervalCount")
+    val intervalCount: Int? = null, // Optional: 1 for monthly/yearly, 3 for quarterly
+
     @SerializedName("donor")
     val donor: DonorInfo? = null,  // Optional donor information
-    
+
     @SerializedName("paymentMethodId")
-    val paymentMethodId: String? = null  // Optional: for recurring payments
+    val paymentMethodId: String? = null,  // Optional: for recurring payments
+
+    @SerializedName("setupIntentId")
+    val setupIntentId: String? = null,  // Optional: finalize recurring with saved card
+
+    @SerializedName("customerId")
+    val customerId: String? = null  // Optional: reuse customer between setup + finalize calls
 )
 
 /**
@@ -31,31 +40,31 @@ data class CreatePaymentIntentRequest(
 data class PaymentMetadata(
     @SerializedName("campaignId")
     val campaignId: String,
-    
+
     @SerializedName("campaignTitle")
     val campaignTitle: String,
-    
+
     @SerializedName("organizationId")
     val organizationId: String,
-    
+
     @SerializedName("platform")
     val platform: String = "android_kiosk",
-    
+
     @SerializedName("kioskId")
     val kioskId: String? = null,
-    
+
     @SerializedName("donorName")
     val donorName: String? = null,
-    
+
     @SerializedName("donorEmail")
     val donorEmail: String? = null,
-    
+
     @SerializedName("isAnonymous")
     val isAnonymous: Boolean = false,
-    
+
     @SerializedName("isGiftAid")
     val isGiftAid: Boolean = false,
-    
+
     @SerializedName("recurringInterest")
     val recurringInterest: Boolean = false
 )
@@ -66,10 +75,10 @@ data class PaymentMetadata(
 data class DonorInfo(
     @SerializedName("email")
     val email: String,
-    
+
     @SerializedName("name")
     val name: String,
-    
+
     @SerializedName("phone")
     val phone: String? = null
 )
@@ -80,20 +89,26 @@ data class DonorInfo(
 data class CreatePaymentIntentResponse(
     @SerializedName("clientSecret")
     val clientSecret: String?,
-    
+
+    @SerializedName("setupIntentClientSecret")
+    val setupIntentClientSecret: String? = null,
+
+    @SerializedName("customerId")
+    val customerId: String? = null,
+
     // For recurring payments that succeed immediately
     @SerializedName("success")
     val success: Boolean? = null,
-    
+
     @SerializedName("message")
     val message: String? = null,
-    
+
     @SerializedName("subscriptionId")
     val subscriptionId: String? = null,
-    
+
     @SerializedName("invoiceId")
     val invoiceId: String? = null,
-    
+
     @SerializedName("amountPaid")
     val amountPaid: Long? = null
 )
@@ -107,11 +122,11 @@ sealed class PaymentResult {
         val amount: Long,
         val currency: String
     ) : PaymentResult()
-    
+
     data class Error(
         val message: String,
         val code: String? = null
     ) : PaymentResult()
-    
+
     object Cancelled : PaymentResult()
 }

--- a/android/app/src/main/java/com/example/swiftcause/data/repository/PaymentRepository.kt
+++ b/android/app/src/main/java/com/example/swiftcause/data/repository/PaymentRepository.kt
@@ -30,6 +30,12 @@ class PaymentRepository(
         private const val FUNCTION_URL = "https://us-central1-swiftcause-app.cloudfunctions.net/createKioskPaymentIntent"
     }
 
+    private fun JSONObject.putIfNotNull(key: String, value: Any?) {
+        if (value != null) {
+            put(key, value)
+        }
+    }
+
     /**
      * Creates a payment intent for one-time or recurring donations
      * Uses raw HTTP POST (exactly like web) instead of Firebase SDK
@@ -57,19 +63,19 @@ class PaymentRepository(
             val requestJson = JSONObject().apply {
                 put("amount", request.amount)
                 put("currency", request.currency)
-                put("frequency", request.frequency ?: JSONObject.NULL)
-                put("intervalCount", request.intervalCount ?: JSONObject.NULL)
-                put("paymentMethodId", request.paymentMethodId ?: JSONObject.NULL)
-                put("setupIntentId", request.setupIntentId ?: JSONObject.NULL)
-                put("customerId", request.customerId ?: JSONObject.NULL)
+                putIfNotNull("frequency", request.frequency)
+                putIfNotNull("intervalCount", request.intervalCount)
+                putIfNotNull("paymentMethodId", request.paymentMethodId)
+                putIfNotNull("setupIntentId", request.setupIntentId)
+                putIfNotNull("customerId", request.customerId)
                 put("metadata", JSONObject().apply {
                     put("campaignId", request.metadata.campaignId)
                     put("campaignTitle", request.metadata.campaignTitle)
                     put("organizationId", request.metadata.organizationId)
                     put("platform", request.metadata.platform)
-                    put("kioskId", request.metadata.kioskId ?: JSONObject.NULL)
-                    put("donorName", request.metadata.donorName ?: JSONObject.NULL)
-                    put("donorEmail", request.metadata.donorEmail ?: JSONObject.NULL)
+                    putIfNotNull("kioskId", request.metadata.kioskId)
+                    putIfNotNull("donorName", request.metadata.donorName)
+                    putIfNotNull("donorEmail", request.metadata.donorEmail)
                     put("isAnonymous", request.metadata.isAnonymous)
                     put("isGiftAid", request.metadata.isGiftAid)
                     put("recurringInterest", request.metadata.recurringInterest)

--- a/android/app/src/main/java/com/example/swiftcause/data/repository/PaymentRepository.kt
+++ b/android/app/src/main/java/com/example/swiftcause/data/repository/PaymentRepository.kt
@@ -11,13 +11,19 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 
 /**
  * Repository for handling payment operations via raw HTTP
  * Matches the web implementation which uses fetch() instead of Firebase SDK
  */
 class PaymentRepository(
-    private val httpClient: OkHttpClient = OkHttpClient()
+    private val httpClient: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(20, TimeUnit.SECONDS)
+        .writeTimeout(20, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .callTimeout(75, TimeUnit.SECONDS)
+        .build()
 ) {
     companion object {
         private const val TAG = "PaymentRepository"

--- a/android/app/src/main/java/com/example/swiftcause/data/repository/PaymentRepository.kt
+++ b/android/app/src/main/java/com/example/swiftcause/data/repository/PaymentRepository.kt
@@ -51,6 +51,11 @@ class PaymentRepository(
             val requestJson = JSONObject().apply {
                 put("amount", request.amount)
                 put("currency", request.currency)
+                put("frequency", request.frequency ?: JSONObject.NULL)
+                put("intervalCount", request.intervalCount ?: JSONObject.NULL)
+                put("paymentMethodId", request.paymentMethodId ?: JSONObject.NULL)
+                put("setupIntentId", request.setupIntentId ?: JSONObject.NULL)
+                put("customerId", request.customerId ?: JSONObject.NULL)
                 put("metadata", JSONObject().apply {
                     put("campaignId", request.metadata.campaignId)
                     put("campaignTitle", request.metadata.campaignTitle)
@@ -63,6 +68,16 @@ class PaymentRepository(
                     put("isGiftAid", request.metadata.isGiftAid)
                     put("recurringInterest", request.metadata.recurringInterest)
                 })
+                put(
+                    "donor",
+                    request.donor?.let {
+                        JSONObject().apply {
+                            put("email", it.email)
+                            put("name", it.name)
+                            put("phone", it.phone ?: JSONObject.NULL)
+                        }
+                    } ?: JSONObject.NULL
+                )
             }
 
             Log.d(TAG, "Calling Cloud Function: $FUNCTION_URL")
@@ -94,20 +109,39 @@ class PaymentRepository(
 
             // Parse response
             val responseJson = JSONObject(responseBody)
-            val clientSecret = responseJson.optString("clientSecret")
+            val readNullableString = { key: String ->
+                if (!responseJson.has(key) || responseJson.isNull(key)) null else responseJson.optString(key).ifEmpty { null }
+            }
+            val clientSecret = readNullableString("clientSecret")
+            val setupIntentClientSecret = readNullableString("setupIntentClientSecret")
+            val customerId = readNullableString("customerId")
+            val success = responseJson.optBoolean("success", false)
+            val message = readNullableString("message")
+            val subscriptionId = readNullableString("subscriptionId")
+            val invoiceId = readNullableString("invoiceId")
+            val amountPaid = if (responseJson.has("amountPaid") && !responseJson.isNull("amountPaid")) {
+                responseJson.optLong("amountPaid")
+            } else {
+                null
+            }
 
-            if (clientSecret.isEmpty()) {
-                throw Exception("Missing clientSecret in response")
+            if (clientSecret == null && setupIntentClientSecret == null && !success) {
+                throw Exception(message ?: "Missing payment confirmation data in response")
             }
 
             Log.d(TAG, "✓ Payment Intent Created Successfully")
-            Log.d(TAG, "Client Secret: ${clientSecret.take(20)}...")
+            Log.d(TAG, "Client Secret: ${clientSecret?.take(20)}...")
 
             Result.success(
                 CreatePaymentIntentResponse(
                     clientSecret = clientSecret,
-                    success = true,
-                    message = "Payment intent created"
+                    setupIntentClientSecret = setupIntentClientSecret,
+                    customerId = customerId,
+                    success = success,
+                    message = message ?: if (clientSecret != null) "Payment intent created" else null,
+                    subscriptionId = subscriptionId,
+                    invoiceId = invoiceId,
+                    amountPaid = amountPaid
                 )
             )
 

--- a/android/app/src/main/java/com/example/swiftcause/presentation/viewmodels/CampaignListViewModel.kt
+++ b/android/app/src/main/java/com/example/swiftcause/presentation/viewmodels/CampaignListViewModel.kt
@@ -33,6 +33,8 @@ class CampaignListViewModel(
     private val repository: CampaignRepository = CampaignRepository()
 ) : AndroidViewModel(application) {
 
+    constructor(application: Application) : this(application, CampaignRepository())
+
     private val _uiState = MutableStateFlow(CampaignListUiState())
     val uiState: StateFlow<CampaignListUiState> = _uiState.asStateFlow()
 

--- a/android/app/src/main/java/com/example/swiftcause/presentation/viewmodels/PaymentViewModel.kt
+++ b/android/app/src/main/java/com/example/swiftcause/presentation/viewmodels/PaymentViewModel.kt
@@ -38,10 +38,16 @@ class PaymentViewModel(
     private val _magicLinkToken = MutableStateFlow<String?>(null)
     val magicLinkToken: StateFlow<String?> = _magicLinkToken.asStateFlow()
 
+    // Whether current PaymentSheet presentation should use SetupIntent flow
+    private val _isSetupIntentFlow = MutableStateFlow(false)
+    val isSetupIntentFlow: StateFlow<Boolean> = _isSetupIntentFlow.asStateFlow()
+
     private var amount: Long = 0
     private var currency: String = ""
     private var paymentIntentId: String = ""
     private var magicLinkPollingJob: Job? = null
+    private var pendingRequest: CreatePaymentIntentRequest? = null
+    private var paymentSheetFlowMode: PaymentSheetFlowMode = PaymentSheetFlowMode.PAYMENT_INTENT
 
     private val firestore = FirebaseFirestore.getInstance()
 
@@ -58,6 +64,7 @@ class PaymentViewModel(
         donorEmail: String? = null,
         isAnonymous: Boolean = false,
         frequency: String? = null,  // null = one-time, "month", "year" = recurring
+        intervalCount: Int? = null,
         isGiftAid: Boolean = false,  // Campaign has Gift Aid enabled
         kioskId: String? = null
     ) {
@@ -73,6 +80,7 @@ class PaymentViewModel(
                 Log.d(TAG, "Organization ID: $organizationId")
                 Log.d(TAG, "Is Recurring: ${frequency != null}")
                 Log.d(TAG, "Frequency: $frequency")
+                Log.d(TAG, "Interval Count: $intervalCount")
                 Log.d(TAG, "Is Anonymous: $isAnonymous")
                 Log.d(TAG, "Is Gift Aid: $isGiftAid")
 
@@ -93,13 +101,16 @@ class PaymentViewModel(
                         recurringInterest = frequency != null
                     ),
                     frequency = frequency,
-                    donor = if (!donorEmail.isNullOrBlank() && !donorName.isNullOrBlank()) {
+                    intervalCount = intervalCount,
+                    donor = if (!donorEmail.isNullOrBlank()) {
                         DonorInfo(
                             email = donorEmail,
-                            name = donorName
+                            name = donorName ?: "Anonymous"
                         )
                     } else null
                 )
+
+                pendingRequest = request
 
                 Log.d(TAG, "Calling PaymentRepository.createPaymentIntent()")
 
@@ -109,9 +120,18 @@ class PaymentViewModel(
                 result.fold(
                     onSuccess = { response ->
                         Log.d(TAG, "Repository returned success")
-                        if (response.clientSecret != null) {
+                        if (response.setupIntentClientSecret != null) {
+                            _clientSecret.value = response.setupIntentClientSecret
+                            pendingRequest = pendingRequest?.copy(customerId = response.customerId)
+                            paymentSheetFlowMode = PaymentSheetFlowMode.SETUP_INTENT
+                            _isSetupIntentFlow.value = true
+                            _paymentState.value = PaymentState.Ready
+                            Log.d(TAG, "Recurring setup prepared - State: Ready")
+                        } else if (response.clientSecret != null) {
                             _clientSecret.value = response.clientSecret
                             paymentIntentId = response.clientSecret.substringBeforeLast("_secret_")
+                            paymentSheetFlowMode = PaymentSheetFlowMode.PAYMENT_INTENT
+                            _isSetupIntentFlow.value = false
                             _paymentState.value = PaymentState.Ready
                             Log.d(TAG, "Payment prepared - State: Ready")
                             Log.d(TAG, "Client secret length: ${response.clientSecret.length}")
@@ -154,13 +174,18 @@ class PaymentViewModel(
         viewModelScope.launch {
             when (result) {
                 is PaymentSheetResult.Completed -> {
-                    Log.d(TAG, "Payment completed")
-                    _paymentState.value = PaymentState.Success(
-                        transactionId = paymentIntentId,
-                        amount = amount,
-                        currency = currency
-                    )
-                    onPaymentSuccess()
+                    if (paymentSheetFlowMode == PaymentSheetFlowMode.SETUP_INTENT) {
+                        Log.d(TAG, "SetupIntent completed; finalizing recurring subscription")
+                        finalizeRecurringSubscription(onPaymentSuccess)
+                    } else {
+                        Log.d(TAG, "Payment completed")
+                        _paymentState.value = PaymentState.Success(
+                            transactionId = paymentIntentId,
+                            amount = amount,
+                            currency = currency
+                        )
+                        onPaymentSuccess()
+                    }
                 }
                 is PaymentSheetResult.Canceled -> {
                     Log.d(TAG, "Payment canceled")
@@ -183,9 +208,67 @@ class PaymentViewModel(
         _paymentState.value = PaymentState.Idle
         _clientSecret.value = null
         _magicLinkToken.value = null
+        _isSetupIntentFlow.value = false
         this.amount = 0
         this.currency = ""
         this.paymentIntentId = ""
+        this.pendingRequest = null
+        this.paymentSheetFlowMode = PaymentSheetFlowMode.PAYMENT_INTENT
+    }
+
+    private suspend fun finalizeRecurringSubscription(onPaymentSuccess: () -> Unit) {
+        try {
+            val setupIntentClientSecret = _clientSecret.value
+            val setupIntentId = setupIntentClientSecret?.substringBeforeLast("_secret_")
+            val baseRequest = pendingRequest
+
+            if (setupIntentId.isNullOrBlank() || baseRequest == null) {
+                _paymentState.value = PaymentState.Error(
+                    message = "Missing setup confirmation data for recurring donation"
+                )
+                return
+            }
+
+            _paymentState.value = PaymentState.Loading
+
+            val finalizeRequest = baseRequest.copy(
+                setupIntentId = setupIntentId,
+                customerId = baseRequest.customerId
+            )
+
+            val result = paymentRepository.createPaymentIntent(finalizeRequest)
+            result.fold(
+                onSuccess = { response ->
+                    if (response.clientSecret != null) {
+                        _clientSecret.value = response.clientSecret
+                        paymentIntentId = response.clientSecret.substringBeforeLast("_secret_")
+                        paymentSheetFlowMode = PaymentSheetFlowMode.PAYMENT_INTENT
+                        _isSetupIntentFlow.value = false
+                        _paymentState.value = PaymentState.Ready
+                    } else if (response.success == true) {
+                        _paymentState.value = PaymentState.Success(
+                            transactionId = response.subscriptionId ?: setupIntentId,
+                            amount = amount,
+                            currency = currency
+                        )
+                        onPaymentSuccess()
+                    } else {
+                        _paymentState.value = PaymentState.Error(
+                            message = response.message ?: "Failed to finalize recurring subscription"
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _paymentState.value = PaymentState.Error(
+                        message = error.message ?: "Failed to finalize recurring subscription"
+                    )
+                }
+            )
+        } catch (e: Exception) {
+            _paymentState.value = PaymentState.Error(
+                message = e.message ?: "Failed to finalize recurring subscription"
+            )
+        }
     }
 
     /**
@@ -236,6 +319,11 @@ class PaymentViewModel(
             }
         }
     }
+}
+
+private enum class PaymentSheetFlowMode {
+    PAYMENT_INTENT,
+    SETUP_INTENT,
 }
 
 /**

--- a/android/app/src/main/java/com/example/swiftcause/presentation/viewmodels/PaymentViewModel.kt
+++ b/android/app/src/main/java/com/example/swiftcause/presentation/viewmodels/PaymentViewModel.kt
@@ -138,8 +138,11 @@ class PaymentViewModel(
                         } else if (response.success == true) {
                             // Recurring payment succeeded immediately
                             Log.d(TAG, "Recurring payment succeeded immediately")
+                            val magicLinkLookupId = response.invoiceId
+                                ?: response.subscriptionId
+                                ?: ""
                             _paymentState.value = PaymentState.Success(
-                                transactionId = response.subscriptionId ?: "",
+                                transactionId = magicLinkLookupId,
                                 amount = amount,
                                 currency = currency
                             )
@@ -246,8 +249,11 @@ class PaymentViewModel(
                         _isSetupIntentFlow.value = false
                         _paymentState.value = PaymentState.Ready
                     } else if (response.success == true) {
+                        val magicLinkLookupId = response.invoiceId
+                            ?: response.subscriptionId
+                            ?: setupIntentId
                         _paymentState.value = PaymentState.Success(
-                            transactionId = response.subscriptionId ?: setupIntentId,
+                            transactionId = magicLinkLookupId,
                             amount = amount,
                             currency = currency
                         )

--- a/backend/functions/handlers/payments.js
+++ b/backend/functions/handlers/payments.js
@@ -144,6 +144,16 @@ const createKioskPaymentIntent = (req, res) => {
         customerId,
       } = req.body;
 
+      console.log('[Payment] Incoming createKioskPaymentIntent request', {
+        campaignId: metadata?.campaignId || null,
+        frequency: frequency || null,
+        intervalCount: intervalCount ?? null,
+        hasDonorEmail: Boolean(donor?.email),
+        hasPaymentMethodId: Boolean(paymentMethodId),
+        hasSetupIntentId: Boolean(setupIntentId),
+        hasCustomerId: Boolean(customerId),
+      });
+
       if (!amount || !currency || !metadata || !metadata.campaignId) {
         return res.status(400).send({ error: 'Missing amount, currency, or campaignId' });
       }
@@ -234,6 +244,13 @@ const createKioskPaymentIntent = (req, res) => {
         clientSecret = paymentIntent.client_secret;
       } else {
         // Recurring donation (subscription)
+        console.log('[Payment] Entering recurring branch', {
+          frequency,
+          intervalCount,
+          hasPaymentMethodId: Boolean(paymentMethodId),
+          hasSetupIntentId: Boolean(setupIntentId),
+        });
+
         if (!donor?.email) {
           return res.status(400).send({ error: 'Missing donor.email for recurring donation' });
         }
@@ -254,6 +271,12 @@ const createKioskPaymentIntent = (req, res) => {
         // 1) First call (no paymentMethodId/setupIntentId): return SetupIntent client secret
         // 2) Second call (setupIntentId provided): resolve payment_method from SetupIntent
         if (!resolvedPaymentMethodId && !setupIntentId) {
+          console.log('[Payment] Recurring bootstrap: creating SetupIntent', {
+            customerId: customer.id,
+            frequency,
+            normalizedIntervalCount,
+          });
+
           const setupIntent = await stripeClient.setupIntents.create({
             customer: customer.id,
             payment_method_types: ['card'],
@@ -274,6 +297,11 @@ const createKioskPaymentIntent = (req, res) => {
         }
 
         if (!resolvedPaymentMethodId && setupIntentId) {
+          console.log('[Payment] Recurring finalize: resolving payment method from SetupIntent', {
+            setupIntentId,
+            customerId: customer.id,
+          });
+
           const setupIntent = await stripeClient.setupIntents.retrieve(setupIntentId, {
             expand: ['payment_method'],
           });
@@ -357,6 +385,76 @@ const createKioskPaymentIntent = (req, res) => {
           payment_intent_status: subscription.latest_invoice?.payment_intent?.status,
         });
 
+        // Update invoice + payment intent metadata before heavier persistence work.
+        // Stripe emits payment_intent.created at object creation time, so that event can still
+        // show empty metadata; this ensures subsequent events/object reads have the canonical keys.
+        let latestInvoice = subscription.latest_invoice;
+
+        if (
+          latestInvoice &&
+          !latestInvoice.payment_intent &&
+          latestInvoice.status === 'open' &&
+          latestInvoice.id
+        ) {
+          console.warn(
+            'Latest invoice is open without expanded payment intent; reloading invoice',
+            {
+              subscriptionId: subscription.id,
+              invoiceId: latestInvoice.id,
+            },
+          );
+
+          latestInvoice = await stripeClient.invoices.retrieve(latestInvoice.id, {
+            expand: ['payment_intent'],
+          });
+        }
+
+        const recurringMetadata = {
+          ...canonicalMetadata,
+          isRecurring: true,
+          recurringInterest: true,
+          frequency,
+          intervalCount: String(normalizedIntervalCount),
+          subscriptionId: subscription.id,
+        };
+
+        if (latestInvoice?.id) {
+          try {
+            await stripeClient.invoices.update(latestInvoice.id, {
+              metadata: {
+                ...recurringMetadata,
+                invoiceId: latestInvoice.id,
+              },
+            });
+          } catch (invoiceMetaError) {
+            console.warn('Unable to update invoice metadata for recurring donation', {
+              invoiceId: latestInvoice.id,
+              error: invoiceMetaError.message,
+            });
+          }
+        }
+
+        const paymentIntentId =
+          typeof latestInvoice?.payment_intent === 'string'
+            ? latestInvoice.payment_intent
+            : latestInvoice?.payment_intent?.id;
+
+        if (paymentIntentId) {
+          try {
+            await stripeClient.paymentIntents.update(paymentIntentId, {
+              metadata: {
+                ...recurringMetadata,
+                invoiceId: latestInvoice?.id || null,
+              },
+            });
+          } catch (paymentIntentMetaError) {
+            console.warn('Unable to update payment intent metadata for recurring donation', {
+              paymentIntentId,
+              error: paymentIntentMetaError.message,
+            });
+          }
+        }
+
         await createSubscriptionDoc({
           stripeSubscriptionId: subscription.id,
           customerId: customer.id,
@@ -379,27 +477,6 @@ const createKioskPaymentIntent = (req, res) => {
             ...canonicalMetadata,
           },
         });
-
-        let latestInvoice = subscription.latest_invoice;
-
-        if (
-          latestInvoice &&
-          !latestInvoice.payment_intent &&
-          latestInvoice.status === 'open' &&
-          latestInvoice.id
-        ) {
-          console.warn(
-            'Latest invoice is open without expanded payment intent; reloading invoice',
-            {
-              subscriptionId: subscription.id,
-              invoiceId: latestInvoice.id,
-            },
-          );
-
-          latestInvoice = await stripeClient.invoices.retrieve(latestInvoice.id, {
-            expand: ['payment_intent'],
-          });
-        }
 
         if (latestInvoice) {
           if (latestInvoice.payment_intent) {

--- a/backend/functions/handlers/payments.js
+++ b/backend/functions/handlers/payments.js
@@ -3,6 +3,7 @@ const { stripe, ensureStripeInitialized } = require('../services/stripe');
 const { verifyAuth } = require('../middleware/auth');
 const cors = require('../middleware/cors');
 const { resolveLocationIdFromKiosk, resolveLocationForDonation } = require('../shared/location');
+const { createSubscriptionDoc } = require('../entities/subscription');
 
 const ALLOWED_ORIGINS = new Set([
   'http://localhost:3000',
@@ -131,7 +132,17 @@ const createKioskPaymentIntent = (req, res) => {
       // Ensure Stripe is initialized
       const stripeClient = ensureStripeInitialized();
 
-      const { amount, currency = 'usd', metadata, frequency, donor, paymentMethodId } = req.body;
+      const {
+        amount,
+        currency = 'usd',
+        metadata,
+        frequency,
+        intervalCount = 1,
+        donor,
+        paymentMethodId,
+        setupIntentId,
+        customerId,
+      } = req.body;
 
       if (!amount || !currency || !metadata || !metadata.campaignId) {
         return res.status(400).send({ error: 'Missing amount, currency, or campaignId' });
@@ -184,13 +195,23 @@ const createKioskPaymentIntent = (req, res) => {
         return res.status(400).send({ error: 'Org not onboarded with Stripe' });
       }
 
-      // Create a Customer for tracking donations and supporting recurring payments
-      // Note: Link will appear if customer has an email, but that's okay for kiosk use
-      const customer = await stripeClient.customers.create({
-        email: donor?.email || undefined,
-        name: donor?.name || undefined,
-        metadata: canonicalMetadata,
-      });
+      // Resolve or create a Stripe customer for donation/subscription tracking.
+      // Recurring setup + finalize calls must share the same customer.
+      let customer = null;
+      if (customerId) {
+        customer = await stripeClient.customers.retrieve(customerId);
+        if (!customer || customer.deleted) {
+          return res.status(400).send({ error: 'Invalid customerId' });
+        }
+      } else {
+        // Create a Customer for tracking donations and supporting recurring payments
+        // Note: Link will appear if customer has an email, but that's okay for kiosk use
+        customer = await stripeClient.customers.create({
+          email: donor?.email || undefined,
+          name: donor?.name || undefined,
+          metadata: canonicalMetadata,
+        });
+      }
 
       let clientSecret;
 
@@ -213,38 +234,118 @@ const createKioskPaymentIntent = (req, res) => {
         clientSecret = paymentIntent.client_secret;
       } else {
         // Recurring donation (subscription)
-        if (!paymentMethodId) {
-          return res.status(400).send({ error: 'Missing paymentMethodId for subscription' });
+        if (!donor?.email) {
+          return res.status(400).send({ error: 'Missing donor.email for recurring donation' });
         }
 
-        // Attach payment method to customer and set as default
-        await stripeClient.paymentMethods.attach(paymentMethodId, {
-          customer: customer.id,
-        });
-        await stripeClient.customers.update(customer.id, {
-          invoice_settings: { default_payment_method: paymentMethodId },
-        });
+        const normalizedIntervalCount = Number(intervalCount);
+        if (
+          !Number.isInteger(normalizedIntervalCount) ||
+          normalizedIntervalCount < 1 ||
+          (frequency === 'year' && normalizedIntervalCount !== 1) ||
+          (frequency === 'month' && ![1, 3].includes(normalizedIntervalCount))
+        ) {
+          return res.status(400).send({ error: 'Invalid intervalCount for frequency' });
+        }
+
+        let resolvedPaymentMethodId = paymentMethodId;
+
+        // Two-step recurring flow support:
+        // 1) First call (no paymentMethodId/setupIntentId): return SetupIntent client secret
+        // 2) Second call (setupIntentId provided): resolve payment_method from SetupIntent
+        if (!resolvedPaymentMethodId && !setupIntentId) {
+          const setupIntent = await stripeClient.setupIntents.create({
+            customer: customer.id,
+            payment_method_types: ['card'],
+            usage: 'off_session',
+            metadata: {
+              ...canonicalMetadata,
+              platform: 'kiosk',
+              flow: 'recurring_setup',
+              frequency,
+              intervalCount: String(normalizedIntervalCount),
+            },
+          });
+
+          return res.status(200).send({
+            setupIntentClientSecret: setupIntent.client_secret,
+            customerId: customer.id,
+          });
+        }
+
+        if (!resolvedPaymentMethodId && setupIntentId) {
+          const setupIntent = await stripeClient.setupIntents.retrieve(setupIntentId, {
+            expand: ['payment_method'],
+          });
+
+          if (!setupIntent || !setupIntent.customer || setupIntent.customer !== customer.id) {
+            return res.status(400).send({ error: 'Invalid setupIntentId for customer' });
+          }
+
+          if (setupIntent.status !== 'succeeded') {
+            return res.status(400).send({
+              error: `SetupIntent status: ${setupIntent.status}`,
+              setupIntentId,
+            });
+          }
+
+          resolvedPaymentMethodId =
+            typeof setupIntent.payment_method === 'string'
+              ? setupIntent.payment_method
+              : setupIntent.payment_method?.id;
+        }
+
+        if (!resolvedPaymentMethodId) {
+          console.error('Missing payment method for recurring donation finalization');
+          return res.status(400).send({
+            error: 'Missing paymentMethodId for recurring donation; use PaymentSheet setup first',
+          });
+        }
 
         // Create price for subscription
         const price = await stripeClient.prices.create({
           unit_amount: amount,
           currency,
-          recurring: { interval: frequency }, // "month" or "year"
+          recurring: { interval: frequency, interval_count: normalizedIntervalCount }, // month/year with count
           product_data: {
             name: `Recurring donation to campaign ${campaignId}`,
           },
         });
 
-        // Create subscription with the default payment method
-        const subscription = await stripeClient.subscriptions.create({
+        let subscription;
+        // Attach payment method to customer and set as default
+        try {
+          await stripeClient.paymentMethods.attach(resolvedPaymentMethodId, {
+            customer: customer.id,
+          });
+        } catch (attachError) {
+          const alreadyAttached =
+            attachError?.code === 'resource_already_exists' ||
+            (typeof attachError?.message === 'string' &&
+              attachError.message.includes('already attached'));
+          if (!alreadyAttached) {
+            throw attachError;
+          }
+        }
+        await stripeClient.customers.update(customer.id, {
+          invoice_settings: { default_payment_method: resolvedPaymentMethodId },
+        });
+
+        // Create subscription using the attached payment method (web-like flow)
+        subscription = await stripeClient.subscriptions.create({
           customer: customer.id,
           items: [{ price: price.id }],
-          default_payment_method: paymentMethodId,
+          default_payment_method: resolvedPaymentMethodId,
           collection_method: 'charge_automatically',
           expand: ['latest_invoice.payment_intent'],
           trial_period_days: 0,
           transfer_data: { destination: stripeAccountId },
-          metadata: { ...canonicalMetadata, platform: 'kiosk', frequency },
+          metadata: {
+            ...canonicalMetadata,
+            platform: 'kiosk',
+            frequency,
+            intervalCount: String(normalizedIntervalCount),
+          },
         });
 
         console.log('Subscription created:', {
@@ -256,7 +357,49 @@ const createKioskPaymentIntent = (req, res) => {
           payment_intent_status: subscription.latest_invoice?.payment_intent?.status,
         });
 
-        const latestInvoice = subscription.latest_invoice;
+        await createSubscriptionDoc({
+          stripeSubscriptionId: subscription.id,
+          customerId: customer.id,
+          campaignId,
+          organizationId: orgId,
+          interval: frequency,
+          intervalCount: normalizedIntervalCount,
+          amount,
+          currency,
+          status: subscription.status,
+          currentPeriodEnd: subscription.current_period_end,
+          startedAt: subscription.start_date || subscription.current_period_start || null,
+          nextPaymentAt: subscription.current_period_end || null,
+          metadata: {
+            donorEmail: donor?.email || canonicalMetadata.donorEmail || null,
+            donorName: donor?.name || canonicalMetadata.donorName || 'Anonymous',
+            donorPhone: donor?.phone || canonicalMetadata.donorPhone || null,
+            campaignTitle: campaignData.title || canonicalMetadata.campaignTitle || null,
+            platform: canonicalMetadata.platform || 'kiosk',
+            ...canonicalMetadata,
+          },
+        });
+
+        let latestInvoice = subscription.latest_invoice;
+
+        if (
+          latestInvoice &&
+          !latestInvoice.payment_intent &&
+          latestInvoice.status === 'open' &&
+          latestInvoice.id
+        ) {
+          console.warn(
+            'Latest invoice is open without expanded payment intent; reloading invoice',
+            {
+              subscriptionId: subscription.id,
+              invoiceId: latestInvoice.id,
+            },
+          );
+
+          latestInvoice = await stripeClient.invoices.retrieve(latestInvoice.id, {
+            expand: ['payment_intent'],
+          });
+        }
 
         if (latestInvoice) {
           if (latestInvoice.payment_intent) {

--- a/backend/functions/handlers/payments.js
+++ b/backend/functions/handlers/payments.js
@@ -27,6 +27,18 @@ const logOnboardingLinkAccess = (level, payload) => {
 
   console.info('Stripe onboarding link privileged access', logPayload);
 };
+
+const normalizeStripeMetadata = (metadata = {}) =>
+  Object.fromEntries(
+    Object.entries(metadata)
+      .filter(([, value]) => value !== undefined && value !== null)
+      .map(([key, value]) => {
+        if (typeof value === 'string') return [key, value];
+        if (typeof value === 'number' || typeof value === 'boolean') return [key, String(value)];
+        return [key, JSON.stringify(value)];
+      }),
+  );
+
 /**
  * Create Stripe onboarding link for organization
  * @param {object} req - Express request object
@@ -194,6 +206,7 @@ const createKioskPaymentIntent = (req, res) => {
         // Location reference — read by webhook to build location_snapshot on donation
         location_id: kioskLocationId,
       };
+      const stripeCanonicalMetadata = normalizeStripeMetadata(canonicalMetadata);
 
       const orgSnap = await admin.firestore().collection('organizations').doc(orgId).get();
       if (!orgSnap.exists) {
@@ -219,7 +232,7 @@ const createKioskPaymentIntent = (req, res) => {
         customer = await stripeClient.customers.create({
           email: donor?.email || undefined,
           name: donor?.name || undefined,
-          metadata: canonicalMetadata,
+          metadata: stripeCanonicalMetadata,
         });
       }
 
@@ -239,7 +252,11 @@ const createKioskPaymentIntent = (req, res) => {
             },
           },
           transfer_data: { destination: stripeAccountId },
-          metadata: { ...canonicalMetadata, platform: 'kiosk', frequency: 'once' },
+          metadata: normalizeStripeMetadata({
+            ...canonicalMetadata,
+            platform: 'kiosk',
+            frequency: 'once',
+          }),
         });
         clientSecret = paymentIntent.client_secret;
       } else {
@@ -281,13 +298,13 @@ const createKioskPaymentIntent = (req, res) => {
             customer: customer.id,
             payment_method_types: ['card'],
             usage: 'off_session',
-            metadata: {
+            metadata: normalizeStripeMetadata({
               ...canonicalMetadata,
               platform: 'kiosk',
               flow: 'recurring_setup',
               frequency,
               intervalCount: String(normalizedIntervalCount),
-            },
+            }),
           });
 
           return res.status(200).send({
@@ -368,12 +385,12 @@ const createKioskPaymentIntent = (req, res) => {
           expand: ['latest_invoice.payment_intent'],
           trial_period_days: 0,
           transfer_data: { destination: stripeAccountId },
-          metadata: {
+          metadata: normalizeStripeMetadata({
             ...canonicalMetadata,
             platform: 'kiosk',
             frequency,
             intervalCount: String(normalizedIntervalCount),
-          },
+          }),
         });
 
         console.log('Subscription created:', {
@@ -421,10 +438,10 @@ const createKioskPaymentIntent = (req, res) => {
         if (latestInvoice?.id) {
           try {
             await stripeClient.invoices.update(latestInvoice.id, {
-              metadata: {
+              metadata: normalizeStripeMetadata({
                 ...recurringMetadata,
                 invoiceId: latestInvoice.id,
-              },
+              }),
             });
           } catch (invoiceMetaError) {
             console.warn('Unable to update invoice metadata for recurring donation', {
@@ -442,10 +459,10 @@ const createKioskPaymentIntent = (req, res) => {
         if (paymentIntentId) {
           try {
             await stripeClient.paymentIntents.update(paymentIntentId, {
-              metadata: {
+              metadata: normalizeStripeMetadata({
                 ...recurringMetadata,
                 invoiceId: latestInvoice?.id || null,
-              },
+              }),
             });
           } catch (paymentIntentMetaError) {
             console.warn('Unable to update payment intent metadata for recurring donation', {

--- a/backend/functions/handlers/subscriptions.js
+++ b/backend/functions/handlers/subscriptions.js
@@ -2,7 +2,6 @@ const admin = require('firebase-admin');
 const { ensureStripeInitialized } = require('../services/stripe');
 const cors = require('../middleware/cors');
 const { createSubscriptionDoc } = require('../entities/subscription');
-const { createDonationDoc } = require('../entities/donation');
 const { resolveLocationForDonation, resolveLocationIdFromKiosk } = require('../shared/location');
 const DEFAULT_GIFT_AID_DECLARATION_TEXT =
   'I want to Gift Aid my donation and any donations I make in the future or have made in the past four years to this charity. I am a UK taxpayer and understand that if I pay less Income Tax and/or Capital Gains Tax than the amount of Gift Aid claimed on all my donations in that tax year it is my responsibility to pay any difference.';
@@ -453,9 +452,67 @@ const createRecurringSubscription = (req, res) => {
       });
 
       // Handle first invoice
-      const latestInvoice = subscription.latest_invoice;
+      let latestInvoice = subscription.latest_invoice;
+      if (typeof latestInvoice === 'string') {
+        latestInvoice = await stripeClient.invoices.retrieve(latestInvoice, {
+          expand: ['payment_intent'],
+        });
+      }
       const recurringInterval =
         interval === 'year' ? 'yearly' : normalizedIntervalCount === 3 ? 'quarterly' : 'monthly';
+      const recurringMetadata = {
+        campaignId,
+        organizationId: orgId,
+        donorEmail: donor.email || null,
+        donorName: donor.name || 'Anonymous',
+        donorPhone: donor.phone || null,
+        platform: metadata.platform || 'web',
+        ...metadata,
+        ...stripeLocationMetadata,
+        isRecurring: true,
+        recurringInterest: true,
+        recurringInterval,
+        interval,
+        intervalCount: String(normalizedIntervalCount),
+        subscriptionId: subscription.id,
+      };
+
+      if (latestInvoice?.id) {
+        try {
+          await stripeClient.invoices.update(latestInvoice.id, {
+            metadata: {
+              ...recurringMetadata,
+              invoiceId: latestInvoice.id,
+            },
+          });
+        } catch (invoiceMetaError) {
+          console.warn('Unable to update invoice metadata for recurring subscription', {
+            invoiceId: latestInvoice.id,
+            error: invoiceMetaError.message,
+          });
+        }
+      }
+
+      const paymentIntentId =
+        typeof latestInvoice?.payment_intent === 'string'
+          ? latestInvoice.payment_intent
+          : latestInvoice?.payment_intent?.id;
+
+      if (paymentIntentId) {
+        try {
+          await stripeClient.paymentIntents.update(paymentIntentId, {
+            metadata: {
+              ...recurringMetadata,
+              invoiceId: latestInvoice?.id || null,
+            },
+          });
+        } catch (paymentIntentMetaError) {
+          console.warn('Unable to update payment intent metadata for recurring subscription', {
+            paymentIntentId,
+            error: paymentIntentMetaError.message,
+          });
+        }
+      }
 
       console.log('Latest invoice details:', {
         exists: !!latestInvoice,
@@ -466,45 +523,6 @@ const createRecurringSubscription = (req, res) => {
 
       if (latestInvoice?.payment_intent) {
         const paymentIntent = latestInvoice.payment_intent;
-        // Safety net: if first recurring payment is already successful, persist donation immediately.
-        if (paymentIntent.status === 'succeeded') {
-          const donationId = paymentIntent.id || latestInvoice.id || subscription.id;
-          await createDonationDoc({
-            transactionId: donationId,
-            campaignId,
-            organizationId: orgId,
-            amount: latestInvoice.amount_paid || amount,
-            currency,
-            donorEmail: donor.email || null,
-            donorName: donor.name || 'Anonymous',
-            donorPhone: donor.phone || null,
-            isGiftAid: toBoolean(metadata.isGiftAid),
-            isRecurring: true,
-            recurringInterval,
-            subscriptionId: subscription.id,
-            invoiceId: latestInvoice.id || null,
-            kioskId: subscriptionKioskId,
-            platform: metadata.platform || 'web',
-            location_id: subscriptionLocationId,
-            location_snapshot: subscriptionLocationSnapshot,
-            metadata: {
-              campaignTitleSnapshot: campaignData.title || 'Recurring Donation',
-              source: 'create_recurring_subscription',
-            },
-          });
-
-          await createGiftAidDeclarationFromMetadata({
-            donationId,
-            amountMinor: latestInvoice.amount_paid || amount,
-            metadata,
-            campaignId,
-            campaignTitle: campaignData.title || 'Recurring Donation',
-            organizationId: orgId,
-            donationDateIso: new Date(
-              (latestInvoice.created || Math.floor(Date.now() / 1000)) * 1000,
-            ).toISOString(),
-          });
-        }
 
         return res.status(200).send({
           subscriptionId: subscription.id,
@@ -516,43 +534,6 @@ const createRecurringSubscription = (req, res) => {
           requiresAction: paymentIntent.status === 'requires_action',
         });
       } else if (latestInvoice?.status === 'paid') {
-        const donationId = latestInvoice.payment_intent?.id || latestInvoice.id || subscription.id;
-        await createDonationDoc({
-          transactionId: donationId,
-          campaignId,
-          organizationId: orgId,
-          amount: latestInvoice.amount_paid || amount,
-          currency,
-          donorEmail: donor.email || null,
-          donorName: donor.name || 'Anonymous',
-          donorPhone: donor.phone || null,
-          isGiftAid: toBoolean(metadata.isGiftAid),
-          isRecurring: true,
-          recurringInterval,
-          subscriptionId: subscription.id,
-          invoiceId: latestInvoice.id || null,
-          kioskId: subscriptionKioskId,
-          platform: metadata.platform || 'web',
-          location_id: subscriptionLocationId,
-          location_snapshot: subscriptionLocationSnapshot,
-          metadata: {
-            campaignTitleSnapshot: campaignData.title || 'Recurring Donation',
-            source: 'create_recurring_subscription',
-          },
-        });
-
-        await createGiftAidDeclarationFromMetadata({
-          donationId,
-          amountMinor: latestInvoice.amount_paid || amount,
-          metadata,
-          campaignId,
-          campaignTitle: campaignData.title || 'Recurring Donation',
-          organizationId: orgId,
-          donationDateIso: new Date(
-            (latestInvoice.created || Math.floor(Date.now() / 1000)) * 1000,
-          ).toISOString(),
-        });
-
         return res.status(200).send({
           success: true,
           subscriptionId: subscription.id,

--- a/backend/functions/handlers/subscriptions.js
+++ b/backend/functions/handlers/subscriptions.js
@@ -19,6 +19,17 @@ const normalizeEmail = (value) => {
   return email ? email.toLowerCase() : null;
 };
 
+const normalizeStripeMetadata = (metadata = {}) =>
+  Object.fromEntries(
+    Object.entries(metadata)
+      .filter(([, value]) => value !== undefined && value !== null)
+      .map(([key, value]) => {
+        if (typeof value === 'string') return [key, value];
+        if (typeof value === 'number' || typeof value === 'boolean') return [key, String(value)];
+        return [key, JSON.stringify(value)];
+      }),
+  );
+
 const getTaxYear = (dateValue) => {
   // Handle Firestore Timestamp objects (duck-type on .toDate())
   const resolved =
@@ -397,6 +408,16 @@ const createRecurringSubscription = (req, res) => {
         : {};
 
       // Create subscription
+      const subscriptionMetadata = normalizeStripeMetadata({
+        campaignId,
+        organizationId: orgId,
+        donorEmail: donor.email,
+        donorName: donor.name || 'Anonymous',
+        platform: metadata.platform || 'web',
+        ...metadata,
+        ...stripeLocationMetadata,
+      });
+
       const subscription = await stripeClient.subscriptions.create({
         customer: customer.id,
         items: [{ price: price.id }],
@@ -404,15 +425,7 @@ const createRecurringSubscription = (req, res) => {
         collection_method: 'charge_automatically',
         expand: ['latest_invoice.payment_intent'],
         transfer_data: { destination: stripeAccountId },
-        metadata: {
-          campaignId,
-          organizationId: orgId,
-          donorEmail: donor.email,
-          donorName: donor.name || 'Anonymous',
-          platform: metadata.platform || 'web',
-          ...metadata,
-          ...stripeLocationMetadata,
-        },
+        metadata: subscriptionMetadata,
       });
 
       console.log('Subscription created:', {
@@ -460,7 +473,7 @@ const createRecurringSubscription = (req, res) => {
       }
       const recurringInterval =
         interval === 'year' ? 'yearly' : normalizedIntervalCount === 3 ? 'quarterly' : 'monthly';
-      const recurringMetadata = {
+      const recurringMetadata = normalizeStripeMetadata({
         campaignId,
         organizationId: orgId,
         donorEmail: donor.email || null,
@@ -475,15 +488,15 @@ const createRecurringSubscription = (req, res) => {
         interval,
         intervalCount: String(normalizedIntervalCount),
         subscriptionId: subscription.id,
-      };
+      });
 
       if (latestInvoice?.id) {
         try {
           await stripeClient.invoices.update(latestInvoice.id, {
-            metadata: {
+            metadata: normalizeStripeMetadata({
               ...recurringMetadata,
               invoiceId: latestInvoice.id,
-            },
+            }),
           });
         } catch (invoiceMetaError) {
           console.warn('Unable to update invoice metadata for recurring subscription', {
@@ -501,10 +514,10 @@ const createRecurringSubscription = (req, res) => {
       if (paymentIntentId) {
         try {
           await stripeClient.paymentIntents.update(paymentIntentId, {
-            metadata: {
+            metadata: normalizeStripeMetadata({
               ...recurringMetadata,
               invoiceId: latestInvoice?.id || null,
-            },
+            }),
           });
         } catch (paymentIntentMetaError) {
           console.warn('Unable to update payment intent metadata for recurring subscription', {

--- a/backend/functions/handlers/webhooks.js
+++ b/backend/functions/handlers/webhooks.js
@@ -373,7 +373,7 @@ const handleAccountUpdatedStripeWebhook = async (req, res) => {
           { merge: true },
         );
       console.log(`Stripe account status updated for organization ${orgId}:
-        Charges Enabled: ${chargesEnabled}, 
+        Charges Enabled: ${chargesEnabled},
         Payouts Enabled: ${payoutsEnabled}`);
     } else {
       console.warn('Received account.updated webhook without orgId in metadata.', account.id);
@@ -393,10 +393,11 @@ const handleAccountUpdatedStripeWebhook = async (req, res) => {
  */
 const handlePaymentCompletedStripeWebhook = async (req, res) => {
   let event;
+  let stripeClient;
 
   try {
     // Ensure Stripe is initialized
-    const stripeClient = ensureStripeInitialized();
+    stripeClient = ensureStripeInitialized();
 
     const sig = req.headers['stripe-signature'];
     const { payment: endpointSecretPayment } = getWebhookSecrets();
@@ -427,11 +428,16 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
       let resolvedIsRecurring = toBoolean(metadata.isRecurring);
       let resolvedRecurringInterval = toStringOrNull(metadata.recurringInterval);
       let resolvedSubscriptionId = toStringOrNull(metadata.subscriptionId);
-      let resolvedInvoiceId = toStringOrNull(paymentIntent.invoice);
+      let resolvedInvoiceId =
+        toStringOrNull(paymentIntent.invoice) ||
+        (paymentIntent.payment_details
+          ? toStringOrNull(paymentIntent.payment_details.order_reference)
+          : null);
       let resolvedDonorName = toStringOrNull(metadata.donorName) || 'Anonymous';
       let resolvedDonorEmail = toStringOrNull(metadata.donorEmail);
       let resolvedDonorPhone = toStringOrNull(metadata.donorPhone);
       let resolvedPlatform = toStringOrNull(metadata.platform) || 'unknown';
+      let recurringSubscriptionMetadata = null;
       let lockedSubscriptionLocationId = null;
       let lockedSubscriptionLocationSnapshot = null;
       let lockedSubscriptionKioskId = null;
@@ -450,6 +456,27 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
         }
       }
 
+      // Some payment_intent.succeeded payloads omit invoice references entirely.
+      // For recurring flows, attempt to locate the invoice by payment intent id.
+      if (!resolvedInvoiceId) {
+        try {
+          const invoiceList = await stripeClient.invoices.list({
+            payment_intent: paymentIntent.id,
+            limit: 1,
+          });
+          const fallbackInvoice = invoiceList?.data?.[0];
+          if (fallbackInvoice) {
+            resolvedInvoiceId = toStringOrNull(fallbackInvoice.id) || resolvedInvoiceId;
+          }
+        } catch (invoiceListError) {
+          console.warn(
+            'Unable to resolve invoice by payment intent id:',
+            paymentIntent.id,
+            invoiceListError.message,
+          );
+        }
+      }
+
       // Enrich recurring signals for subscription-driven payment intents.
       // Some first-invoice payment_intent payloads don't carry recurring metadata directly.
       if (resolvedInvoiceId) {
@@ -464,6 +491,7 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
 
             const subscriptionData = await getSubscriptionByStripeId(stripeSubscriptionId);
             if (subscriptionData) {
+              recurringSubscriptionMetadata = subscriptionData.metadata || null;
               resolvedRecurringInterval =
                 subscriptionData.interval === 'year'
                   ? 'yearly'
@@ -515,6 +543,50 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
         }
       }
 
+      // Normalize the donation transaction ID for recurring payments so the same invoice
+      // is not written twice under different IDs across payment_intent.succeeded and invoice.paid.
+      // For recurring donations we prefer the invoice payment intent when available, otherwise
+      // fall back to the invoice id. One-time donations continue to use the payment intent id.
+      const recurringDonationTransactionId =
+        resolvedIsRecurring && resolvedInvoiceId ? resolvedInvoiceId : paymentIntent.id;
+
+      // Invoiced/recurring donations are finalized from invoice.paid where full subscription
+      // context is available. Skipping here prevents creating sparse placeholder docs
+      // and duplicate recurring donation records.
+      const shouldDeferToInvoicePaid =
+        resolvedIsRecurring ||
+        Boolean(resolvedInvoiceId) ||
+        toBoolean(metadata.recurringInterest) ||
+        Boolean(toStringOrNull(metadata.frequency)) ||
+        Boolean(resolvedSubscriptionId) ||
+        (Object.keys(metadata).length === 0 &&
+          !resolvedCampaignId &&
+          !organizationId &&
+          !resolvedSubscriptionId);
+
+      if (shouldDeferToInvoicePaid) {
+        console.log(
+          '[Webhook] Deferring donation write from payment_intent.succeeded to invoice.paid',
+          {
+            paymentIntentId: paymentIntent.id,
+            invoiceId: resolvedInvoiceId,
+            subscriptionId: resolvedSubscriptionId,
+            resolvedIsRecurring,
+            hasRecurringInterest: toBoolean(metadata.recurringInterest),
+            metadataFrequency: toStringOrNull(metadata.frequency),
+            hasMetadataKeys: Object.keys(metadata).length > 0,
+            hasCampaignContext: Boolean(resolvedCampaignId || organizationId),
+          },
+        );
+
+        await markEventProcessed(event.id, {
+          paymentIntentId: paymentIntent.id,
+          deferredTo: 'invoice.paid',
+          recurringDonationTransactionId,
+        });
+        return res.status(200).send('OK');
+      }
+
       // Resolve location — strict for kiosk donations, null for web/recurring.
       // Backwards-compatible fallback: if kioskId is present but location_id is missing
       // from metadata (older payment intent or producer gap), resolve from the kiosk doc
@@ -540,7 +612,7 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
 
       // Use entity to create donation with recurring support
       await createDonationDoc({
-        transactionId: paymentIntent.id,
+        transactionId: recurringDonationTransactionId,
         campaignId: resolvedCampaignId || null,
         organizationId: organizationId || null,
         amount: paymentIntent.amount,
@@ -567,7 +639,10 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
 
       // Create Gift Aid declaration if needed (old flow: isGiftAid=true in metadata)
       await createGiftAidDeclarationIfNeeded({
-        paymentIntent,
+        paymentIntent: {
+          ...paymentIntent,
+          id: recurringDonationTransactionId,
+        },
         metadata,
         campaignId: resolvedCampaignId,
         campaignTitleSnapshot,
@@ -595,15 +670,15 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
 
             // Fix #2: guard against re-homing a declaration already linked to a different donation
             const existingDonationId = toStringOrNull(declarationData.donationId);
-            if (existingDonationId && existingDonationId !== paymentIntent.id) {
+            if (existingDonationId && existingDonationId !== recurringDonationTransactionId) {
               await writeGiftAidReconciliationIssue({
-                paymentIntentId: paymentIntent.id,
+                paymentIntentId: recurringDonationTransactionId,
                 declarationId: preCreatedDeclarationId,
                 organizationId: organizationId || null,
                 reason: 'pre_created_declaration_already_linked_to_other_donation',
                 metadata: {
                   existingDonationId,
-                  incomingDonationId: paymentIntent.id,
+                  incomingDonationId: recurringDonationTransactionId,
                 },
               });
               console.warn(
@@ -611,7 +686,7 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
                 {
                   declarationId: preCreatedDeclarationId,
                   existingDonationId,
-                  incomingDonationId: paymentIntent.id,
+                  incomingDonationId: recurringDonationTransactionId,
                 },
               );
             } else {
@@ -627,12 +702,14 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
                 toStringOrNull(declarationData.organizationId) ||
                 null;
 
-              const donationRef = db.collection('donations').doc(paymentIntent.id);
+              const recurringDonationRef = db
+                .collection('donations')
+                .doc(recurringDonationTransactionId);
 
               // Update donation: mark as Gift Aid, set donor name, link declaration
               await withRetries(
                 () =>
-                  donationRef.set(
+                  recurringDonationRef.set(
                     {
                       isGiftAid: true,
                       giftAidDeclarationId: preCreatedDeclarationId,
@@ -650,7 +727,7 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
                 () =>
                   declarationRef.set(
                     {
-                      donationId: paymentIntent.id,
+                      donationId: recurringDonationTransactionId,
                       donationAmount: paymentIntent.amount,
                       giftAidAmount: Math.round(paymentIntent.amount * 0.25),
                       campaignId: resolvedCampaignId || declarationData.campaignId || null,
@@ -682,7 +759,7 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
               );
 
               console.log('✅ [Gift Aid] Pre-created declaration linked to donation', {
-                donationId: paymentIntent.id,
+                donationId: recurringDonationTransactionId,
                 declarationId: preCreatedDeclarationId,
                 donorName: donorNameFromDeclaration,
               });
@@ -713,12 +790,20 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
 
       // Generate magic link token automatically (Issue #587)
       // Token generated for all Gift Aid campaigns to enable post-donation opt-in
-      const magicLinkPurpose = determinePurpose(metadata);
+      const magicLinkMetadata = resolvedIsRecurring
+        ? {
+            ...(recurringSubscriptionMetadata || {}),
+            ...metadata,
+            isRecurring: true,
+            recurringInterest: true,
+          }
+        : metadata;
+      const magicLinkPurpose = determinePurpose(magicLinkMetadata);
       if (magicLinkPurpose) {
         try {
           const tokenResult = await generateMagicLinkToken({
-            paymentIntentId: paymentIntent.id,
-            donationId: paymentIntent.id,
+            paymentIntentId: recurringDonationTransactionId,
+            donationId: recurringDonationTransactionId,
             campaignId: resolvedCampaignId || null,
             charityId: organizationId || null,
             kioskId: toStringOrNull(metadata.kioskId) || null,
@@ -730,18 +815,18 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
 
           if (tokenResult.alreadyExists) {
             console.log('✅ [Magic Link] Token already exists (idempotent)', {
-              paymentIntentId: paymentIntent.id,
+              paymentIntentId: recurringDonationTransactionId,
               purpose: magicLinkPurpose,
             });
           } else if (tokenResult.skipped) {
             console.log('⚠️ [Magic Link] Generation skipped', {
-              paymentIntentId: paymentIntent.id,
+              paymentIntentId: recurringDonationTransactionId,
               reason: tokenResult.reason,
             });
           } else {
             console.log('✅ [Magic Link] Token generated successfully', {
-              paymentIntentId: paymentIntent.id,
-              donationId: paymentIntent.id,
+              paymentIntentId: recurringDonationTransactionId,
+              donationId: recurringDonationTransactionId,
               purpose: magicLinkPurpose,
               expiresAt: tokenResult.expiresAt?.toDate().toISOString(),
             });
@@ -749,15 +834,17 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
         } catch (magicLinkError) {
           // Don't fail the webhook if magic link generation fails
           console.error('❌ [Magic Link] Generation failed (non-critical)', {
-            paymentIntentId: paymentIntent.id,
+            paymentIntentId: recurringDonationTransactionId,
             error: magicLinkError.message,
           });
         }
       } else {
         console.log('ℹ️ [Magic Link] Not needed for this donation', {
-          paymentIntentId: paymentIntent.id,
+          paymentIntentId: recurringDonationTransactionId,
           isGiftAid: metadata.isGiftAid,
           isRecurring: metadata.isRecurring,
+          recurringInterest: magicLinkMetadata.recurringInterest,
+          sourceMetadataKeys: Object.keys(magicLinkMetadata || {}),
         });
       }
 
@@ -854,9 +941,16 @@ const handleSubscriptionWebhook = async (req, res) => {
  * @return {Promise<void>}
  */
 const handleInvoicePaid = async (invoice) => {
-  const subscriptionId = invoice.subscription;
+  const subscriptionId =
+    toStringOrNull(invoice.subscription) ||
+    (invoice.parent && invoice.parent.subscription_details
+      ? toStringOrNull(invoice.parent.subscription_details.subscription)
+      : null);
   if (!subscriptionId) {
-    console.log('Invoice not associated with subscription:', invoice.id);
+    console.log(
+      'Invoice not associated with subscription (no top-level or parent.subscription_details):',
+      invoice.id,
+    );
     return;
   }
 
@@ -930,7 +1024,7 @@ const handleInvoicePaid = async (invoice) => {
   }
 
   await createDonationDoc({
-    transactionId: invoice.payment_intent || invoice.id,
+    transactionId: invoice.id,
     campaignId: subscriptionData.campaignId,
     organizationId: subscriptionData.organizationId,
     amount: invoice.amount_paid,
@@ -956,7 +1050,7 @@ const handleInvoicePaid = async (invoice) => {
   // Ensure Gift Aid declarations are also created for recurring payments when metadata includes Gift Aid details.
   await createGiftAidDeclarationIfNeeded({
     paymentIntent: {
-      id: invoice.payment_intent || invoice.id,
+      id: invoice.id,
       amount: invoice.amount_paid,
       created: invoice.created,
     },
@@ -965,6 +1059,59 @@ const handleInvoicePaid = async (invoice) => {
     campaignTitleSnapshot: subscriptionData.metadata?.campaignTitle || 'Recurring Donation',
     organizationId: subscriptionData.organizationId,
   });
+
+  // Generate magic link token for recurring donations using canonical invoice id.
+  // This keeps the token key aligned with recurring donation document id and avoids
+  // dependence on sparse payment_intent metadata timing.
+  const magicLinkMetadata = {
+    ...(subscriptionData.metadata || {}),
+    isRecurring: true,
+    recurringInterest: true,
+  };
+  const magicLinkPurpose = determinePurpose(magicLinkMetadata);
+  if (magicLinkPurpose) {
+    try {
+      const tokenResult = await generateMagicLinkToken({
+        paymentIntentId: invoice.id,
+        donationId: invoice.id,
+        campaignId: subscriptionData.campaignId || null,
+        charityId: subscriptionData.organizationId || null,
+        kioskId: recurringKioskId || null,
+        amount: invoice.amount_paid,
+        currency: invoice.currency,
+        purpose: magicLinkPurpose,
+        donorEmail: subscriptionData.donorEmail || subscriptionData.metadata?.donorEmail || null,
+      });
+
+      if (tokenResult.alreadyExists) {
+        console.log('✅ [Magic Link] Recurring token already exists (idempotent)', {
+          invoiceId: invoice.id,
+          purpose: magicLinkPurpose,
+        });
+      } else if (tokenResult.skipped) {
+        console.log('⚠️ [Magic Link] Recurring generation skipped', {
+          invoiceId: invoice.id,
+          reason: tokenResult.reason,
+        });
+      } else {
+        console.log('✅ [Magic Link] Recurring token generated', {
+          invoiceId: invoice.id,
+          purpose: magicLinkPurpose,
+          expiresAt: tokenResult.expiresAt?.toDate().toISOString(),
+        });
+      }
+    } catch (magicLinkError) {
+      console.error('❌ [Magic Link] Recurring generation failed (non-critical)', {
+        invoiceId: invoice.id,
+        error: magicLinkError.message,
+      });
+    }
+  } else {
+    console.log('ℹ️ [Magic Link] Not needed for recurring invoice', {
+      invoiceId: invoice.id,
+      sourceMetadataKeys: Object.keys(magicLinkMetadata || {}),
+    });
+  }
 
   // Update subscription analytics: lastPaymentAt
   await updateSubscriptionStatus(subscriptionId, 'active', {

--- a/backend/functions/handlers/webhooks.js
+++ b/backend/functions/handlers/webhooks.js
@@ -428,11 +428,7 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
       let resolvedIsRecurring = toBoolean(metadata.isRecurring);
       let resolvedRecurringInterval = toStringOrNull(metadata.recurringInterval);
       let resolvedSubscriptionId = toStringOrNull(metadata.subscriptionId);
-      let resolvedInvoiceId =
-        toStringOrNull(paymentIntent.invoice) ||
-        (paymentIntent.payment_details
-          ? toStringOrNull(paymentIntent.payment_details.order_reference)
-          : null);
+      let resolvedInvoiceId = toStringOrNull(paymentIntent.invoice);
       let resolvedDonorName = toStringOrNull(metadata.donorName) || 'Anonymous';
       let resolvedDonorEmail = toStringOrNull(metadata.donorEmail);
       let resolvedDonorPhone = toStringOrNull(metadata.donorPhone);
@@ -456,9 +452,16 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
         }
       }
 
-      // Some payment_intent.succeeded payloads omit invoice references entirely.
-      // For recurring flows, attempt to locate the invoice by payment intent id.
-      if (!resolvedInvoiceId) {
+      // Some subscription-driven payment_intent.succeeded payloads omit invoice references.
+      // Only attempt the Stripe invoice lookup when we have a recurring/invoiced signal.
+      const hasRecurringSignal =
+        resolvedIsRecurring ||
+        Boolean(resolvedSubscriptionId) ||
+        toBoolean(metadata.recurringInterest) ||
+        toBoolean(metadata.isRecurring) ||
+        toStringOrNull(metadata.frequency) !== null;
+
+      if (!resolvedInvoiceId && hasRecurringSignal) {
         try {
           const invoiceList = await stripeClient.invoices.list({
             payment_intent: paymentIntent.id,
@@ -558,11 +561,7 @@ const handlePaymentCompletedStripeWebhook = async (req, res) => {
         Boolean(resolvedInvoiceId) ||
         toBoolean(metadata.recurringInterest) ||
         Boolean(toStringOrNull(metadata.frequency)) ||
-        Boolean(resolvedSubscriptionId) ||
-        (Object.keys(metadata).length === 0 &&
-          !resolvedCampaignId &&
-          !organizationId &&
-          !resolvedSubscriptionId);
+        Boolean(resolvedSubscriptionId);
 
       if (shouldDeferToInvoicePaid) {
         console.log(

--- a/backend/functions/handlers/webhooks.test.js
+++ b/backend/functions/handlers/webhooks.test.js
@@ -403,7 +403,7 @@ describe('handleSubscriptionWebhook recurring location handling', () => {
     expect(res.statusCode).toBe(200);
     expect(createDonationDoc).toHaveBeenCalledWith(
       expect.objectContaining({
-        transactionId: 'pi_locked_location_001',
+        transactionId: 'in_locked_location_001',
         kioskId: 'kiosk_reassigned_001',
         location_id: 'loc_original_building',
         location_snapshot: {

--- a/backend/functions/handlers/webhooks.test.js
+++ b/backend/functions/handlers/webhooks.test.js
@@ -7,6 +7,7 @@ jest.mock('../services/stripe', () => ({
   })),
   ensureStripeInitialized: jest.fn(() => ({
     invoices: {
+      list: jest.fn(),
       retrieve: jest.fn(),
     },
     subscriptions: {
@@ -163,6 +164,101 @@ describe('handlePaymentCompletedStripeWebhook', () => {
         },
       }),
     );
+  });
+
+  it('writes a one-time payment even when metadata is sparse and no invoice is present', async () => {
+    const event = {
+      id: 'evt_sparse_one_time',
+      type: 'payment_intent.succeeded',
+      data: {
+        object: {
+          id: 'pi_sparse_one_time',
+          amount: 1200,
+          currency: 'gbp',
+          invoice: null,
+          metadata: {},
+        },
+      },
+    };
+
+    verifyWebhookSignatureWithAnySecret.mockReturnValue(event);
+
+    const res = createResponse();
+    await handlePaymentCompletedStripeWebhook(makeRequest(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(createDonationDoc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transactionId: 'pi_sparse_one_time',
+        amount: 1200,
+        currency: 'gbp',
+        isRecurring: false,
+      }),
+    );
+  });
+
+  it('defers recurring payment_intent.succeeded when invoice is resolved via Stripe lookup', async () => {
+    const stripe = {
+      invoices: {
+        list: jest.fn(),
+        retrieve: jest.fn(),
+      },
+      subscriptions: {
+        retrieve: jest.fn(),
+      },
+    };
+    require('../services/stripe').ensureStripeInitialized.mockReturnValue(stripe);
+    stripe.invoices.list.mockResolvedValue({
+      data: [
+        {
+          id: 'in_recurring_lookup_001',
+        },
+      ],
+    });
+    stripe.invoices.retrieve.mockResolvedValue({
+      id: 'in_recurring_lookup_001',
+      subscription: 'sub_recurring_lookup_001',
+    });
+    getSubscriptionByStripeId.mockResolvedValue({
+      stripeSubscriptionId: 'sub_recurring_lookup_001',
+      campaignId: 'camp_1',
+      organizationId: 'org_1',
+      interval: 'month',
+      intervalCount: 1,
+      donorEmail: 'donor@example.com',
+      donorName: 'Recurring Donor',
+      metadata: {
+        recurringInterest: 'true',
+      },
+    });
+
+    const event = {
+      id: 'evt_recurring_lookup',
+      type: 'payment_intent.succeeded',
+      data: {
+        object: {
+          id: 'pi_recurring_lookup_001',
+          amount: 2000,
+          currency: 'gbp',
+          invoice: null,
+          metadata: {
+            recurringInterest: 'true',
+          },
+        },
+      },
+    };
+
+    verifyWebhookSignatureWithAnySecret.mockReturnValue(event);
+
+    const res = createResponse();
+    await handlePaymentCompletedStripeWebhook(makeRequest(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(createDonationDoc).not.toHaveBeenCalled();
+    expect(stripe.invoices.list).toHaveBeenCalledWith({
+      payment_intent: 'pi_recurring_lookup_001',
+      limit: 1,
+    });
   });
 
   // ─── Declaration-first linkage tests ────────────────────────────────────────


### PR DESCRIPTION
## Summary
   
   This PR fixes and redesigns the recurring payment flow end-to-end (Android + backend), with a focus on 
  Stripe metadata consistency, webhook-driven correctness, and duplicate prevention.
   
   ## Problem
   
   Recurring payments had multiple issues:
   - Metadata was missing/inconsistent on recurring Stripe objects/events.
   - Duplicate donation records were created (`pi_...` + `in_...`) for the same recurring payment.
   - Recurring flow behavior differed across setup/finalize and webhook paths.
   - Android recurring finalize calls were vulnerable to network timeout under slower backend responses.
   - Magic link generation for recurring payments was unreliable due to event timing/context gaps.
   
   ## What changed
   
   ### 1) Recurring flow redesign (canonical event + id)
   - Moved recurring donation creation to **`invoice.paid`** as the canonical source.
   - Standardized recurring donation `transactionId` to **`invoice.id` (`in_...`)**.
   - Updated webhook behavior so `payment_intent.succeeded` defers recurring/invoiced writes to `invoice.paid` 
  and avoids shadow docs.
   
   ### 2) Metadata propagation fixes
   - Ensured recurring metadata is propagated to:
     - subscription metadata
     - first invoice metadata
     - first payment intent metadata
   - Added stronger recurring/invoiced signal detection in webhook deferral logic (including sparse/empty 
  metadata payload scenarios).
   
   ### 3) Shadow doc elimination
   - Removed synchronous recurring donation writes from `createRecurringSubscription` path.
   - Prevented fallback one-time style doc creation for recurring invoice-backed events.
   
   ### 4) Magic link reliability (recurring)
   - Added recurring magic link token generation on `invoice.paid` using canonical invoice context.
   - Aligned magic link keying/idempotency with recurring donation doc identity (`in_...`).
   
   ### 5) Android recurring stability updates
   - Improved recurring request/finalize flow support in Android models/viewmodels.
   - Increased HTTP timeouts in `PaymentRepository` to reduce finalize timeout failures.
   - Updated related Android flow integration points (`MainActivity`, `PaymentViewModel`, etc.).
   
   ## Files touched (high level)
   
   - `backend/functions/handlers/payments.js`
   - `backend/functions/handlers/subscriptions.js`
   - `backend/functions/handlers/webhooks.js`
   - `backend/functions/handlers/webhooks.test.js`
   - `android/app/src/main/java/com/example/swiftcause/...`
     - `MainActivity.kt`
     - `PaymentModels.kt`
     - `PaymentRepository.kt`
     - `CampaignListViewModel.kt`
     - `PaymentViewModel.kt`
   
   ## Behavioral outcome
   
   - One-time donations continue to use `pi_...` transaction IDs.
   - Recurring donations now consistently use `in_...` transaction IDs.
   - Recurring payments now produce a single canonical donation record per paid invoice.
   - Recurring metadata and downstream automation (including magic link) are now deterministic and event-safe.
