### PR TITLE
fix(payments): harden createPaymentIntent against missing or partial metadata

### DIFF
--- a/backend/functions/handlers/payments.js
+++ b/backend/functions/handlers/payments.js
@@ -569,7 +569,8 @@ const createPaymentIntent = async (req, res) => {
     );
 
     const { amount, currency, metadata } = req.body;
-    const { platform } = metadata || null;
+    const safeMetadata = metadata && typeof metadata === 'object' ? metadata : {};
+    const { platform } = safeMetadata;
 
     let paymentMethodTypes = ['card'];
     if (platform === 'android_ttp') {
@@ -580,20 +581,20 @@ const createPaymentIntent = async (req, res) => {
       return res.status(400).send({ error: 'Missing amount or currency' });
     }
 
-    const { campaignId, donorId, donorName, isGiftAid } = metadata;
+    const { campaignId, donorId, donorName, isGiftAid } = safeMetadata;
 
     const paymentIntent = await stripeClient.paymentIntents.create({
       amount,
       currency,
       customer: customerId,
       payment_method_types: paymentMethodTypes,
-      metadata: {
-        campaignId,
-        donorId,
-        donorName,
-        isGiftAid: isGiftAid.toString(),
-        platform,
-      },
+      metadata: normalizeStripeMetadata({
+        campaignId: campaignId || null,
+        donorId: donorId || null,
+        donorName: donorName || null,
+        isGiftAid: Boolean(isGiftAid),
+        platform: platform || null,
+      }),
     });
 
     if (platform === 'android_ttp') {


### PR DESCRIPTION
# Intro
  createPaymentIntent could crash with an unhandled TypeError when the request body omitted metadata or when isGiftAid was not present in it. Both failures would surface as a 500 to the caller and produce no payment intent, even though the request was otherwise valid (auth passed, amount and currency present). This was a P0 pre-production hardening item.

 ## Before
```

  // If req.body.metadata is undefined:
  // → metadata || null evaluates to null
  // → destructuring null throws TypeError immediately
  const { platform } = metadata || null;

  // If metadata exists but isGiftAid is not in it:
  // → isGiftAid is undefined
  // → undefined.toString() throws TypeError
  isGiftAid: isGiftAid.toString(),
```

  Any caller that omitted metadata, sent metadata: null, or sent a metadata object without isGiftAid would crash the function before reaching Stripe.

  ## After

 ```
 // metadata || {} means missing/null/non-object all fall back to an empty object safely
  const safeMetadata = metadata && typeof metadata === 'object' ? metadata : {};
  const { platform } = safeMetadata;

  // Boolean(undefined) → false, Boolean(null) → false — no crash
  // normalizeStripeMetadata (already used elsewhere in this file) converts
  // booleans to strings and drops null/undefined keys, consistent with 
  createKioskPaymentIntent
  metadata: normalizeStripeMetadata({
    isGiftAid: Boolean(isGiftAid),
    ...
  }),
```

 - Missing or partial metadata now produces the expected partial payment intent rather than an unhandled crash. The normalizeStripeMetadata helper was already defined in this file and used by createKioskPaymentIntent — this change brings createPaymentIntent in line with the same pattern.