### PR TITLE
Add admin device management APIs

### DIFF
--- a/backend/functions/handlers/managedDeviceAdmin.test.js
+++ b/backend/functions/handlers/managedDeviceAdmin.test.js
@@ -1,0 +1,394 @@
+jest.mock('firebase-admin', () => require('../testUtils/mockFirebaseAdmin'));
+jest.mock('../middleware/cors', () => (req, res, callback) => callback());
+
+const admin = require('firebase-admin');
+const {
+  adminCreateDeviceProfile,
+  adminListManagedDevices,
+  adminUpdateManagedDeviceMetadata,
+  adminQueueDeviceCommand,
+  adminListDeviceCommands,
+  adminListDeviceEvents,
+} = require('./managedDevices');
+
+const createResponse = () => {
+  const response = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return response;
+};
+
+const invokeHandler = async (handler, request) => {
+  let done;
+  const finished = new Promise((resolve) => {
+    done = resolve;
+  });
+
+  const response = createResponse();
+  response.send = (payload) => {
+    response.body = payload;
+    done();
+    return response;
+  };
+
+  handler(request, response);
+  await finished;
+  return response;
+};
+
+const request = ({ method = 'POST', body = {}, query = {}, token = 'uid:user-1' } = {}) => ({
+  method,
+  body,
+  query,
+  headers: token
+    ? {
+        authorization: `Bearer ${token}`,
+      }
+    : {},
+});
+
+const seedUser = async (id = 'user-1', data = {}) => {
+  await admin
+    .firestore()
+    .collection('users')
+    .doc(id)
+    .set({
+      organizationId: 'org-1',
+      role: 'manager',
+      permissions: ['view_kiosks', 'edit_kiosk'],
+      ...data,
+    });
+};
+
+const seedKiosk = async (id = 'kiosk-1', data = {}) => {
+  await admin
+    .firestore()
+    .collection('kiosks')
+    .doc(id)
+    .set({
+      organizationId: 'org-1',
+      name: 'Lobby kiosk',
+      ...data,
+    });
+};
+
+const seedDevice = async (id = 'device-1', data = {}) => {
+  await admin
+    .firestore()
+    .collection('managedDevices')
+    .doc(id)
+    .set({
+      organizationId: 'org-1',
+      kioskId: 'kiosk-1',
+      status: 'online',
+      deviceInfo: {
+        model: 'Medium Tablet',
+      },
+      lastHeartbeatAt: { __type: 'timestamp', ms: 1000 },
+      lastError: null,
+      ...data,
+    });
+};
+
+describe('managed device admin APIs', () => {
+  beforeEach(() => {
+    admin.__reset();
+    jest.clearAllMocks();
+  });
+
+  it('rejects unauthenticated admin requests', async () => {
+    const res = await invokeHandler(adminCreateDeviceProfile, request({ body: {}, token: null }));
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects callers without kiosk-management permission', async () => {
+    await seedUser('user-1', {
+      role: 'viewer',
+      permissions: ['view_kiosks'],
+    });
+
+    const res = await invokeHandler(adminCreateDeviceProfile, request());
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('creates an organization-scoped device profile for the caller organization', async () => {
+    await seedUser();
+    await seedKiosk();
+
+    const res = await invokeHandler(
+      adminCreateDeviceProfile,
+      request({
+        body: {
+          kioskId: 'kiosk-1',
+          label: 'Front desk tablet',
+          apiBaseUrl: 'https://functions.example.test',
+        },
+      }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      organizationId: 'org-1',
+      kioskId: 'kiosk-1',
+      status: 'active',
+      provisioningPayload: {
+        enrollmentToken: expect.any(String),
+        organizationId: 'org-1',
+        kioskId: 'kiosk-1',
+        controllerPackage: 'com.swiftcause.devicecontroller',
+        apiBaseUrl: 'https://functions.example.test',
+      },
+    });
+    expect(admin.__getDoc('deviceEnrollments', res.body.enrollmentToken)).toMatchObject({
+      organizationId: 'org-1',
+      kioskId: 'kiosk-1',
+      label: 'Front desk tablet',
+      status: 'active',
+      createdBy: 'user-1',
+    });
+  });
+
+  it('rejects profile creation for another organization', async () => {
+    await seedUser();
+
+    const res = await invokeHandler(
+      adminCreateDeviceProfile,
+      request({ body: { organizationId: 'org-2' } }),
+    );
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('rejects protected APK and package fields when creating a profile', async () => {
+    await seedUser();
+
+    const res = await invokeHandler(
+      adminCreateDeviceProfile,
+      request({
+        body: {
+          assignedKioskApkId: 'apk-1',
+          controllerPackage: 'com.attacker.controller',
+        },
+      }),
+    );
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('requires kiosk preassignment to belong to the caller organization', async () => {
+    await seedUser();
+    await seedKiosk('other-kiosk', { organizationId: 'org-2' });
+
+    const res = await invokeHandler(
+      adminCreateDeviceProfile,
+      request({ body: { kioskId: 'other-kiosk' } }),
+    );
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('lists only caller-organization managed devices with optional kiosk filtering', async () => {
+    await seedUser();
+    await seedDevice('device-1', { kioskId: 'kiosk-1' });
+    await seedDevice('device-2', { kioskId: 'kiosk-2' });
+    await seedDevice('device-3', { organizationId: 'org-2', kioskId: 'kiosk-1' });
+
+    const res = await invokeHandler(
+      adminListManagedDevices,
+      request({ method: 'GET', query: { kioskId: 'kiosk-1' } }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.devices).toEqual([
+      expect.objectContaining({
+        id: 'device-1',
+        organizationId: 'org-1',
+        kioskId: 'kiosk-1',
+        status: 'online',
+      }),
+    ]);
+  });
+
+  it('updates editable placement metadata and same-org kiosk assignment', async () => {
+    await seedUser();
+    await seedKiosk('kiosk-2');
+    await seedDevice();
+
+    const res = await invokeHandler(
+      adminUpdateManagedDeviceMetadata,
+      request({
+        body: {
+          deviceId: 'device-1',
+          displayName: 'Lobby tablet',
+          placementLabel: 'Main lobby',
+          placementNotes: 'Mounted beside reception',
+          latitude: 51.5074,
+          longitude: -0.1278,
+          kioskId: 'kiosk-2',
+        },
+      }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(admin.__getDoc('managedDevices', 'device-1')).toMatchObject({
+      displayName: 'Lobby tablet',
+      placementLabel: 'Main lobby',
+      placementNotes: 'Mounted beside reception',
+      latitude: 51.5074,
+      longitude: -0.1278,
+      kioskId: 'kiosk-2',
+      updatedBy: 'user-1',
+    });
+  });
+
+  it('rejects protected metadata updates', async () => {
+    await seedUser();
+    await seedDevice();
+
+    const res = await invokeHandler(
+      adminUpdateManagedDeviceMetadata,
+      request({
+        body: {
+          deviceId: 'device-1',
+          organizationId: 'org-2',
+          deviceSecretHash: 'leak',
+        },
+      }),
+    );
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects invalid coordinates and cross-org kiosk assignment', async () => {
+    await seedUser();
+    await seedDevice();
+    await seedKiosk('other-kiosk', { organizationId: 'org-2' });
+
+    const invalidCoordinates = await invokeHandler(
+      adminUpdateManagedDeviceMetadata,
+      request({ body: { deviceId: 'device-1', latitude: 120, longitude: 0 } }),
+    );
+    expect(invalidCoordinates.statusCode).toBe(400);
+
+    const crossOrgKiosk = await invokeHandler(
+      adminUpdateManagedDeviceMetadata,
+      request({ body: { deviceId: 'device-1', kioskId: 'other-kiosk' } }),
+    );
+    expect(crossOrgKiosk.statusCode).toBe(403);
+  });
+
+  it('queues only safe device commands for caller-organization devices', async () => {
+    await seedUser();
+    await seedDevice();
+
+    const res = await invokeHandler(
+      adminQueueDeviceCommand,
+      request({
+        body: {
+          deviceId: 'device-1',
+          commandType: 'restart_kiosk',
+        },
+      }),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(admin.__getCollection('deviceCommands')).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          organizationId: 'org-1',
+          deviceId: 'device-1',
+          commandType: 'restart_kiosk',
+          status: 'pending',
+          queuedBy: 'user-1',
+        }),
+      }),
+    ]);
+
+    const denied = await invokeHandler(
+      adminQueueDeviceCommand,
+      request({
+        body: {
+          deviceId: 'device-1',
+          commandType: 'factory_reset',
+        },
+      }),
+    );
+    expect(denied.statusCode).toBe(400);
+  });
+
+  it('rejects command and event listing for cross-org devices', async () => {
+    await seedUser();
+    await seedDevice('device-2', { organizationId: 'org-2' });
+
+    const commands = await invokeHandler(
+      adminListDeviceCommands,
+      request({ method: 'GET', query: { deviceId: 'device-2' } }),
+    );
+    expect(commands.statusCode).toBe(403);
+
+    const events = await invokeHandler(
+      adminListDeviceEvents,
+      request({ method: 'GET', query: { deviceId: 'device-2' } }),
+    );
+    expect(events.statusCode).toBe(403);
+  });
+
+  it('lists commands and events for caller-organization devices', async () => {
+    await seedUser();
+    await seedDevice();
+    await admin.firestore().collection('deviceCommands').doc('command-1').set({
+      organizationId: 'org-1',
+      deviceId: 'device-1',
+      commandType: 'sync_policy',
+      status: 'pending',
+    });
+    await admin.firestore().collection('deviceCommands').doc('command-2').set({
+      organizationId: 'org-2',
+      deviceId: 'device-1',
+      commandType: 'sync_policy',
+      status: 'pending',
+    });
+    await admin.firestore().collection('deviceEvents').doc('event-1').set({
+      organizationId: 'org-1',
+      deviceId: 'device-1',
+      type: 'HEARTBEAT',
+    });
+
+    const commands = await invokeHandler(
+      adminListDeviceCommands,
+      request({ method: 'GET', query: { deviceId: 'device-1' } }),
+    );
+    const events = await invokeHandler(
+      adminListDeviceEvents,
+      request({ method: 'GET', query: { deviceId: 'device-1' } }),
+    );
+
+    expect(commands.statusCode).toBe(200);
+    expect(commands.body.commands).toEqual([
+      expect.objectContaining({
+        id: 'command-1',
+        organizationId: 'org-1',
+      }),
+    ]);
+    expect(events.statusCode).toBe(200);
+    expect(events.body.events).toEqual([
+      expect.objectContaining({
+        id: 'event-1',
+        type: 'HEARTBEAT',
+      }),
+    ]);
+  });
+});

--- a/backend/functions/handlers/managedDevices.js
+++ b/backend/functions/handlers/managedDevices.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const admin = require('firebase-admin');
 const cors = require('../middleware/cors');
+const { verifyAuth } = require('../middleware/auth');
 
 const CONTROLLER_PACKAGE = 'com.swiftcause.devicecontroller';
 const KIOSK_PACKAGE = 'com.swiftcause.kiosk';
@@ -13,6 +14,26 @@ const ALLOWED_DEVICE_STATUSES = new Set([
   'install_failed',
   'kiosk_active',
   'error',
+]);
+const ALLOWED_ADMIN_COMMANDS = new Set([
+  'sync_policy',
+  'restart_kiosk',
+  'refresh_content',
+  'clear_error',
+]);
+const PROTECTED_ADMIN_FIELDS = new Set([
+  'apkId',
+  'assignedKioskApkId',
+  'kioskApkId',
+  'packageName',
+  'controllerPackage',
+  'kioskPackage',
+  'launchPackage',
+  'deviceSecret',
+  'deviceSecretHash',
+  'organizationId',
+  'policy',
+  'lockTaskPolicy',
 ]);
 
 const timestamp = () => admin.firestore.Timestamp.now();
@@ -46,6 +67,37 @@ const requiredString = (value, fieldName) => {
   return value.trim();
 };
 
+const optionalString = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return typeof value === 'string' ? value.trim() || null : null;
+};
+
+const rejectProtectedFields = (payload, allowed = []) => {
+  const allowedFields = new Set(allowed);
+  const blocked = Object.keys(payload || {}).filter(
+    (key) => PROTECTED_ADMIN_FIELDS.has(key) && !allowedFields.has(key),
+  );
+  if (blocked.length > 0) {
+    const error = new Error(`Protected fields cannot be updated: ${blocked.join(', ')}`);
+    error.code = 400;
+    throw error;
+  }
+};
+
+const validateCoordinate = (value, fieldName, min, max) => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < min || value > max) {
+    const error = new Error(`${fieldName} must be a number between ${min} and ${max}`);
+    error.code = 400;
+    throw error;
+  }
+  return value;
+};
+
 const buildDeviceId = ({ organizationId, controllerPackage, androidId, serialNumber }) => {
   const deviceKey = androidId || serialNumber;
   const hash = crypto
@@ -66,6 +118,95 @@ const getDevice = async (deviceId) => {
   }
 
   return { id: doc.id, ...doc.data() };
+};
+
+const getCaller = async (req) => {
+  const auth = await verifyAuth(req);
+  const callerDoc = await admin.firestore().collection('users').doc(auth.uid).get();
+  if (!callerDoc.exists) {
+    const error = new Error('Caller is not a valid user');
+    error.code = 403;
+    throw error;
+  }
+
+  const caller = callerDoc.data() || {};
+  const permissions = Array.isArray(caller.permissions) ? caller.permissions : [];
+  const canManageDevices =
+    caller.role === 'admin' ||
+    caller.role === 'super_admin' ||
+    permissions.includes('system_admin') ||
+    permissions.includes('create_kiosk') ||
+    permissions.includes('edit_kiosk');
+  if (!canManageDevices) {
+    const error = new Error('You do not have permission to manage devices');
+    error.code = 403;
+    throw error;
+  }
+  if (!caller.organizationId) {
+    const error = new Error('Caller organization is required');
+    error.code = 403;
+    throw error;
+  }
+
+  return {
+    uid: auth.uid,
+    organizationId: caller.organizationId,
+    role: caller.role,
+    permissions,
+  };
+};
+
+const getKioskForCaller = async (kioskId, callerOrganizationId) => {
+  const kioskDoc = await admin.firestore().collection('kiosks').doc(kioskId).get();
+  if (!kioskDoc.exists) {
+    const error = new Error('Kiosk not found');
+    error.code = 404;
+    throw error;
+  }
+
+  const kiosk = kioskDoc.data() || {};
+  if (kiosk.organizationId !== callerOrganizationId) {
+    const error = new Error('Kiosk is not in caller organization');
+    error.code = 403;
+    throw error;
+  }
+
+  return { id: kioskDoc.id, ...kiosk };
+};
+
+const getDeviceForCaller = async (deviceId, callerOrganizationId) => {
+  const device = await getDevice(deviceId);
+  if (device.organizationId !== callerOrganizationId) {
+    const error = new Error('Device is not in caller organization');
+    error.code = 403;
+    throw error;
+  }
+  return device;
+};
+
+const serializeDevice = (device) => ({
+  id: device.id,
+  organizationId: device.organizationId,
+  kioskId: device.kioskId || null,
+  status: device.status || null,
+  displayName: device.displayName || null,
+  placementLabel: device.placementLabel || null,
+  placementNotes: device.placementNotes || null,
+  latitude: device.latitude ?? null,
+  longitude: device.longitude ?? null,
+  lastHeartbeatAt: device.lastHeartbeatAt || null,
+  lastPolicyFetchAt: device.lastPolicyFetchAt || null,
+  lastStatusAt: device.lastStatusAt || null,
+  lastError: device.lastError || null,
+  installStatus: device.installStatus || null,
+  launchStatus: device.launchStatus || null,
+  deviceOwner: device.deviceOwner ?? null,
+  deviceInfo: device.deviceInfo || {},
+});
+
+const getCollectionRows = async (collectionName) => {
+  const snapshot = await admin.firestore().collection(collectionName).get();
+  return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
 };
 
 const getAuthenticatedDevice = async (req, deviceId) => {
@@ -379,10 +520,232 @@ const kioskApkDownload = (req, res) => {
   });
 };
 
+const adminCreateDeviceProfile = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const caller = await getCaller(req);
+      rejectProtectedFields(req.body || {}, ['organizationId']);
+      const requestedOrganizationId = optionalString(req.body?.organizationId);
+      if (requestedOrganizationId && requestedOrganizationId !== caller.organizationId) {
+        return sendError(res, 403, 'You can only create profiles for your organization');
+      }
+
+      const kioskId = optionalString(req.body?.kioskId);
+      if (kioskId) {
+        await getKioskForCaller(kioskId, caller.organizationId);
+      }
+
+      const enrollmentToken = crypto.randomBytes(24).toString('base64url');
+      const now = timestamp();
+      const label = optionalString(req.body?.label);
+      await admin
+        .firestore()
+        .collection('deviceEnrollments')
+        .doc(enrollmentToken)
+        .set({
+          organizationId: caller.organizationId,
+          kioskId: kioskId || null,
+          label,
+          status: 'active',
+          createdBy: caller.uid,
+          createdAt: now,
+          updatedAt: now,
+        });
+
+      const provisioningPayload = {
+        enrollmentToken,
+        organizationId: caller.organizationId,
+        kioskId: kioskId || null,
+        controllerPackage: CONTROLLER_PACKAGE,
+        apiBaseUrl: optionalString(req.body?.apiBaseUrl),
+      };
+
+      return res.status(200).send({
+        success: true,
+        enrollmentToken,
+        organizationId: caller.organizationId,
+        kioskId: kioskId || null,
+        status: 'active',
+        provisioningPayload,
+      });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to create device profile');
+    }
+  });
+};
+
+const adminListManagedDevices = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'GET') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const caller = await getCaller(req);
+      const kioskId = optionalString(req.query?.kioskId);
+      const rows = await getCollectionRows('managedDevices');
+      const devices = rows
+        .filter((device) => device.organizationId === caller.organizationId)
+        .filter((device) => !kioskId || device.kioskId === kioskId)
+        .map(serializeDevice);
+
+      return res.status(200).send({ success: true, devices });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to list managed devices');
+    }
+  });
+};
+
+const adminUpdateManagedDeviceMetadata = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const caller = await getCaller(req);
+      rejectProtectedFields(req.body || {});
+      const deviceId = requiredString(req.body?.deviceId, 'deviceId');
+      await getDeviceForCaller(deviceId, caller.organizationId);
+
+      const update = {
+        updatedBy: caller.uid,
+        updatedAt: timestamp(),
+      };
+
+      if (Object.prototype.hasOwnProperty.call(req.body, 'displayName')) {
+        update.displayName = optionalString(req.body.displayName);
+      }
+      if (Object.prototype.hasOwnProperty.call(req.body, 'placementLabel')) {
+        update.placementLabel = optionalString(req.body.placementLabel);
+      }
+      if (Object.prototype.hasOwnProperty.call(req.body, 'placementNotes')) {
+        update.placementNotes = optionalString(req.body.placementNotes);
+      }
+      if (Object.prototype.hasOwnProperty.call(req.body, 'latitude')) {
+        update.latitude = validateCoordinate(req.body.latitude, 'latitude', -90, 90);
+      }
+      if (Object.prototype.hasOwnProperty.call(req.body, 'longitude')) {
+        update.longitude = validateCoordinate(req.body.longitude, 'longitude', -180, 180);
+      }
+      if (Object.prototype.hasOwnProperty.call(req.body, 'kioskId')) {
+        const kioskId = optionalString(req.body.kioskId);
+        if (kioskId) {
+          await getKioskForCaller(kioskId, caller.organizationId);
+        }
+        update.kioskId = kioskId;
+      }
+
+      await admin
+        .firestore()
+        .collection('managedDevices')
+        .doc(deviceId)
+        .set(update, { merge: true });
+
+      return res.status(200).send({ success: true, deviceId });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to update device metadata');
+    }
+  });
+};
+
+const adminQueueDeviceCommand = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const caller = await getCaller(req);
+      const deviceId = requiredString(req.body?.deviceId, 'deviceId');
+      const commandType = requiredString(req.body?.commandType, 'commandType');
+      if (!ALLOWED_ADMIN_COMMANDS.has(commandType)) {
+        return sendError(res, 400, 'Unsupported device command');
+      }
+
+      const device = await getDeviceForCaller(deviceId, caller.organizationId);
+      const commandRef = await admin
+        .firestore()
+        .collection('deviceCommands')
+        .add({
+          organizationId: caller.organizationId,
+          kioskId: device.kioskId || null,
+          deviceId,
+          commandType,
+          status: 'pending',
+          queuedBy: caller.uid,
+          queuedAt: timestamp(),
+          updatedAt: timestamp(),
+        });
+
+      return res.status(200).send({
+        success: true,
+        commandId: commandRef.id,
+        status: 'pending',
+      });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to queue device command');
+    }
+  });
+};
+
+const adminListDeviceCommands = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'GET') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const caller = await getCaller(req);
+      const deviceId = requiredString(req.query?.deviceId, 'deviceId');
+      await getDeviceForCaller(deviceId, caller.organizationId);
+      const commands = (await getCollectionRows('deviceCommands')).filter(
+        (command) =>
+          command.organizationId === caller.organizationId && command.deviceId === deviceId,
+      );
+
+      return res.status(200).send({ success: true, commands });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to list device commands');
+    }
+  });
+};
+
+const adminListDeviceEvents = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'GET') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const caller = await getCaller(req);
+      const deviceId = requiredString(req.query?.deviceId, 'deviceId');
+      await getDeviceForCaller(deviceId, caller.organizationId);
+      const events = (await getCollectionRows('deviceEvents')).filter(
+        (event) => event.organizationId === caller.organizationId && event.deviceId === deviceId,
+      );
+
+      return res.status(200).send({ success: true, events });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to list device events');
+    }
+  });
+};
+
 module.exports = {
   kioskDeviceRegister,
   kioskDevicePolicy,
   kioskDeviceStatus,
   kioskDeviceHeartbeat,
   kioskApkDownload,
+  adminCreateDeviceProfile,
+  adminListManagedDevices,
+  adminUpdateManagedDeviceMetadata,
+  adminQueueDeviceCommand,
+  adminListDeviceCommands,
+  adminListDeviceEvents,
 };

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -48,6 +48,12 @@ const {
   kioskDeviceStatus,
   kioskDeviceHeartbeat,
   kioskApkDownload,
+  adminCreateDeviceProfile,
+  adminListManagedDevices,
+  adminUpdateManagedDeviceMetadata,
+  adminQueueDeviceCommand,
+  adminListDeviceCommands,
+  adminListDeviceEvents,
 } = require('./handlers/managedDevices');
 const { completeEmailVerification } = require('./handlers/verification');
 const { logAuthEvent } = require('./handlers/auth');
@@ -162,6 +168,14 @@ exports.kioskDevicePolicy = functions.https.onRequest(kioskDevicePolicy);
 exports.kioskDeviceStatus = functions.https.onRequest(kioskDeviceStatus);
 exports.kioskDeviceHeartbeat = functions.https.onRequest(kioskDeviceHeartbeat);
 exports.kioskApkDownload = functions.https.onRequest(kioskApkDownload);
+exports.adminCreateDeviceProfile = functions.https.onRequest(adminCreateDeviceProfile);
+exports.adminListManagedDevices = functions.https.onRequest(adminListManagedDevices);
+exports.adminUpdateManagedDeviceMetadata = functions.https.onRequest(
+  adminUpdateManagedDeviceMetadata,
+);
+exports.adminQueueDeviceCommand = functions.https.onRequest(adminQueueDeviceCommand);
+exports.adminListDeviceCommands = functions.https.onRequest(adminListDeviceCommands);
+exports.adminListDeviceEvents = functions.https.onRequest(adminListDeviceEvents);
 exports.updateOrganizationSettings = functions.https.onRequest(updateOrganizationSettings);
 
 // Export v2 function with secret

--- a/backend/functions/testUtils/mockFirebaseAdmin.js
+++ b/backend/functions/testUtils/mockFirebaseAdmin.js
@@ -1,6 +1,7 @@
 const collections = new Map();
 let transactionQueue = Promise.resolve();
 let autoIdCounter = 0;
+const authTokens = new Map();
 
 const clone = (value) => {
   if (value === undefined) return undefined;
@@ -116,6 +117,22 @@ const admin = {
   firestore() {
     return firestoreInstance;
   },
+  auth() {
+    return {
+      async verifyIdToken(token) {
+        if (authTokens.has(token)) {
+          return clone(authTokens.get(token));
+        }
+        if (typeof token === 'string' && token.startsWith('uid:')) {
+          return { uid: token.slice(4) };
+        }
+        throw new Error('Invalid token');
+      },
+      async createCustomToken(uid, claims = {}) {
+        return `custom-token:${uid}:${JSON.stringify(claims)}`;
+      },
+    };
+  },
   app() {
     const projectId = process.env.GCLOUD_PROJECT || process.env.GCP_PROJECT || 'demo-project';
     return {
@@ -137,8 +154,13 @@ admin.firestore.FieldValue = {
 
 admin.__reset = () => {
   collections.clear();
+  authTokens.clear();
   transactionQueue = Promise.resolve();
   autoIdCounter = 0;
+};
+
+admin.__setAuthToken = (token, decoded) => {
+  authTokens.set(token, clone(decoded));
 };
 
 admin.__getDoc = (collectionName, id) => {

--- a/docs/MANAGED_DEVICE_APIS.md
+++ b/docs/MANAGED_DEVICE_APIS.md
@@ -68,6 +68,57 @@ links to a kiosk with `kioskId` when the tablet should run that kiosk.
 
 ## API Contract
 
+### Admin portal APIs
+
+The organization portal uses admin-only functions protected by Firebase ID token auth. These
+functions enforce the caller's `organizationId` from the `users` collection and require kiosk
+management access through role or permissions.
+
+Organization admins can:
+
+- create a device provisioning profile
+- list devices in their organization
+- update placement metadata and kiosk linkage
+- queue safe remote commands
+- view device command and event history
+
+Organization admins cannot set APK IDs, package names, device secrets, organization ownership,
+or policy internals.
+
+Supported safe remote commands:
+
+- `sync_policy`
+- `restart_kiosk`
+- `refresh_content`
+- `clear_error`
+
+### `adminCreateDeviceProfile`
+
+Creates an active organization-scoped enrollment profile and returns a copyable provisioning
+payload. The profile can optionally be preassigned to a kiosk in the same organization.
+
+### `adminListManagedDevices`
+
+Lists managed devices for the caller's organization, optionally filtered by kiosk.
+
+### `adminUpdateManagedDeviceMetadata`
+
+Updates organization-facing metadata such as display name, placement label, placement notes,
+latitude, longitude, and kiosk assignment. Protected device and policy fields are rejected.
+
+### `adminQueueDeviceCommand`
+
+Queues an allowlisted remote command for a device in the caller's organization. Android command
+pickup and execution are handled in a later controller integration.
+
+### `adminListDeviceCommands`
+
+Lists command history for a device in the caller's organization.
+
+### `adminListDeviceEvents`
+
+Lists recent device events for a device in the caller's organization.
+
 ### `kioskDeviceRegister`
 
 Registers or updates a managed device from an active enrollment token.
@@ -162,15 +213,18 @@ for:
 - rejecting invalid status values
 - preventing cross-organization APK access
 - preventing same-organization but unassigned APK access
+- creating organization-scoped admin provisioning profiles
+- rejecting cross-organization admin device/profile access
+- updating placement metadata without allowing protected policy fields
+- queueing only allowlisted remote commands
 
 React admin UI, Android controller wiring, QR provisioning, and Firebase Storage upload/signing
 are intentionally left for follow-up PRs.
 
 ## Next Integration Steps
 
-1. Add admin UI for enrollment creation, device listing, kiosk linking, APK assignment, and
-   device event history.
-2. Add storage-backed APK upload and signed download resolution.
-3. Wire the Android controller to register, fetch policy, install the kiosk APK, launch it,
-   and report heartbeat/status.
+1. Add admin UI for provisioning profile creation, device listing, kiosk linking, placement
+   metadata, safe commands, and event history.
+2. Wire the Android controller to pick up queued commands and report command results.
+3. Add storage-backed APK download signing for SwiftCause-controlled rollout.
 4. Validate the full emulator path before physical QR/factory-reset provisioning.


### PR DESCRIPTION
## Why

This is the backend-only PR 1 for portal-managed devices. Organization admins need a safe way to provision devices, track which organization/kiosk owns them, maintain placement metadata, and queue basic remote actions without exposing SwiftCause-controlled APK or policy internals.

This PR is stacked on top of `feature/managed-device-apis` / PR #707.

## What

Adds admin-only Firebase Functions:

- `adminCreateDeviceProfile`
  - Creates an active organization-scoped `deviceEnrollments` profile.
  - Optionally preassigns the profile to a same-org kiosk.
  - Returns a copyable provisioning payload.
  - Rejects APK/package/policy fields from organization-admin payloads.

- `adminListManagedDevices`
  - Lists only devices in the caller organization.
  - Supports optional kiosk filtering.
  - Returns status, heartbeat/error state, placement metadata, linked kiosk, and device info.

- `adminUpdateManagedDeviceMetadata`
  - Allows display name, placement label, placement notes, latitude, longitude, and kiosk assignment.
  - Validates lat/lng ranges.
  - Validates kiosk assignment is same-org.
  - Rejects protected fields such as APK IDs, package names, device secret hash, org ID, and policy internals.

- `adminQueueDeviceCommand`
  - Queues only safe commands:
    - `sync_policy`
    - `restart_kiosk`
    - `refresh_content`
    - `clear_error`
  - Rejects unknown/destructive commands.

- `adminListDeviceCommands`
  - Lists command history for a same-org device.

- `adminListDeviceEvents`
  - Lists event history for a same-org device.

## How

- Reuses existing Firebase ID token verification from `middleware/auth.js`.
- Loads the caller from `users/{uid}` and enforces `organizationId` boundaries.
- Allows admins/super-admins or users with `system_admin`, `create_kiosk`, or `edit_kiosk`.
- Keeps SwiftCause-controlled fields out of organization-admin APIs.
- Uses current Firestore collections from PR #707: `deviceEnrollments`, `managedDevices`, `deviceCommands`, and `deviceEvents`.
- Updates `docs/MANAGED_DEVICE_APIS.md` with the organization-facing admin API and safe-command boundary.

## TDD / Tests

Added `backend/functions/handlers/managedDeviceAdmin.test.js` covering:

- unauthenticated admin rejection
- caller without kiosk/device permission rejection
- own-org profile creation
- cross-org profile creation rejection
- protected APK/package field rejection
- same-org kiosk preassignment enforcement
- device listing scoped to caller organization
- metadata update for placement fields
- protected metadata field rejection
- invalid coordinate rejection
- cross-org kiosk assignment rejection
- safe command queueing
- destructive/unknown command rejection
- cross-org command/event listing rejection
- same-org command/event listing success

Also extended the Firebase Admin test mock to support `verifyIdToken` for auth-backed handler tests.

## Verification

```bash
cd backend/functions
npm test -- managedDevice
npm test
npm run lint
git diff --check
```

## Notes

This PR does not add portal UI or Android command pickup/execution. Those are the next two slices.
