### PR TITLE
Add managed device API handlers

### DIFF
--- a/backend/functions/handlers/managedDevices.js
+++ b/backend/functions/handlers/managedDevices.js
@@ -1,0 +1,340 @@
+const crypto = require('crypto');
+const admin = require('firebase-admin');
+const cors = require('../middleware/cors');
+
+const CONTROLLER_PACKAGE = 'com.swiftcause.devicecontroller';
+const KIOSK_PACKAGE = 'com.swiftcause.kiosk';
+const HEARTBEAT_INTERVAL_SECONDS = 60;
+const ALLOWED_DEVICE_STATUSES = new Set([
+  'enrolled',
+  'online',
+  'offline',
+  'installing',
+  'install_failed',
+  'kiosk_active',
+  'error',
+]);
+
+const timestamp = () => admin.firestore.Timestamp.now();
+
+const sendError = (res, code, message) => res.status(code).send({ error: message });
+
+const requiredString = (value, fieldName) => {
+  if (typeof value !== 'string' || !value.trim()) {
+    const error = new Error(`${fieldName} is required`);
+    error.code = 400;
+    throw error;
+  }
+
+  return value.trim();
+};
+
+const buildDeviceId = ({ organizationId, controllerPackage, androidId, serialNumber }) => {
+  const deviceKey = androidId || serialNumber;
+  const hash = crypto
+    .createHash('sha256')
+    .update(`${organizationId}:${controllerPackage}:${deviceKey}`)
+    .digest('hex')
+    .slice(0, 24);
+
+  return `device_${hash}`;
+};
+
+const getDevice = async (deviceId) => {
+  const doc = await admin.firestore().collection('managedDevices').doc(deviceId).get();
+  if (!doc.exists) {
+    const error = new Error('Managed device not found');
+    error.code = 404;
+    throw error;
+  }
+
+  return { id: doc.id, ...doc.data() };
+};
+
+const getAssignedApk = async (device) => {
+  if (device.assignedKioskApkId) {
+    const apkDoc = await admin
+      .firestore()
+      .collection('kioskApks')
+      .doc(device.assignedKioskApkId)
+      .get();
+    return apkDoc.exists ? { id: apkDoc.id, ...apkDoc.data() } : null;
+  }
+
+  if (device.kioskId) {
+    const kioskDoc = await admin.firestore().collection('kiosks').doc(device.kioskId).get();
+    if (kioskDoc.exists) {
+      const kiosk = kioskDoc.data();
+      const apkId = kiosk.assignedKioskApkId || kiosk.kioskApkId;
+      if (apkId) {
+        const apkDoc = await admin.firestore().collection('kioskApks').doc(apkId).get();
+        return apkDoc.exists ? { id: apkDoc.id, ...apkDoc.data() } : null;
+      }
+    }
+  }
+
+  const apkSnapshot = await admin.firestore().collection('kioskApks').get();
+  const activeApk = apkSnapshot.docs
+    .map((doc) => ({ id: doc.id, ...doc.data() }))
+    .find(
+      (apk) =>
+        apk.organizationId === device.organizationId &&
+        apk.packageName === KIOSK_PACKAGE &&
+        apk.active !== false,
+    );
+
+  return activeApk || null;
+};
+
+const appendDeviceEvent = async (type, device, payload = {}) => {
+  await admin
+    .firestore()
+    .collection('deviceEvents')
+    .add({
+      type,
+      organizationId: device.organizationId,
+      kioskId: device.kioskId || null,
+      deviceId: device.id,
+      payload,
+      status: payload.status || null,
+      createdAt: timestamp(),
+    });
+};
+
+const kioskDeviceRegister = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const enrollmentToken = requiredString(req.body?.enrollmentToken, 'enrollmentToken');
+      const controllerPackage = req.body?.controllerPackage || CONTROLLER_PACKAGE;
+      const androidId = typeof req.body?.androidId === 'string' ? req.body.androidId.trim() : '';
+      const serialNumber =
+        typeof req.body?.serialNumber === 'string' ? req.body.serialNumber.trim() : '';
+      if (!androidId && !serialNumber) {
+        return sendError(res, 400, 'androidId or serialNumber is required');
+      }
+
+      const enrollmentDoc = await admin
+        .firestore()
+        .collection('deviceEnrollments')
+        .doc(enrollmentToken)
+        .get();
+      if (!enrollmentDoc.exists) {
+        return sendError(res, 401, 'Invalid enrollment token');
+      }
+
+      const enrollment = enrollmentDoc.data();
+      if (enrollment.status !== 'active') {
+        return sendError(res, 403, 'Enrollment is not active');
+      }
+
+      const deviceId = buildDeviceId({
+        organizationId: enrollment.organizationId,
+        controllerPackage,
+        androidId,
+        serialNumber,
+      });
+      const now = timestamp();
+      const device = {
+        organizationId: enrollment.organizationId,
+        kioskId: enrollment.kioskId || null,
+        enrollmentId: enrollmentToken,
+        controllerPackage,
+        kioskPackage: enrollment.kioskPackage || KIOSK_PACKAGE,
+        status: 'enrolled',
+        deviceInfo: {
+          androidId: androidId || null,
+          serialNumber: serialNumber || null,
+          model: req.body?.model || null,
+          manufacturer: req.body?.manufacturer || null,
+          controllerVersion: req.body?.controllerVersion || null,
+        },
+        lastRegisteredAt: now,
+        updatedAt: now,
+      };
+
+      await admin
+        .firestore()
+        .collection('managedDevices')
+        .doc(deviceId)
+        .set(device, { merge: true });
+
+      return res.status(200).send({
+        success: true,
+        deviceId,
+        organizationId: device.organizationId,
+        kioskId: device.kioskId,
+        status: device.status,
+      });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to register device');
+    }
+  });
+};
+
+const kioskDevicePolicy = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'GET') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const deviceId = requiredString(req.query?.deviceId, 'deviceId');
+      const device = await getDevice(deviceId);
+      const apk = await getAssignedApk(device);
+
+      await admin.firestore().collection('managedDevices').doc(deviceId).set(
+        {
+          lastPolicyFetchAt: timestamp(),
+          updatedAt: timestamp(),
+        },
+        { merge: true },
+      );
+
+      return res.status(200).send({
+        success: true,
+        deviceId,
+        organizationId: device.organizationId,
+        kioskId: device.kioskId || null,
+        controllerPackage: device.controllerPackage || CONTROLLER_PACKAGE,
+        kioskPackage: device.kioskPackage || KIOSK_PACKAGE,
+        launchPackage: device.kioskPackage || KIOSK_PACKAGE,
+        heartbeatIntervalSeconds: HEARTBEAT_INTERVAL_SECONDS,
+        apk: apk
+          ? {
+              apkId: apk.id,
+              packageName: apk.packageName,
+              versionCode: apk.versionCode,
+              versionName: apk.versionName || null,
+              checksumSha256: apk.checksumSha256 || null,
+            }
+          : null,
+      });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to fetch device policy');
+    }
+  });
+};
+
+const kioskDeviceStatus = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const deviceId = requiredString(req.body?.deviceId, 'deviceId');
+      const status = requiredString(req.body?.status, 'status');
+      if (!ALLOWED_DEVICE_STATUSES.has(status)) {
+        return sendError(res, 400, 'Invalid device status');
+      }
+
+      const device = await getDevice(deviceId);
+      const update = {
+        status,
+        installStatus: req.body?.installStatus || null,
+        launchStatus: req.body?.launchStatus || null,
+        deviceOwner: Boolean(req.body?.deviceOwner),
+        lastError: req.body?.error || null,
+        lastStatusAt: timestamp(),
+        updatedAt: timestamp(),
+      };
+
+      await admin
+        .firestore()
+        .collection('managedDevices')
+        .doc(deviceId)
+        .set(update, { merge: true });
+      await appendDeviceEvent('STATUS_UPDATED', { id: deviceId, ...device }, update);
+
+      return res.status(200).send({
+        success: true,
+        deviceId,
+        status,
+      });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to update device status');
+    }
+  });
+};
+
+const kioskDeviceHeartbeat = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const deviceId = requiredString(req.body?.deviceId, 'deviceId');
+      const device = await getDevice(deviceId);
+      const update = {
+        status: 'online',
+        batteryLevel: req.body?.batteryLevel ?? null,
+        networkType: req.body?.networkType || null,
+        lastHeartbeatAt: timestamp(),
+        updatedAt: timestamp(),
+      };
+
+      await admin
+        .firestore()
+        .collection('managedDevices')
+        .doc(deviceId)
+        .set(update, { merge: true });
+      await appendDeviceEvent('HEARTBEAT', { id: deviceId, ...device }, update);
+
+      return res.status(200).send({
+        success: true,
+        deviceId,
+        nextHeartbeatIntervalSeconds: HEARTBEAT_INTERVAL_SECONDS,
+      });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to record heartbeat');
+    }
+  });
+};
+
+const kioskApkDownload = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'GET') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const deviceId = requiredString(req.query?.deviceId, 'deviceId');
+      const apkId = requiredString(req.query?.apkId, 'apkId');
+      const device = await getDevice(deviceId);
+      const apkDoc = await admin.firestore().collection('kioskApks').doc(apkId).get();
+      if (!apkDoc.exists) {
+        return sendError(res, 404, 'APK not found');
+      }
+
+      const apk = apkDoc.data();
+      if (apk.organizationId !== device.organizationId) {
+        return sendError(res, 403, 'APK is not assigned to this organization');
+      }
+
+      return res.status(200).send({
+        success: true,
+        apkId,
+        packageName: apk.packageName,
+        versionCode: apk.versionCode,
+        versionName: apk.versionName || null,
+        downloadUrl: apk.downloadUrl || null,
+        checksumSha256: apk.checksumSha256 || null,
+      });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to resolve APK download');
+    }
+  });
+};
+
+module.exports = {
+  kioskDeviceRegister,
+  kioskDevicePolicy,
+  kioskDeviceStatus,
+  kioskDeviceHeartbeat,
+  kioskApkDownload,
+};

--- a/backend/functions/handlers/managedDevices.js
+++ b/backend/functions/handlers/managedDevices.js
@@ -19,6 +19,23 @@ const timestamp = () => admin.firestore.Timestamp.now();
 
 const sendError = (res, code, message) => res.status(code).send({ error: message });
 
+const hashSecret = (secret) => crypto.createHash('sha256').update(secret).digest('hex');
+
+const createDeviceSecret = () => crypto.randomBytes(32).toString('base64url');
+
+const getDeviceSecret = (req) => {
+  const authHeader =
+    typeof req.headers?.authorization === 'string' ? req.headers.authorization : '';
+  const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  if (bearerMatch) {
+    return bearerMatch[1].trim();
+  }
+
+  return typeof req.headers?.['x-device-secret'] === 'string'
+    ? req.headers['x-device-secret'].trim()
+    : '';
+};
+
 const requiredString = (value, fieldName) => {
   if (typeof value !== 'string' || !value.trim()) {
     const error = new Error(`${fieldName} is required`);
@@ -49,6 +66,22 @@ const getDevice = async (deviceId) => {
   }
 
   return { id: doc.id, ...doc.data() };
+};
+
+const getAuthenticatedDevice = async (req, deviceId) => {
+  const device = await getDevice(deviceId);
+  const deviceSecret = getDeviceSecret(req);
+  if (
+    !deviceSecret ||
+    !device.deviceSecretHash ||
+    hashSecret(deviceSecret) !== device.deviceSecretHash
+  ) {
+    const error = new Error('Invalid device credentials');
+    error.code = 401;
+    throw error;
+  }
+
+  return device;
 };
 
 const getAssignedApk = async (device) => {
@@ -109,7 +142,6 @@ const kioskDeviceRegister = (req, res) => {
       }
 
       const enrollmentToken = requiredString(req.body?.enrollmentToken, 'enrollmentToken');
-      const controllerPackage = req.body?.controllerPackage || CONTROLLER_PACKAGE;
       const androidId = typeof req.body?.androidId === 'string' ? req.body.androidId.trim() : '';
       const serialNumber =
         typeof req.body?.serialNumber === 'string' ? req.body.serialNumber.trim() : '';
@@ -133,17 +165,19 @@ const kioskDeviceRegister = (req, res) => {
 
       const deviceId = buildDeviceId({
         organizationId: enrollment.organizationId,
-        controllerPackage,
+        controllerPackage: CONTROLLER_PACKAGE,
         androidId,
         serialNumber,
       });
       const now = timestamp();
+      const deviceSecret = createDeviceSecret();
       const device = {
         organizationId: enrollment.organizationId,
         kioskId: enrollment.kioskId || null,
         enrollmentId: enrollmentToken,
-        controllerPackage,
+        controllerPackage: CONTROLLER_PACKAGE,
         kioskPackage: enrollment.kioskPackage || KIOSK_PACKAGE,
+        deviceSecretHash: hashSecret(deviceSecret),
         status: 'enrolled',
         deviceInfo: {
           androidId: androidId || null,
@@ -165,6 +199,7 @@ const kioskDeviceRegister = (req, res) => {
       return res.status(200).send({
         success: true,
         deviceId,
+        deviceSecret,
         organizationId: device.organizationId,
         kioskId: device.kioskId,
         status: device.status,
@@ -183,7 +218,7 @@ const kioskDevicePolicy = (req, res) => {
       }
 
       const deviceId = requiredString(req.query?.deviceId, 'deviceId');
-      const device = await getDevice(deviceId);
+      const device = await getAuthenticatedDevice(req, deviceId);
       const apk = await getAssignedApk(device);
 
       await admin.firestore().collection('managedDevices').doc(deviceId).set(
@@ -232,16 +267,24 @@ const kioskDeviceStatus = (req, res) => {
         return sendError(res, 400, 'Invalid device status');
       }
 
-      const device = await getDevice(deviceId);
+      const device = await getAuthenticatedDevice(req, deviceId);
       const update = {
         status,
-        installStatus: req.body?.installStatus || null,
-        launchStatus: req.body?.launchStatus || null,
-        deviceOwner: Boolean(req.body?.deviceOwner),
-        lastError: req.body?.error || null,
         lastStatusAt: timestamp(),
         updatedAt: timestamp(),
       };
+      if (Object.prototype.hasOwnProperty.call(req.body, 'installStatus')) {
+        update.installStatus = req.body.installStatus;
+      }
+      if (Object.prototype.hasOwnProperty.call(req.body, 'launchStatus')) {
+        update.launchStatus = req.body.launchStatus;
+      }
+      if (Object.prototype.hasOwnProperty.call(req.body, 'deviceOwner')) {
+        update.deviceOwner = req.body.deviceOwner === null ? null : Boolean(req.body.deviceOwner);
+      }
+      if (Object.prototype.hasOwnProperty.call(req.body, 'error')) {
+        update.lastError = req.body.error;
+      }
 
       await admin
         .firestore()
@@ -269,7 +312,7 @@ const kioskDeviceHeartbeat = (req, res) => {
       }
 
       const deviceId = requiredString(req.body?.deviceId, 'deviceId');
-      const device = await getDevice(deviceId);
+      const device = await getAuthenticatedDevice(req, deviceId);
       const update = {
         status: 'online',
         batteryLevel: req.body?.batteryLevel ?? null,
@@ -305,7 +348,12 @@ const kioskApkDownload = (req, res) => {
 
       const deviceId = requiredString(req.query?.deviceId, 'deviceId');
       const apkId = requiredString(req.query?.apkId, 'apkId');
-      const device = await getDevice(deviceId);
+      const device = await getAuthenticatedDevice(req, deviceId);
+      const assignedApk = await getAssignedApk(device);
+      if (!assignedApk || assignedApk.id !== apkId) {
+        return sendError(res, 403, 'APK is not assigned to this device');
+      }
+
       const apkDoc = await admin.firestore().collection('kioskApks').doc(apkId).get();
       if (!apkDoc.exists) {
         return sendError(res, 404, 'APK not found');

--- a/backend/functions/handlers/managedDevices.test.js
+++ b/backend/functions/handlers/managedDevices.test.js
@@ -1,0 +1,300 @@
+jest.mock('firebase-admin', () => require('../testUtils/mockFirebaseAdmin'));
+jest.mock('../middleware/cors', () => (req, res, callback) => callback());
+
+const admin = require('firebase-admin');
+const {
+  kioskDeviceRegister,
+  kioskDevicePolicy,
+  kioskDeviceStatus,
+  kioskDeviceHeartbeat,
+  kioskApkDownload,
+} = require('./managedDevices');
+
+const createResponse = () => {
+  const response = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return response;
+};
+
+const invokeHandler = async (handler, request) => {
+  let done;
+  const finished = new Promise((resolve) => {
+    done = resolve;
+  });
+
+  const response = createResponse();
+  const finish = (payload) => {
+    response.body = payload;
+    done();
+    return response;
+  };
+  response.send = finish;
+  response.json = finish;
+
+  handler(request, response);
+  await finished;
+  return response;
+};
+
+const request = ({ method = 'POST', body = {}, query = {} } = {}) => ({
+  method,
+  body,
+  query,
+});
+
+const seedEnrollment = async (id = 'enroll-1', data = {}) => {
+  await admin
+    .firestore()
+    .collection('deviceEnrollments')
+    .doc(id)
+    .set({
+      organizationId: 'org-1',
+      kioskId: 'kiosk-1',
+      status: 'active',
+      ...data,
+    });
+};
+
+const seedKiosk = async (id = 'kiosk-1', data = {}) => {
+  await admin
+    .firestore()
+    .collection('kiosks')
+    .doc(id)
+    .set({
+      organizationId: 'org-1',
+      name: 'Main Entrance',
+      assignedKioskApkId: 'apk-1',
+      ...data,
+    });
+};
+
+const seedApk = async (id = 'apk-1', data = {}) => {
+  await admin
+    .firestore()
+    .collection('kioskApks')
+    .doc(id)
+    .set({
+      organizationId: 'org-1',
+      packageName: 'com.swiftcause.kiosk',
+      versionCode: 7,
+      versionName: '1.0.7',
+      downloadUrl: 'https://example.test/swiftcause-kiosk.apk',
+      checksumSha256: 'abc123',
+      active: true,
+      ...data,
+    });
+};
+
+const registerDevice = async (overrides = {}) => {
+  await seedEnrollment();
+  return invokeHandler(
+    kioskDeviceRegister,
+    request({
+      body: {
+        enrollmentToken: 'enroll-1',
+        controllerPackage: 'com.swiftcause.devicecontroller',
+        androidId: 'android-123',
+        model: 'Medium Tablet',
+        manufacturer: 'Google',
+        controllerVersion: '0.1.0',
+        ...overrides,
+      },
+    }),
+  );
+};
+
+describe('managed device APIs', () => {
+  beforeEach(() => {
+    admin.__reset();
+    jest.clearAllMocks();
+  });
+
+  it('registers a managed device from an active enrollment', async () => {
+    const res = await registerDevice();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      organizationId: 'org-1',
+      kioskId: 'kiosk-1',
+      status: 'enrolled',
+    });
+
+    const device = admin.__getDoc('managedDevices', res.body.deviceId);
+    expect(device).toMatchObject({
+      organizationId: 'org-1',
+      kioskId: 'kiosk-1',
+      controllerPackage: 'com.swiftcause.devicecontroller',
+      kioskPackage: 'com.swiftcause.kiosk',
+      status: 'enrolled',
+      deviceInfo: expect.objectContaining({
+        androidId: 'android-123',
+        model: 'Medium Tablet',
+      }),
+    });
+  });
+
+  it('updates the same managed device when it registers again', async () => {
+    const first = await registerDevice({ model: 'Medium Tablet' });
+    const second = await registerDevice({ model: 'Medium Tablet API 35' });
+
+    expect(second.body.deviceId).toBe(first.body.deviceId);
+    expect(admin.__getCollection('managedDevices')).toHaveLength(1);
+    expect(admin.__getDoc('managedDevices', first.body.deviceId).deviceInfo.model).toBe(
+      'Medium Tablet API 35',
+    );
+  });
+
+  it('rejects unknown or revoked enrollment tokens', async () => {
+    const unknown = await invokeHandler(
+      kioskDeviceRegister,
+      request({ body: { enrollmentToken: 'missing', androidId: 'android-123' } }),
+    );
+    expect(unknown.statusCode).toBe(401);
+
+    await seedEnrollment('revoked', { status: 'revoked' });
+    const revoked = await invokeHandler(
+      kioskDeviceRegister,
+      request({ body: { enrollmentToken: 'revoked', androidId: 'android-123' } }),
+    );
+    expect(revoked.statusCode).toBe(403);
+  });
+
+  it('returns kiosk policy and assigned APK metadata for a registered device', async () => {
+    await seedKiosk();
+    await seedApk();
+    const registered = await registerDevice();
+
+    const res = await invokeHandler(
+      kioskDevicePolicy,
+      request({ method: 'GET', query: { deviceId: registered.body.deviceId } }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      controllerPackage: 'com.swiftcause.devicecontroller',
+      kioskPackage: 'com.swiftcause.kiosk',
+      launchPackage: 'com.swiftcause.kiosk',
+      heartbeatIntervalSeconds: 60,
+      apk: {
+        apkId: 'apk-1',
+        packageName: 'com.swiftcause.kiosk',
+        versionCode: 7,
+      },
+    });
+  });
+
+  it('records status updates and appends a device event', async () => {
+    const registered = await registerDevice();
+
+    const res = await invokeHandler(
+      kioskDeviceStatus,
+      request({
+        body: {
+          deviceId: registered.body.deviceId,
+          status: 'kiosk_active',
+          installStatus: 'installed',
+          deviceOwner: true,
+        },
+      }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(admin.__getDoc('managedDevices', registered.body.deviceId)).toMatchObject({
+      status: 'kiosk_active',
+      installStatus: 'installed',
+      deviceOwner: true,
+    });
+    expect(admin.__getCollection('deviceEvents')).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: 'STATUS_UPDATED',
+          deviceId: registered.body.deviceId,
+          status: 'kiosk_active',
+        }),
+      }),
+    ]);
+  });
+
+  it('updates heartbeat state and appends a heartbeat event', async () => {
+    const registered = await registerDevice();
+
+    const res = await invokeHandler(
+      kioskDeviceHeartbeat,
+      request({
+        body: {
+          deviceId: registered.body.deviceId,
+          batteryLevel: 82,
+          networkType: 'wifi',
+        },
+      }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      nextHeartbeatIntervalSeconds: 60,
+    });
+    expect(admin.__getDoc('managedDevices', registered.body.deviceId)).toMatchObject({
+      status: 'online',
+      batteryLevel: 82,
+      networkType: 'wifi',
+    });
+    expect(admin.__getCollection('deviceEvents')[0].data).toMatchObject({
+      type: 'HEARTBEAT',
+      deviceId: registered.body.deviceId,
+    });
+  });
+
+  it('rejects invalid status values', async () => {
+    const registered = await registerDevice();
+    const res = await invokeHandler(
+      kioskDeviceStatus,
+      request({ body: { deviceId: registered.body.deviceId, status: 'sideways' } }),
+    );
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns APK download metadata only for the assigned organization APK', async () => {
+    await seedKiosk();
+    await seedApk();
+    const registered = await registerDevice();
+
+    const res = await invokeHandler(
+      kioskApkDownload,
+      request({ method: 'GET', query: { deviceId: registered.body.deviceId, apkId: 'apk-1' } }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      apkId: 'apk-1',
+      downloadUrl: 'https://example.test/swiftcause-kiosk.apk',
+      checksumSha256: 'abc123',
+    });
+
+    await seedApk('other-apk', { organizationId: 'org-2' });
+    const denied = await invokeHandler(
+      kioskApkDownload,
+      request({ method: 'GET', query: { deviceId: registered.body.deviceId, apkId: 'other-apk' } }),
+    );
+    expect(denied.statusCode).toBe(403);
+  });
+});

--- a/backend/functions/handlers/managedDevices.test.js
+++ b/backend/functions/handlers/managedDevices.test.js
@@ -55,6 +55,15 @@ const request = ({ method = 'POST', body = {}, query = {} } = {}) => ({
   method,
   body,
   query,
+  headers: {},
+});
+
+const withDeviceSecret = (req, deviceSecret) => ({
+  ...req,
+  headers: {
+    ...(req.headers || {}),
+    authorization: `Bearer ${deviceSecret}`,
+  },
 });
 
 const seedEnrollment = async (id = 'enroll-1', data = {}) => {
@@ -134,6 +143,7 @@ describe('managed device APIs', () => {
       kioskId: 'kiosk-1',
       status: 'enrolled',
     });
+    expect(res.body.deviceSecret).toEqual(expect.any(String));
 
     const device = admin.__getDoc('managedDevices', res.body.deviceId);
     expect(device).toMatchObject({
@@ -147,6 +157,8 @@ describe('managed device APIs', () => {
         model: 'Medium Tablet',
       }),
     });
+    expect(device.deviceSecretHash).toEqual(expect.any(String));
+    expect(device.deviceSecret).toBeUndefined();
   });
 
   it('updates the same managed device when it registers again', async () => {
@@ -157,6 +169,17 @@ describe('managed device APIs', () => {
     expect(admin.__getCollection('managedDevices')).toHaveLength(1);
     expect(admin.__getDoc('managedDevices', first.body.deviceId).deviceInfo.model).toBe(
       'Medium Tablet API 35',
+    );
+  });
+
+  it('pins controller package when deriving device identity', async () => {
+    const first = await registerDevice({ controllerPackage: 'com.attacker.controller' });
+    const second = await registerDevice({ controllerPackage: 'com.swiftcause.devicecontroller' });
+
+    expect(second.body.deviceId).toBe(first.body.deviceId);
+    expect(admin.__getCollection('managedDevices')).toHaveLength(1);
+    expect(admin.__getDoc('managedDevices', first.body.deviceId).controllerPackage).toBe(
+      'com.swiftcause.devicecontroller',
     );
   });
 
@@ -182,7 +205,10 @@ describe('managed device APIs', () => {
 
     const res = await invokeHandler(
       kioskDevicePolicy,
-      request({ method: 'GET', query: { deviceId: registered.body.deviceId } }),
+      withDeviceSecret(
+        request({ method: 'GET', query: { deviceId: registered.body.deviceId } }),
+        registered.body.deviceSecret,
+      ),
     );
 
     expect(res.statusCode).toBe(200);
@@ -200,19 +226,33 @@ describe('managed device APIs', () => {
     });
   });
 
+  it('rejects policy requests without the device secret', async () => {
+    const registered = await registerDevice();
+
+    const res = await invokeHandler(
+      kioskDevicePolicy,
+      request({ method: 'GET', query: { deviceId: registered.body.deviceId } }),
+    );
+
+    expect(res.statusCode).toBe(401);
+  });
+
   it('records status updates and appends a device event', async () => {
     const registered = await registerDevice();
 
     const res = await invokeHandler(
       kioskDeviceStatus,
-      request({
-        body: {
-          deviceId: registered.body.deviceId,
-          status: 'kiosk_active',
-          installStatus: 'installed',
-          deviceOwner: true,
-        },
-      }),
+      withDeviceSecret(
+        request({
+          body: {
+            deviceId: registered.body.deviceId,
+            status: 'kiosk_active',
+            installStatus: 'installed',
+            deviceOwner: true,
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
     );
 
     expect(res.statusCode).toBe(200);
@@ -232,18 +272,121 @@ describe('managed device APIs', () => {
     ]);
   });
 
+  it('rejects status updates with an invalid device secret', async () => {
+    const registered = await registerDevice();
+    const res = await invokeHandler(
+      kioskDeviceStatus,
+      withDeviceSecret(
+        request({ body: { deviceId: registered.body.deviceId, status: 'online' } }),
+        'wrong-secret',
+      ),
+    );
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('preserves existing status detail fields when a partial update omits them', async () => {
+    const registered = await registerDevice();
+
+    await invokeHandler(
+      kioskDeviceStatus,
+      withDeviceSecret(
+        request({
+          body: {
+            deviceId: registered.body.deviceId,
+            status: 'install_failed',
+            installStatus: 'failed',
+            launchStatus: 'blocked',
+            deviceOwner: true,
+            error: 'Package installer blocked',
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
+    );
+
+    const res = await invokeHandler(
+      kioskDeviceStatus,
+      withDeviceSecret(
+        request({
+          body: {
+            deviceId: registered.body.deviceId,
+            status: 'online',
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(admin.__getDoc('managedDevices', registered.body.deviceId)).toMatchObject({
+      status: 'online',
+      installStatus: 'failed',
+      launchStatus: 'blocked',
+      deviceOwner: true,
+      lastError: 'Package installer blocked',
+    });
+  });
+
+  it('clears optional status detail fields when null is explicitly provided', async () => {
+    const registered = await registerDevice();
+
+    await invokeHandler(
+      kioskDeviceStatus,
+      withDeviceSecret(
+        request({
+          body: {
+            deviceId: registered.body.deviceId,
+            status: 'install_failed',
+            installStatus: 'failed',
+            launchStatus: 'blocked',
+            error: 'Package installer blocked',
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
+    );
+
+    const res = await invokeHandler(
+      kioskDeviceStatus,
+      withDeviceSecret(
+        request({
+          body: {
+            deviceId: registered.body.deviceId,
+            status: 'online',
+            installStatus: null,
+            launchStatus: null,
+            error: null,
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(admin.__getDoc('managedDevices', registered.body.deviceId)).toMatchObject({
+      status: 'online',
+      installStatus: null,
+      launchStatus: null,
+      lastError: null,
+    });
+  });
+
   it('updates heartbeat state and appends a heartbeat event', async () => {
     const registered = await registerDevice();
 
     const res = await invokeHandler(
       kioskDeviceHeartbeat,
-      request({
-        body: {
-          deviceId: registered.body.deviceId,
-          batteryLevel: 82,
-          networkType: 'wifi',
-        },
-      }),
+      withDeviceSecret(
+        request({
+          body: {
+            deviceId: registered.body.deviceId,
+            batteryLevel: 82,
+            networkType: 'wifi',
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
     );
 
     expect(res.statusCode).toBe(200);
@@ -266,7 +409,10 @@ describe('managed device APIs', () => {
     const registered = await registerDevice();
     const res = await invokeHandler(
       kioskDeviceStatus,
-      request({ body: { deviceId: registered.body.deviceId, status: 'sideways' } }),
+      withDeviceSecret(
+        request({ body: { deviceId: registered.body.deviceId, status: 'sideways' } }),
+        registered.body.deviceSecret,
+      ),
     );
 
     expect(res.statusCode).toBe(400);
@@ -279,7 +425,10 @@ describe('managed device APIs', () => {
 
     const res = await invokeHandler(
       kioskApkDownload,
-      request({ method: 'GET', query: { deviceId: registered.body.deviceId, apkId: 'apk-1' } }),
+      withDeviceSecret(
+        request({ method: 'GET', query: { deviceId: registered.body.deviceId, apkId: 'apk-1' } }),
+        registered.body.deviceSecret,
+      ),
     );
 
     expect(res.statusCode).toBe(200);
@@ -293,8 +442,41 @@ describe('managed device APIs', () => {
     await seedApk('other-apk', { organizationId: 'org-2' });
     const denied = await invokeHandler(
       kioskApkDownload,
-      request({ method: 'GET', query: { deviceId: registered.body.deviceId, apkId: 'other-apk' } }),
+      withDeviceSecret(
+        request({
+          method: 'GET',
+          query: { deviceId: registered.body.deviceId, apkId: 'other-apk' },
+        }),
+        registered.body.deviceSecret,
+      ),
     );
+    expect(denied.statusCode).toBe(403);
+  });
+
+  it('rejects same-org APK IDs that are not assigned to the device policy', async () => {
+    await seedKiosk();
+    await seedApk();
+    await seedApk('same-org-unassigned-apk', {
+      organizationId: 'org-1',
+      versionCode: 8,
+      downloadUrl: 'https://example.test/unassigned.apk',
+    });
+    const registered = await registerDevice();
+
+    const denied = await invokeHandler(
+      kioskApkDownload,
+      withDeviceSecret(
+        request({
+          method: 'GET',
+          query: {
+            deviceId: registered.body.deviceId,
+            apkId: 'same-org-unassigned-apk',
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
+    );
+
     expect(denied.statusCode).toBe(403);
   });
 });

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -42,6 +42,13 @@ const {
 const { createStripeAccountForNewOrg, sendWelcomeEmailForNewOrg } = require('./handlers/triggers');
 const { verifySignupRecaptcha } = require('./handlers/signup');
 const { kioskLogin } = require('./handlers/kiosk');
+const {
+  kioskDeviceRegister,
+  kioskDevicePolicy,
+  kioskDeviceStatus,
+  kioskDeviceHeartbeat,
+  kioskApkDownload,
+} = require('./handlers/managedDevices');
 const { completeEmailVerification } = require('./handlers/verification');
 const { logAuthEvent } = require('./handlers/auth');
 const { createConnectionToken } = require('./handlers/terminal');
@@ -150,6 +157,11 @@ exports.createConnectionToken = functions.https.onRequest(
 exports.createStripeAccountForNewOrg = createStripeAccountForNewOrg;
 exports.sendWelcomeEmailForNewOrg = sendWelcomeEmailForNewOrg;
 exports.kioskLogin = functions.https.onRequest(kioskLogin);
+exports.kioskDeviceRegister = functions.https.onRequest(kioskDeviceRegister);
+exports.kioskDevicePolicy = functions.https.onRequest(kioskDevicePolicy);
+exports.kioskDeviceStatus = functions.https.onRequest(kioskDeviceStatus);
+exports.kioskDeviceHeartbeat = functions.https.onRequest(kioskDeviceHeartbeat);
+exports.kioskApkDownload = functions.https.onRequest(kioskApkDownload);
 exports.updateOrganizationSettings = functions.https.onRequest(updateOrganizationSettings);
 
 // Export v2 function with secret

--- a/docs/MANAGED_DEVICE_APIS.md
+++ b/docs/MANAGED_DEVICE_APIS.md
@@ -1,0 +1,146 @@
+# SwiftCause Managed Device APIs
+
+## Purpose
+
+SwiftCause needs to manage Android tablets separately from the donor-facing kiosk experience.
+The existing kiosk model represents fundraising configuration: campaigns, location, access
+code, display settings, and donation behavior. A managed device represents the physical
+Android tablet and its controller state: enrollment, policy sync, APK installation, kiosk
+launch status, and heartbeat.
+
+This separation lets SwiftCause replace or reassign tablets without corrupting kiosk
+fundraising data. It also gives the Android controller a narrow backend contract before
+React admin UI and Android integration are added.
+
+## Architecture
+
+The intended flow is:
+
+```text
+SwiftCause React Admin UI
+        |
+Firebase Functions + Firestore
+        |
+SwiftCause Device Controller Android app
+        |
+SwiftCause Kiosk Android app
+```
+
+The device controller is the Android management app. It is expected to use package
+`com.swiftcause.devicecontroller`. The donor-facing kiosk app is expected to use package
+`com.swiftcause.kiosk`.
+
+The Headwind Android agent can provide the controller foundation, but SwiftCause owns the
+admin UI, backend APIs, Firestore model, and donor kiosk app.
+
+## Firestore Model
+
+The first API slice uses these collections:
+
+- `deviceEnrollments`: active/revoked enrollment records for pairing a tablet with an
+  organization and optional kiosk.
+- `managedDevices`: physical Android device records, linked to `organizationId` and
+  optional `kioskId`.
+- `kioskApks`: uploaded or assigned kiosk APK metadata.
+- `deviceEvents`: append-only event records for status changes and heartbeats.
+
+Existing `kiosks` documents remain focused on fundraising configuration. A managed device
+links to a kiosk with `kioskId` when the tablet should run that kiosk.
+
+## API Contract
+
+### `kioskDeviceRegister`
+
+Registers or updates a managed device from an active enrollment token.
+
+Required input:
+
+- `enrollmentToken`
+- `androidId` or `serialNumber`
+
+Important behavior:
+
+- validates the enrollment record
+- creates a deterministic `managedDevices` ID
+- links the device to enrollment `organizationId` and optional `kioskId`
+- stores controller and device metadata
+
+### `kioskDevicePolicy`
+
+Returns the current policy for a registered device.
+
+Important behavior:
+
+- resolves controller and kiosk package names
+- returns launch package and heartbeat interval
+- returns assigned kiosk APK metadata when available
+- records the last policy fetch timestamp
+
+### `kioskDeviceStatus`
+
+Records controller status from the Android device.
+
+Supported statuses:
+
+- `enrolled`
+- `online`
+- `offline`
+- `installing`
+- `install_failed`
+- `kiosk_active`
+- `error`
+
+Important behavior:
+
+- updates install, launch, Device Owner, and error state
+- appends a `STATUS_UPDATED` event
+
+### `kioskDeviceHeartbeat`
+
+Records periodic liveness from the Android controller.
+
+Important behavior:
+
+- marks the device online
+- updates heartbeat, battery, and network metadata
+- appends a `HEARTBEAT` event
+- returns the next heartbeat interval
+
+### `kioskApkDownload`
+
+Returns APK download metadata for a registered device.
+
+Important behavior:
+
+- validates the device
+- validates APK organization ownership
+- returns package, version, checksum, and download URL metadata
+
+This first slice does not implement signed Firebase Storage download URLs. That can be added
+after the API contract is proven.
+
+## TDD Scope
+
+The first backend slice is intentionally API-first and backend-only. It includes Jest tests
+for:
+
+- registering from an active enrollment
+- repeated registration updating the same device
+- rejecting unknown or revoked enrollments
+- fetching policy with assigned APK metadata
+- recording status updates and events
+- recording heartbeat updates and events
+- rejecting invalid status values
+- preventing cross-organization APK access
+
+React admin UI, Android controller wiring, QR provisioning, and Firebase Storage upload/signing
+are intentionally left for follow-up PRs.
+
+## Next Integration Steps
+
+1. Add admin UI for enrollment creation, device listing, kiosk linking, APK assignment, and
+   device event history.
+2. Add storage-backed APK upload and signed download resolution.
+3. Wire the Android controller to register, fetch policy, install the kiosk APK, launch it,
+   and report heartbeat/status.
+4. Validate the full emulator path before physical QR/factory-reset provisioning.

--- a/docs/MANAGED_DEVICE_APIS.md
+++ b/docs/MANAGED_DEVICE_APIS.md
@@ -33,6 +33,25 @@ The device controller is the Android management app. It is expected to use packa
 The Headwind Android agent can provide the controller foundation, but SwiftCause owns the
 admin UI, backend APIs, Firestore model, and donor kiosk app.
 
+The backend pins the controller package server-side. Client-provided package names are not
+used to derive managed device identity.
+
+## Device Authentication
+
+Registration is authenticated by an active enrollment token. After registration, the backend
+returns a one-time plaintext `deviceSecret` and stores only `deviceSecretHash` on the
+`managedDevices` record.
+
+The Android controller must store the plaintext secret locally and send it on later requests
+using either:
+
+- `Authorization: Bearer <deviceSecret>`
+- `x-device-secret: <deviceSecret>`
+
+The device secret is required for policy, status, heartbeat, and APK download endpoints. App
+Check, attestation, secret rotation, and admin-driven revocation can be layered on top of this
+contract later.
+
 ## Firestore Model
 
 The first API slice uses these collections:
@@ -62,6 +81,8 @@ Important behavior:
 
 - validates the enrollment record
 - creates a deterministic `managedDevices` ID
+- returns a one-time `deviceSecret`
+- stores only `deviceSecretHash`
 - links the device to enrollment `organizationId` and optional `kioskId`
 - stores controller and device metadata
 
@@ -71,6 +92,7 @@ Returns the current policy for a registered device.
 
 Important behavior:
 
+- requires a valid device secret
 - resolves controller and kiosk package names
 - returns launch package and heartbeat interval
 - returns assigned kiosk APK metadata when available
@@ -92,7 +114,9 @@ Supported statuses:
 
 Important behavior:
 
+- requires a valid device secret
 - updates install, launch, Device Owner, and error state
+- preserves omitted optional fields on partial updates
 - appends a `STATUS_UPDATED` event
 
 ### `kioskDeviceHeartbeat`
@@ -101,6 +125,7 @@ Records periodic liveness from the Android controller.
 
 Important behavior:
 
+- requires a valid device secret
 - marks the device online
 - updates heartbeat, battery, and network metadata
 - appends a `HEARTBEAT` event
@@ -112,7 +137,9 @@ Returns APK download metadata for a registered device.
 
 Important behavior:
 
+- requires a valid device secret
 - validates the device
+- validates the requested APK is the resolved assigned APK for the device policy
 - validates APK organization ownership
 - returns package, version, checksum, and download URL metadata
 
@@ -128,10 +155,13 @@ for:
 - repeated registration updating the same device
 - rejecting unknown or revoked enrollments
 - fetching policy with assigned APK metadata
+- rejecting unauthenticated policy/status requests
 - recording status updates and events
+- preserving existing state during partial status updates
 - recording heartbeat updates and events
 - rejecting invalid status values
 - preventing cross-organization APK access
+- preventing same-organization but unassigned APK access
 
 React admin UI, Android controller wiring, QR provisioning, and Firebase Storage upload/signing
 are intentionally left for follow-up PRs.


### PR DESCRIPTION
## Why

SwiftCause needs a backend contract for Android tablet/device management before wiring in the React admin UI or the Headwind-based controller. Today the monorepo has donor-facing kiosk auth, but it does not yet have a tested API surface for enrolling a physical device, fetching kiosk policy, reporting install/launch status, recording heartbeats, or resolving an assigned kiosk APK.

This PR adds that API-first foundation while keeping the diff intentionally small and backend-only.

## What

Adds a new Firebase Functions handler module for managed device APIs:

- `kioskDeviceRegister`
  - Validates an active enrollment token.
  - Creates or updates a deterministic `managedDevices` record.
  - Returns a one-time plaintext `deviceSecret` and stores only `deviceSecretHash`.
  - Links the device to `organizationId` and optional `kioskId` from the enrollment.
  - Pins the controller package server-side as `com.swiftcause.devicecontroller`.

- `kioskDevicePolicy`
  - Requires the enrollment-bound device secret.
  - Returns controller package, kiosk package, launch package, heartbeat interval, and assigned APK metadata.
  - Resolves APK assignment from device, linked kiosk, or active org APK fallback.
  - Records the last policy fetch timestamp.

- `kioskDeviceStatus`
  - Requires the enrollment-bound device secret.
  - Accepts normalized device statuses such as `enrolled`, `online`, `installing`, `install_failed`, `kiosk_active`, and `error`.
  - Updates install/launch/device-owner state only when those fields are explicitly provided, preserving existing state on partial updates.
  - Appends a `STATUS_UPDATED` event.

- `kioskDeviceHeartbeat`
  - Requires the enrollment-bound device secret.
  - Marks the device online.
  - Updates heartbeat metadata such as battery/network state.
  - Appends a `HEARTBEAT` event.

- `kioskApkDownload`
  - Requires the enrollment-bound device secret.
  - Resolves assigned APK download metadata for a registered device.
  - Enforces that the requested APK is the resolved assigned APK, not just any APK in the same org.
  - Keeps organization ownership validation as a second safety check.

Also adds a design note at `docs/MANAGED_DEVICE_APIS.md` describing what we are building, why kiosk and device are separate concepts, the device secret flow, the API contract, the Firestore model, and the next integration steps.

## Security / Review Fixes

This PR addresses the requested review changes:

- Added endpoint authentication for policy, status, heartbeat, and APK download using an enrollment-bound device secret.
- Stores only a hash of the device secret server-side.
- Server-pins controller package identity so client input cannot create multiple records for the same tablet by changing package name.
- Preserves existing status detail fields on partial updates.
- Restricts APK download to the device's resolved assigned APK, including rejection of same-org but unassigned APK IDs.

## How

The implementation follows the existing JavaScript Firebase Functions style in the repo:

- Uses the existing CORS middleware pattern.
- Keeps donor-facing `kioskLogin` unchanged.
- Adds independent device-management collections instead of overloading the existing `kiosks` business object:
  - `deviceEnrollments`
  - `managedDevices`
  - `kioskApks`
  - `deviceEvents`
- Uses deterministic device IDs derived from org, server-pinned controller package, and Android identifier/serial so repeated registration updates the same device.
- Keeps APK download as metadata only for this first TDD slice; storage signing/redirect behavior can be layered in later.

## TDD / Tests

Added Jest coverage in `backend/functions/handlers/managedDevices.test.js` for:

- active enrollment registration
- register response containing `deviceSecret` while persisted device stores only `deviceSecretHash`
- repeated registration updating the same device
- client-controlled controller package not affecting deterministic device identity
- unknown/revoked enrollment rejection
- policy fetch with assigned APK metadata
- policy rejection without device secret
- status rejection with invalid device secret
- status update persistence and event append
- partial status update preserving existing detail fields
- explicit null clearing optional status detail fields
- heartbeat persistence and event append with valid device secret
- invalid status rejection
- assigned APK download success
- same-org unassigned APK rejection
- cross-org APK rejection

Verified locally:

```bash
cd backend/functions
npm test -- managedDevices
npm test
npm run lint
```

Also ran:

```bash
git diff --check
```

## Notes

This PR deliberately does not change React UI or Android code. It establishes the backend API contract first so the next PR can wire the SwiftCause admin UI and the controller integration against tested endpoints.

See `docs/MANAGED_DEVICE_APIS.md` for the reviewer-facing architecture and rollout notes.
