### PR TITLE
Add Mono device controller emulator E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,11 @@ android/.gradle/
 android/.idea/
 android/local.properties
 android/build/
-android/app/build/
+android/*/build/
 android/app/google-services.json
 android/*.iml
 android/.externalNativeBuild/
 android/.cxx/
+
+# Local device E2E state
+.e2e/

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,8 +2,19 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.google.services)
     alias(libs.plugins.kotlin.serialization)
+}
+
+val hasGoogleServicesConfig = listOf(
+    "google-services.json",
+    "src/debug/google-services.json",
+    "src/release/google-services.json",
+).any { layout.projectDirectory.file(it).asFile.exists() }
+
+if (hasGoogleServicesConfig) {
+    apply(plugin = "com.google.gms.google-services")
+} else {
+    logger.warn("google-services.json not found; skipping Google Services plugin for this build.")
 }
 
 android {
@@ -34,9 +45,26 @@ android {
             "MAGIC_LINK_BASE_URL",
             "\"https://swiftcause--swiftcause-app.us-east4.hosted.app\""
         )
+        buildConfigField(
+            "String",
+            "KIOSK_API_BASE_URL",
+            "\"https://us-central1-swiftcause-app.cloudfunctions.net/\""
+        )
+        buildConfigField("String", "FIREBASE_EMULATOR_HOST", "\"\"")
+        manifestPlaceholders["usesCleartextTraffic"] = "false"
     }
 
     buildTypes {
+        debug {
+            buildConfigField(
+                "String",
+                "KIOSK_API_BASE_URL",
+                "\"http://10.0.2.2:5001/swiftcause-app/us-central1/\""
+            )
+            buildConfigField("String", "FIREBASE_EMULATOR_HOST", "\"10.0.2.2\"")
+            manifestPlaceholders["usesCleartextTraffic"] = "true"
+        }
+
         release {
             isMinifyEnabled = false
             proguardFiles(

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.SwiftCause">
+        android:theme="@style/Theme.SwiftCause"
+        android:usesCleartextTraffic="${usesCleartextTraffic}">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/java/com/example/swiftcause/MainActivity.kt
+++ b/android/app/src/main/java/com/example/swiftcause/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.swiftcause
 
 import android.Manifest
+import android.app.admin.DevicePolicyManager
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -8,6 +9,7 @@ import android.nfc.NfcAdapter
 import android.os.Bundle
 import android.os.SystemClock
 import android.provider.Settings
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -95,6 +97,7 @@ class MainActivity : ComponentActivity() {
 
         // Initialize Stripe with key from local.properties (from root .env)
         StripeConfig.initialize(this)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         setContent {
             SwiftCauseTheme {
@@ -102,6 +105,19 @@ class MainActivity : ComponentActivity() {
                     AppEntryPoint(modifier = Modifier.padding(innerPadding))
                 }
             }
+        }
+        enterLockTaskIfAllowed()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        enterLockTaskIfAllowed()
+    }
+
+    private fun enterLockTaskIfAllowed() {
+        val dpm = getSystemService(DevicePolicyManager::class.java)
+        if (dpm.isLockTaskPermitted(packageName)) {
+            startLockTask()
         }
     }
 }

--- a/android/app/src/main/java/com/example/swiftcause/data/api/RetrofitClient.kt
+++ b/android/app/src/main/java/com/example/swiftcause/data/api/RetrofitClient.kt
@@ -1,13 +1,12 @@
 package com.example.swiftcause.data.api
 
+import com.example.swiftcause.BuildConfig
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 
 object RetrofitClient {
-    private const val BASE_URL = "https://us-central1-swiftcause-app.cloudfunctions.net/"
-    
     private val okHttpClient = OkHttpClient.Builder()
         .connectTimeout(30, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
@@ -15,7 +14,7 @@ object RetrofitClient {
         .build()
     
     private val retrofit = Retrofit.Builder()
-        .baseUrl(BASE_URL)
+        .baseUrl(BuildConfig.KIOSK_API_BASE_URL)
         .client(okHttpClient)
         .addConverterFactory(GsonConverterFactory.create())
         .build()

--- a/android/app/src/main/java/com/example/swiftcause/data/repository/CampaignRepository.kt
+++ b/android/app/src/main/java/com/example/swiftcause/data/repository/CampaignRepository.kt
@@ -1,6 +1,7 @@
 package com.example.swiftcause.data.repository
 
 import com.example.swiftcause.domain.models.Campaign
+import com.example.swiftcause.utils.FirebaseManager
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 
@@ -13,7 +14,7 @@ data class OrganizationBranding(
 )
 
 class CampaignRepository(
-    private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance()
+    private val firestore: FirebaseFirestore = FirebaseManager.firestore
 ) {
 
     /**

--- a/android/app/src/main/java/com/example/swiftcause/utils/FirebaseManager.kt
+++ b/android/app/src/main/java/com/example/swiftcause/utils/FirebaseManager.kt
@@ -1,5 +1,6 @@
 package com.example.swiftcause.utils
 
+import com.example.swiftcause.BuildConfig
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.auth
@@ -7,6 +8,19 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestore
 
 object FirebaseManager {
-    val auth: FirebaseAuth by lazy { Firebase.auth }
-    val firestore: FirebaseFirestore by lazy { Firebase.firestore }
+    val auth: FirebaseAuth by lazy {
+        Firebase.auth.apply {
+            if (BuildConfig.FIREBASE_EMULATOR_HOST.isNotBlank()) {
+                useEmulator(BuildConfig.FIREBASE_EMULATOR_HOST, 9099)
+            }
+        }
+    }
+
+    val firestore: FirebaseFirestore by lazy {
+        Firebase.firestore.apply {
+            if (BuildConfig.FIREBASE_EMULATOR_HOST.isNotBlank()) {
+                useEmulator(BuildConfig.FIREBASE_EMULATOR_HOST, 8081)
+            }
+        }
+    }
 }

--- a/android/device-controller/build.gradle.kts
+++ b/android/device-controller/build.gradle.kts
@@ -1,0 +1,55 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+}
+
+android {
+    namespace = "com.swiftcause.devicecontroller"
+    compileSdk {
+        version = release(36)
+    }
+
+    defaultConfig {
+        applicationId = "com.swiftcause.devicecontroller"
+        minSdk = 26
+        targetSdk = 36
+        versionCode = 1
+        versionName = "0.1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField(
+            "String",
+            "DEFAULT_API_BASE_URL",
+            "\"http://10.0.2.2:5001/swiftcause-app/us-central1\"",
+        )
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+    buildFeatures {
+        buildConfig = true
+    }
+}
+
+dependencies {
+    implementation(libs.androidx.core.ktx)
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
+}

--- a/android/device-controller/proguard-rules.pro
+++ b/android/device-controller/proguard-rules.pro
@@ -1,0 +1,1 @@
+# E2E controller module only. Keep rules empty until release hardening.

--- a/android/device-controller/src/main/AndroidManifest.xml
+++ b/android/device-controller/src/main/AndroidManifest.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+
+    <queries>
+        <package android:name="com.swiftcause.kiosk" />
+        <package android:name="com.example.swiftcause" />
+    </queries>
+
+    <application
+        android:allowBackup="false"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
+        <activity
+            android:name=".E2eActivity"
+            android:exported="true"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="com.swiftcause.devicecontroller.E2E" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <receiver
+            android:name=".DeviceAdminReceiver"
+            android:description="@string/device_admin_description"
+            android:exported="true"
+            android:label="@string/device_admin_label"
+            android:permission="android.permission.BIND_DEVICE_ADMIN">
+            <meta-data
+                android:name="android.app.device_admin"
+                android:resource="@xml/device_admin" />
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+            </intent-filter>
+        </receiver>
+    </application>
+</manifest>

--- a/android/device-controller/src/main/java/com/swiftcause/devicecontroller/DeviceAdminReceiver.kt
+++ b/android/device-controller/src/main/java/com/swiftcause/devicecontroller/DeviceAdminReceiver.kt
@@ -1,0 +1,3 @@
+package com.swiftcause.devicecontroller
+
+class DeviceAdminReceiver : android.app.admin.DeviceAdminReceiver()

--- a/android/device-controller/src/main/java/com/swiftcause/devicecontroller/DeviceControllerEndpoints.kt
+++ b/android/device-controller/src/main/java/com/swiftcause/devicecontroller/DeviceControllerEndpoints.kt
@@ -1,0 +1,30 @@
+package com.swiftcause.devicecontroller
+
+object DeviceControllerEndpoints {
+    val safeCommands = setOf("sync_policy", "restart_kiosk", "refresh_content", "clear_error")
+
+    fun normalizeBaseUrl(baseUrl: String): String = baseUrl.trim().trimEnd('/')
+
+    fun register(baseUrl: String): String = "${normalizeBaseUrl(baseUrl)}/kioskDeviceRegister"
+
+    fun policy(baseUrl: String, deviceId: String): String =
+        "${normalizeBaseUrl(baseUrl)}/kioskDevicePolicy?deviceId=${urlEncode(deviceId)}"
+
+    fun apkDownload(baseUrl: String, deviceId: String, apkId: String): String =
+        "${normalizeBaseUrl(baseUrl)}/kioskApkDownload?deviceId=${urlEncode(deviceId)}&apkId=${urlEncode(apkId)}"
+
+    fun status(baseUrl: String): String = "${normalizeBaseUrl(baseUrl)}/kioskDeviceStatus"
+
+    fun heartbeat(baseUrl: String): String = "${normalizeBaseUrl(baseUrl)}/kioskDeviceHeartbeat"
+
+    fun commands(baseUrl: String, deviceId: String): String =
+        "${normalizeBaseUrl(baseUrl)}/kioskDeviceCommands?deviceId=${urlEncode(deviceId)}"
+
+    fun commandResult(baseUrl: String): String =
+        "${normalizeBaseUrl(baseUrl)}/kioskDeviceCommandResult"
+
+    fun isSupportedCommand(commandType: String): Boolean = safeCommands.contains(commandType)
+
+    private fun urlEncode(value: String): String =
+        java.net.URLEncoder.encode(value, "UTF-8")
+}

--- a/android/device-controller/src/main/java/com/swiftcause/devicecontroller/E2eActivity.kt
+++ b/android/device-controller/src/main/java/com/swiftcause/devicecontroller/E2eActivity.kt
@@ -1,0 +1,435 @@
+package com.swiftcause.devicecontroller
+
+import android.Manifest
+import android.app.Activity
+import android.app.PendingIntent
+import android.app.admin.DevicePolicyManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.content.pm.PackageInstaller
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import android.view.Gravity
+import android.widget.TextView
+import org.json.JSONObject
+import java.io.BufferedInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.MessageDigest
+
+class E2eActivity : Activity() {
+    private lateinit var statusView: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        statusView = TextView(this).apply {
+            gravity = Gravity.CENTER
+            textSize = 18f
+            setPadding(32, 32, 32, 32)
+            text = "SwiftCause Device Controller"
+        }
+        setContentView(statusView)
+        Thread { runE2eFlow() }.start()
+    }
+
+    private fun runE2eFlow() {
+        try {
+            val prefs = getSharedPreferences(PREFS, MODE_PRIVATE)
+            val apiBaseUrl = DeviceControllerEndpoints.normalizeBaseUrl(
+                readExtraOrPref(prefs, "apiBaseUrl", BuildConfig.DEFAULT_API_BASE_URL),
+            )
+            val enrollmentToken = readExtraOrPref(prefs, "enrollmentToken", "")
+            require(enrollmentToken.isNotBlank()) { "Missing enrollmentToken extra" }
+            prefs.edit()
+                .putString("apiBaseUrl", apiBaseUrl)
+                .putString("enrollmentToken", enrollmentToken)
+                .apply()
+
+            setStatus("Registering controller...")
+            val registration = register(apiBaseUrl, enrollmentToken)
+            val deviceId = registration.getString("deviceId")
+            val deviceSecret = registration.getString("deviceSecret")
+            prefs.edit()
+                .putString("deviceId", deviceId)
+                .putString("deviceSecret", deviceSecret)
+                .apply()
+
+            setStatus("Fetching policy...")
+            val policy = fetchPolicy(apiBaseUrl, deviceId, deviceSecret)
+            reportStatus(
+                apiBaseUrl,
+                deviceId,
+                deviceSecret,
+                "online",
+                installStatus = "policy_fetched",
+                deviceOwner = isDeviceOwner(),
+            )
+
+            val apkPolicy = policy.optJSONObject("apk")
+            if (apkPolicy == null) {
+                reportStatus(
+                    apiBaseUrl,
+                    deviceId,
+                    deviceSecret,
+                    "error",
+                    error = "Policy did not include an APK",
+                )
+                sendHeartbeat(apiBaseUrl, deviceId, deviceSecret)
+                return
+            }
+
+            val downloadMetadata = fetchApkDownload(
+                apiBaseUrl,
+                deviceId,
+                deviceSecret,
+                apkPolicy.getString("apkId"),
+            )
+            setStatus("Downloading kiosk APK...")
+            reportStatus(apiBaseUrl, deviceId, deviceSecret, "installing", installStatus = "downloading")
+            val apkFile = download(downloadMetadata.getString("downloadUrl"), "swiftcause-test-kiosk.apk")
+            val expectedHash = downloadMetadata.optString("checksumSha256", "")
+            if (expectedHash.isNotBlank()) {
+                val actualHash = sha256(apkFile)
+                require(expectedHash.equals(actualHash, ignoreCase = true)) {
+                    "APK SHA-256 mismatch: $actualHash"
+                }
+            }
+
+            val kioskPackage = downloadMetadata.getString("packageName")
+            setStatus("Installing $kioskPackage...")
+            val installed = installApk(apkFile, kioskPackage)
+            if (installed) {
+                configureKioskPackage(kioskPackage)
+            }
+            reportStatus(
+                apiBaseUrl,
+                deviceId,
+                deviceSecret,
+                if (installed) "online" else "install_failed",
+                installStatus = if (installed) "installed" else "install_timeout",
+                deviceOwner = isDeviceOwner(),
+                error = if (installed) null else "PackageInstaller did not report installed package",
+            )
+
+            if (installed) {
+                setStatus("Launching kiosk...")
+                val launched = launchPackage(kioskPackage)
+                reportStatus(
+                    apiBaseUrl,
+                    deviceId,
+                    deviceSecret,
+                    if (launched) "kiosk_active" else "error",
+                    launchStatus = if (launched) "launched" else "launch_intent_missing",
+                    deviceOwner = isDeviceOwner(),
+                    error = if (launched) null else "Launch intent not found for $kioskPackage",
+                )
+            }
+
+            setStatus("Polling commands...")
+            executePendingCommands(apiBaseUrl, deviceId, deviceSecret, kioskPackage)
+            sendHeartbeat(apiBaseUrl, deviceId, deviceSecret)
+            setStatus("SwiftCause emulator E2E complete")
+        } catch (error: Exception) {
+            setStatus("SwiftCause E2E failed: ${error.message}")
+            android.util.Log.e(TAG, "E2E failed", error)
+            tryReportFailure(error)
+        }
+    }
+
+    private fun register(apiBaseUrl: String, enrollmentToken: String): JSONObject {
+        val body = JSONObject()
+            .put("enrollmentToken", enrollmentToken)
+            .put("androidId", Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID))
+            .put("serialNumber", Build.SERIAL ?: "")
+            .put("manufacturer", Build.MANUFACTURER)
+            .put("model", Build.MODEL)
+            .put("controllerVersion", BuildConfig.VERSION_NAME)
+        return postJson(DeviceControllerEndpoints.register(apiBaseUrl), null, body)
+    }
+
+    private fun fetchPolicy(apiBaseUrl: String, deviceId: String, deviceSecret: String): JSONObject =
+        getJson(DeviceControllerEndpoints.policy(apiBaseUrl, deviceId), deviceSecret)
+
+    private fun fetchApkDownload(
+        apiBaseUrl: String,
+        deviceId: String,
+        deviceSecret: String,
+        apkId: String,
+    ): JSONObject = getJson(DeviceControllerEndpoints.apkDownload(apiBaseUrl, deviceId, apkId), deviceSecret)
+
+    private fun executePendingCommands(
+        apiBaseUrl: String,
+        deviceId: String,
+        deviceSecret: String,
+        kioskPackage: String,
+    ) {
+        val response = getJson(DeviceControllerEndpoints.commands(apiBaseUrl, deviceId), deviceSecret)
+        val commands = response.optJSONArray("commands") ?: return
+        for (index in 0 until commands.length()) {
+            val command = commands.getJSONObject(index)
+            val commandId = command.getString("id")
+            val commandType = command.getString("commandType")
+            try {
+                require(DeviceControllerEndpoints.isSupportedCommand(commandType)) {
+                    "Unsupported command: $commandType"
+                }
+                when (commandType) {
+                    "sync_policy" -> fetchPolicy(apiBaseUrl, deviceId, deviceSecret)
+                    "restart_kiosk" -> require(launchPackage(kioskPackage)) {
+                        "Launch intent not found for $kioskPackage"
+                    }
+                    "refresh_content" -> Unit
+                    "clear_error" -> reportStatus(
+                        apiBaseUrl,
+                        deviceId,
+                        deviceSecret,
+                        "online",
+                        error = null,
+                        clearError = true,
+                    )
+                }
+                reportCommandResult(apiBaseUrl, deviceId, deviceSecret, commandId, "succeeded", "Executed")
+            } catch (error: Exception) {
+                reportCommandResult(
+                    apiBaseUrl,
+                    deviceId,
+                    deviceSecret,
+                    commandId,
+                    "failed",
+                    error.message ?: error.toString(),
+                )
+            }
+        }
+    }
+
+    private fun reportStatus(
+        apiBaseUrl: String,
+        deviceId: String,
+        deviceSecret: String,
+        status: String,
+        installStatus: String? = null,
+        launchStatus: String? = null,
+        deviceOwner: Boolean? = null,
+        error: String? = null,
+        clearError: Boolean = false,
+    ) {
+        val body = JSONObject()
+            .put("deviceId", deviceId)
+            .put("status", status)
+        if (installStatus != null) body.put("installStatus", installStatus)
+        if (launchStatus != null) body.put("launchStatus", launchStatus)
+        if (deviceOwner != null) body.put("deviceOwner", deviceOwner)
+        if (error != null) {
+            body.put("error", error)
+        } else if (status != "online" || clearError) {
+            body.put("error", JSONObject.NULL)
+        }
+        postJson(DeviceControllerEndpoints.status(apiBaseUrl), deviceSecret, body)
+    }
+
+    private fun reportCommandResult(
+        apiBaseUrl: String,
+        deviceId: String,
+        deviceSecret: String,
+        commandId: String,
+        status: String,
+        message: String,
+    ) {
+        val body = JSONObject()
+            .put("deviceId", deviceId)
+            .put("commandId", commandId)
+            .put("status", status)
+            .put("message", message)
+        postJson(DeviceControllerEndpoints.commandResult(apiBaseUrl), deviceSecret, body)
+    }
+
+    private fun sendHeartbeat(apiBaseUrl: String, deviceId: String, deviceSecret: String) {
+        val body = JSONObject()
+            .put("deviceId", deviceId)
+            .put("networkType", "emulator")
+        postJson(DeviceControllerEndpoints.heartbeat(apiBaseUrl), deviceSecret, body)
+    }
+
+    private fun installApk(file: File, packageName: String): Boolean {
+        check(isDeviceOwner()) { "Device Owner is required for silent install" }
+        val installer = packageManager.packageInstaller
+        val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+            .apply { setAppPackageName(packageName) }
+        val sessionId = installer.createSession(params)
+        val session = installer.openSession(sessionId)
+        session.openWrite("swiftcause-kiosk", 0, file.length()).use { out ->
+            BufferedInputStream(FileInputStream(file)).use { input ->
+                input.copyTo(out, 64 * 1024)
+            }
+            out.flush()
+            session.fsync(out)
+        }
+        val callback = Intent("com.swiftcause.devicecontroller.INSTALL_RESULT")
+            .setPackage(this.packageName)
+        val pendingIntent = PendingIntent.getBroadcast(
+            this,
+            sessionId,
+            callback,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+        )
+        session.commit(pendingIntent.intentSender)
+        session.close()
+
+        repeat(20) {
+            Thread.sleep(1_000)
+            if (isPackageInstalled(packageName)) return true
+        }
+        return false
+    }
+
+    private fun launchPackage(packageName: String): Boolean {
+        configureKioskPackage(packageName)
+        val launch = packageManager.getLaunchIntentForPackage(packageName) ?: return false
+        launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity(launch)
+        return true
+    }
+
+    private fun configureKioskPackage(packageName: String) {
+        if (!isDeviceOwner()) return
+        val dpm = getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        val admin = ComponentName(this, DeviceAdminReceiver::class.java)
+        dpm.setLockTaskPackages(admin, arrayOf(packageName, this.packageName))
+        dpm.setKeyguardDisabled(admin, true)
+        dpm.setStatusBarDisabled(admin, true)
+
+        listOf(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.BLUETOOTH_CONNECT,
+            Manifest.permission.BLUETOOTH_SCAN,
+        ).forEach { permission ->
+            dpm.setPermissionGrantState(
+                admin,
+                packageName,
+                permission,
+                DevicePolicyManager.PERMISSION_GRANT_STATE_GRANTED,
+            )
+        }
+    }
+
+    private fun isPackageInstalled(packageName: String): Boolean =
+        try {
+            packageManager.getPackageInfo(packageName, 0)
+            true
+        } catch (_: PackageManager.NameNotFoundException) {
+            false
+        }
+
+    private fun isDeviceOwner(): Boolean {
+        val dpm = getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+        return dpm.isDeviceOwnerApp(packageName)
+    }
+
+    private fun getJson(url: String, bearer: String): JSONObject =
+        JSONObject(read(open(url, "GET", bearer)))
+
+    private fun postJson(url: String, bearer: String?, body: JSONObject): JSONObject {
+        val connection = open(url, "POST", bearer)
+        connection.setRequestProperty("Content-Type", "application/json")
+        connection.doOutput = true
+        connection.outputStream.use { it.write(body.toString().toByteArray(Charsets.UTF_8)) }
+        return JSONObject(read(connection))
+    }
+
+    private fun open(url: String, method: String, bearer: String?): HttpURLConnection {
+        val connection = URL(url).openConnection() as HttpURLConnection
+        connection.requestMethod = method
+        connection.connectTimeout = 15_000
+        connection.readTimeout = 30_000
+        if (!bearer.isNullOrBlank()) {
+            connection.setRequestProperty("Authorization", "Bearer $bearer")
+        }
+        return connection
+    }
+
+    private fun read(connection: HttpURLConnection): String {
+        val code = connection.responseCode
+        val stream = if (code in 200..299) connection.inputStream else connection.errorStream
+        val response = ByteArrayOutputStream().use { out ->
+            stream.use { input -> input.copyTo(out) }
+            out.toString("UTF-8")
+        }
+        check(code in 200..299) { "HTTP $code: $response" }
+        return response
+    }
+
+    private fun download(url: String, name: String): File {
+        val connection = open(url, "GET", null)
+        check(connection.responseCode in 200..299) { "Download failed HTTP ${connection.responseCode}" }
+        val file = File(cacheDir, name)
+        connection.inputStream.use { input ->
+            FileOutputStream(file).use { output -> input.copyTo(output, 64 * 1024) }
+        }
+        return file
+    }
+
+    private fun sha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        FileInputStream(file).use { input ->
+            val buffer = ByteArray(8192)
+            while (true) {
+                val read = input.read(buffer)
+                if (read == -1) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun readExtraOrPref(prefs: SharedPreferences, key: String, defaultValue: String): String =
+        intent.getStringExtra(key)?.takeIf { it.isNotBlank() } ?: prefs.getString(key, defaultValue).orEmpty()
+
+    private fun tryReportFailure(error: Exception) {
+        try {
+            val prefs = getSharedPreferences(PREFS, MODE_PRIVATE)
+                val apiBaseUrl = prefs.getString("apiBaseUrl", BuildConfig.DEFAULT_API_BASE_URL)
+                    ?.let { DeviceControllerEndpoints.normalizeBaseUrl(it) }
+            val deviceId = prefs.getString("deviceId", null)
+            val deviceSecret = prefs.getString("deviceSecret", null)
+            if (!apiBaseUrl.isNullOrBlank() && !deviceId.isNullOrBlank() && !deviceSecret.isNullOrBlank()) {
+                reportStatus(
+                    apiBaseUrl,
+                    deviceId,
+                    deviceSecret,
+                    "error",
+                    error = "${error.message}\n${stackTrace(error)}",
+                    deviceOwner = isDeviceOwner(),
+                )
+            }
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun stackTrace(error: Exception): String {
+        val writer = StringWriter()
+        error.printStackTrace(PrintWriter(writer))
+        return writer.toString()
+    }
+
+    private fun setStatus(message: String) {
+        runOnUiThread { statusView.text = message }
+        android.util.Log.i(TAG, message)
+    }
+
+    companion object {
+        private const val PREFS = "swiftcause_device_controller"
+        private const val TAG = "SwiftCauseE2E"
+    }
+}

--- a/android/device-controller/src/main/res/values/strings.xml
+++ b/android/device-controller/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SwiftCause Device Controller</string>
+    <string name="device_admin_label">SwiftCause Device Controller</string>
+    <string name="device_admin_description">Allows SwiftCause to provision and manage this kiosk tablet.</string>
+</resources>

--- a/android/device-controller/src/main/res/values/themes.xml
+++ b/android/device-controller/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar" />
+</resources>

--- a/android/device-controller/src/main/res/xml/device_admin.xml
+++ b/android/device-controller/src/main/res/xml/device_admin.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-policies>
+        <force-lock />
+    </uses-policies>
+</device-admin>

--- a/android/device-controller/src/test/java/com/swiftcause/devicecontroller/DeviceControllerEndpointsTest.kt
+++ b/android/device-controller/src/test/java/com/swiftcause/devicecontroller/DeviceControllerEndpointsTest.kt
@@ -1,0 +1,35 @@
+package com.swiftcause.devicecontroller
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceControllerEndpointsTest {
+    @Test
+    fun buildsFunctionUrlsFromBaseUrl() {
+        val baseUrl = "http://10.0.2.2:5001/swiftcause-app/us-central1/"
+
+        assertEquals(
+            "http://10.0.2.2:5001/swiftcause-app/us-central1/kioskDeviceRegister",
+            DeviceControllerEndpoints.register(baseUrl),
+        )
+        assertEquals(
+            "http://10.0.2.2:5001/swiftcause-app/us-central1/kioskDevicePolicy?deviceId=device_123",
+            DeviceControllerEndpoints.policy(baseUrl, "device_123"),
+        )
+        assertEquals(
+            "http://10.0.2.2:5001/swiftcause-app/us-central1/kioskApkDownload?deviceId=device_123&apkId=apk+1",
+            DeviceControllerEndpoints.apkDownload(baseUrl, "device_123", "apk 1"),
+        )
+    }
+
+    @Test
+    fun identifiesSafeCommands() {
+        assertTrue(DeviceControllerEndpoints.isSupportedCommand("sync_policy"))
+        assertTrue(DeviceControllerEndpoints.isSupportedCommand("restart_kiosk"))
+        assertTrue(DeviceControllerEndpoints.isSupportedCommand("refresh_content"))
+        assertTrue(DeviceControllerEndpoints.isSupportedCommand("clear_error"))
+        assertFalse(DeviceControllerEndpoints.isSupportedCommand("factory_reset"))
+    }
+}

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -21,4 +21,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "SwiftCause"
 include(":app")
- 
+include(":device-controller")
+include(":test-kiosk")

--- a/android/test-kiosk/build.gradle.kts
+++ b/android/test-kiosk/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+}
+
+android {
+    namespace = "com.swiftcause.kiosk"
+    compileSdk {
+        version = release(36)
+    }
+
+    defaultConfig {
+        applicationId = "com.swiftcause.kiosk"
+        minSdk = 26
+        targetSdk = 36
+        versionCode = 1
+        versionName = "1.0.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+}
+
+dependencies {
+    implementation(libs.androidx.core.ktx)
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
+}

--- a/android/test-kiosk/src/main/AndroidManifest.xml
+++ b/android/test-kiosk/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:allowBackup="false"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/test-kiosk/src/main/java/com/swiftcause/kiosk/MainActivity.kt
+++ b/android/test-kiosk/src/main/java/com/swiftcause/kiosk/MainActivity.kt
@@ -1,0 +1,33 @@
+package com.swiftcause.kiosk
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.Gravity
+import android.widget.LinearLayout
+import android.widget.TextView
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val container = LinearLayout(this).apply {
+            gravity = Gravity.CENTER
+            orientation = LinearLayout.VERTICAL
+            setPadding(48, 48, 48, 48)
+        }
+        container.addView(
+            TextView(this).apply {
+                gravity = Gravity.CENTER
+                text = "SwiftCause Test Kiosk"
+                textSize = 28f
+            },
+        )
+        container.addView(
+            TextView(this).apply {
+                gravity = Gravity.CENTER
+                text = "Installed and launched by the device controller."
+                textSize = 16f
+            },
+        )
+        setContentView(container)
+    }
+}

--- a/android/test-kiosk/src/main/res/values/strings.xml
+++ b/android/test-kiosk/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">SwiftCause Test Kiosk</string>
+</resources>

--- a/android/test-kiosk/src/main/res/values/themes.xml
+++ b/android/test-kiosk/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar" />
+</resources>

--- a/backend/firestore.indexes.json
+++ b/backend/firestore.indexes.json
@@ -260,6 +260,17 @@
       ]
     },
     {
+      "collectionGroup": "deviceCommands",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "organizationId", "order": "ASCENDING" },
+        { "fieldPath": "deviceId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "queuedAt", "order": "ASCENDING" },
+        { "fieldPath": "__name__", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "deviceEvents",
       "queryScope": "COLLECTION",
       "fields": [

--- a/backend/functions/handlers/kiosk.js
+++ b/backend/functions/handlers/kiosk.js
@@ -1,5 +1,6 @@
-const admin = require("firebase-admin");
-const cors = require("../middleware/cors");
+const admin = require('firebase-admin');
+const { FieldValue } = require('firebase-admin/firestore');
+const cors = require('../middleware/cors');
 
 /**
  * Authenticate kiosk and generate custom token
@@ -9,71 +10,71 @@ const cors = require("../middleware/cors");
 const kioskLogin = (req, res) => {
   cors(req, res, async () => {
     try {
-      if (req.method !== "POST") {
-        return res.status(405).send({error: "Method not allowed"});
+      if (req.method !== 'POST') {
+        return res.status(405).send({ error: 'Method not allowed' });
       }
 
-      const {kioskId, accessCode} = req.body;
+      const { kioskId, accessCode } = req.body;
 
       // Validate input
       if (!kioskId || !accessCode) {
         return res.status(400).send({
-          error: "kioskId and accessCode are required",
+          error: 'kioskId and accessCode are required',
         });
       }
 
       // Fetch kiosk document
-      const kioskRef = admin.firestore().collection("kiosks").doc(kioskId);
+      const kioskRef = admin.firestore().collection('kiosks').doc(kioskId);
       const kioskDoc = await kioskRef.get();
 
       if (!kioskDoc.exists) {
         return res.status(401).send({
-          error: "Invalid kiosk credentials",
+          error: 'Invalid kiosk credentials',
         });
       }
 
       const kioskData = kioskDoc.data();
 
       // Verify kiosk status is online
-      if (kioskData.status !== "online") {
+      if (kioskData.status !== 'online') {
         return res.status(403).send({
-          error: "Kiosk is not online",
+          error: 'Kiosk is not online',
         });
       }
 
       // Verify access code
       if (kioskData.accessCode !== accessCode) {
         return res.status(401).send({
-          error: "Invalid kiosk credentials",
+          error: 'Invalid kiosk credentials',
         });
       }
 
       // Generate custom token with kiosk UID format
       const uid = `kiosk:${kioskId}`;
-      
+
       // Fetch organization currency if available
       let organizationCurrency = 'GBP';
       if (kioskData.organizationId) {
         const orgDoc = await admin
-            .firestore()
-            .collection('organizations')
-            .doc(kioskData.organizationId)
-            .get();
+          .firestore()
+          .collection('organizations')
+          .doc(kioskData.organizationId)
+          .get();
         if (orgDoc.exists) {
           organizationCurrency = orgDoc.data().currency || 'GBP';
         }
       }
-      
+
       // Set custom claims with all necessary kiosk data
       const customClaims = {
-        role: "kiosk",
+        role: 'kiosk',
         kioskId: kioskId,
         kioskName: kioskData.name,
         organizationId: kioskData.organizationId || null,
         organizationCurrency: organizationCurrency,
         assignedCampaigns: kioskData.assignedCampaigns || [],
         settings: kioskData.settings || {
-          displayMode: "grid",
+          displayMode: 'grid',
           showAllCampaigns: false,
           maxCampaignsDisplay: 6,
           autoRotateCampaigns: false,
@@ -85,7 +86,7 @@ const kioskLogin = (req, res) => {
 
       // Update last active timestamp
       await kioskRef.update({
-        lastActive: admin.firestore.FieldValue.serverTimestamp(),
+        lastActive: FieldValue.serverTimestamp(),
       });
 
       return res.status(200).send({
@@ -97,7 +98,7 @@ const kioskLogin = (req, res) => {
           organizationId: kioskData.organizationId,
           assignedCampaigns: kioskData.assignedCampaigns || [],
           settings: kioskData.settings || {
-            displayMode: "grid",
+            displayMode: 'grid',
             showAllCampaigns: false,
             maxCampaignsDisplay: 6,
             autoRotateCampaigns: false,
@@ -105,9 +106,9 @@ const kioskLogin = (req, res) => {
         },
       });
     } catch (error) {
-      console.error("Error in kioskLogin:", error);
+      console.error('Error in kioskLogin:', error);
       return res.status(500).send({
-        error: error.message || "Failed to authenticate kiosk",
+        error: error.message || 'Failed to authenticate kiosk',
       });
     }
   });

--- a/backend/functions/handlers/managedDevices.js
+++ b/backend/functions/handlers/managedDevices.js
@@ -377,6 +377,7 @@ const kioskDevicePolicy = (req, res) => {
       const deviceId = requiredString(req.query?.deviceId, 'deviceId');
       const device = await getAuthenticatedDevice(req, deviceId);
       const apk = await getAssignedApk(device);
+      const resolvedKioskPackage = apk?.packageName || device.kioskPackage || KIOSK_PACKAGE;
 
       await admin.firestore().collection('managedDevices').doc(deviceId).set(
         {
@@ -400,8 +401,8 @@ const kioskDevicePolicy = (req, res) => {
         organizationId: device.organizationId,
         kioskId: device.kioskId || null,
         controllerPackage: device.controllerPackage || CONTROLLER_PACKAGE,
-        kioskPackage: device.kioskPackage || KIOSK_PACKAGE,
-        launchPackage: device.kioskPackage || KIOSK_PACKAGE,
+        kioskPackage: resolvedKioskPackage,
+        launchPackage: resolvedKioskPackage,
         heartbeatIntervalSeconds: HEARTBEAT_INTERVAL_SECONDS,
         apk: apk
           ? {
@@ -596,23 +597,39 @@ const kioskDeviceCommandResult = (req, res) => {
 
       const device = await getAuthenticatedDevice(req, deviceId);
       const commandRef = admin.firestore().collection('deviceCommands').doc(commandId);
-      const commandDoc = await commandRef.get();
-      if (!commandDoc.exists) {
-        return sendError(res, 404, 'Device command not found');
-      }
+      const { command, update } = await admin.firestore().runTransaction(async (transaction) => {
+        const commandDoc = await transaction.get(commandRef);
+        if (!commandDoc.exists) {
+          const error = new Error('Device command not found');
+          error.code = 404;
+          throw error;
+        }
 
-      const command = commandDoc.data();
-      if (command.organizationId !== device.organizationId || command.deviceId !== deviceId) {
-        return sendError(res, 403, 'Device command is not assigned to this device');
-      }
+        const commandData = commandDoc.data();
+        if (
+          commandData.organizationId !== device.organizationId ||
+          commandData.deviceId !== deviceId
+        ) {
+          const error = new Error('Device command is not assigned to this device');
+          error.code = 403;
+          throw error;
+        }
+        if (commandData.status !== 'pending') {
+          const error = new Error('Device command is already completed');
+          error.code = 409;
+          throw error;
+        }
 
-      const update = {
-        status,
-        resultMessage: optionalString(req.body?.message),
-        resultAt: timestamp(),
-        updatedAt: timestamp(),
-      };
-      await commandRef.set(update, { merge: true });
+        const commandUpdate = {
+          status,
+          resultMessage: optionalString(req.body?.message),
+          resultAt: timestamp(),
+          updatedAt: timestamp(),
+        };
+        transaction.set(commandRef, commandUpdate, { merge: true });
+
+        return { command: commandData, update: commandUpdate };
+      });
       await appendDeviceEvent(
         'COMMAND_RESULT',
         { id: deviceId, ...device },

--- a/backend/functions/handlers/managedDevices.js
+++ b/backend/functions/handlers/managedDevices.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto');
 const admin = require('firebase-admin');
+const { Timestamp } = require('firebase-admin/firestore');
 const cors = require('../middleware/cors');
 const { verifyAuth } = require('../middleware/auth');
 
@@ -23,7 +24,9 @@ const ALLOWED_ADMIN_COMMANDS = new Set([
 ]);
 const MANAGED_DEVICE_LIST_LIMIT = 100;
 const DEVICE_COMMAND_LIST_LIMIT = 50;
+const DEVICE_COMMAND_PICKUP_LIMIT = 10;
 const DEVICE_EVENT_LIST_LIMIT = 25;
+const ALLOWED_COMMAND_RESULT_STATUSES = new Set(['succeeded', 'failed', 'skipped']);
 const PROTECTED_ADMIN_FIELDS = new Set([
   'apkId',
   'assignedKioskApkId',
@@ -39,7 +42,7 @@ const PROTECTED_ADMIN_FIELDS = new Set([
   'lockTaskPolicy',
 ]);
 
-const timestamp = () => admin.firestore.Timestamp.now();
+const timestamp = () => Timestamp.now();
 
 const sendError = (res, code, message) => res.status(code).send({ error: message });
 
@@ -341,6 +344,14 @@ const kioskDeviceRegister = (req, res) => {
         .collection('managedDevices')
         .doc(deviceId)
         .set(device, { merge: true });
+      await appendDeviceEvent(
+        'REGISTERED',
+        { id: deviceId, ...device },
+        {
+          status: device.status,
+          enrollmentId: enrollmentToken,
+        },
+      );
 
       return res.status(200).send({
         success: true,
@@ -373,6 +384,14 @@ const kioskDevicePolicy = (req, res) => {
           updatedAt: timestamp(),
         },
         { merge: true },
+      );
+      await appendDeviceEvent(
+        'POLICY_FETCHED',
+        { id: deviceId, ...device },
+        {
+          status: 'policy_fetched',
+          apkId: apk?.id || null,
+        },
       );
 
       return res.status(200).send({
@@ -509,6 +528,15 @@ const kioskApkDownload = (req, res) => {
       if (apk.organizationId !== device.organizationId) {
         return sendError(res, 403, 'APK is not assigned to this organization');
       }
+      await appendDeviceEvent(
+        'APK_DOWNLOAD_METADATA',
+        { id: deviceId, ...device },
+        {
+          status: 'apk_download_metadata',
+          apkId,
+          packageName: apk.packageName,
+        },
+      );
 
       return res.status(200).send({
         success: true,
@@ -521,6 +549,88 @@ const kioskApkDownload = (req, res) => {
       });
     } catch (error) {
       return sendError(res, error.code || 500, error.message || 'Failed to resolve APK download');
+    }
+  });
+};
+
+const kioskDeviceCommands = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'GET') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const deviceId = requiredString(req.query?.deviceId, 'deviceId');
+      const device = await getAuthenticatedDevice(req, deviceId);
+      const snapshot = await admin
+        .firestore()
+        .collection('deviceCommands')
+        .where('organizationId', '==', device.organizationId)
+        .where('deviceId', '==', deviceId)
+        .where('status', '==', 'pending')
+        .orderBy('queuedAt', 'asc')
+        .limit(DEVICE_COMMAND_PICKUP_LIMIT)
+        .get();
+      const commands = mapQueryRows(snapshot);
+
+      return res.status(200).send({ success: true, commands });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to list device commands');
+    }
+  });
+};
+
+const kioskDeviceCommandResult = (req, res) => {
+  cors(req, res, async () => {
+    try {
+      if (req.method !== 'POST') {
+        return sendError(res, 405, 'Method not allowed');
+      }
+
+      const deviceId = requiredString(req.body?.deviceId, 'deviceId');
+      const commandId = requiredString(req.body?.commandId, 'commandId');
+      const status = requiredString(req.body?.status, 'status');
+      if (!ALLOWED_COMMAND_RESULT_STATUSES.has(status)) {
+        return sendError(res, 400, 'Invalid command result status');
+      }
+
+      const device = await getAuthenticatedDevice(req, deviceId);
+      const commandRef = admin.firestore().collection('deviceCommands').doc(commandId);
+      const commandDoc = await commandRef.get();
+      if (!commandDoc.exists) {
+        return sendError(res, 404, 'Device command not found');
+      }
+
+      const command = commandDoc.data();
+      if (command.organizationId !== device.organizationId || command.deviceId !== deviceId) {
+        return sendError(res, 403, 'Device command is not assigned to this device');
+      }
+
+      const update = {
+        status,
+        resultMessage: optionalString(req.body?.message),
+        resultAt: timestamp(),
+        updatedAt: timestamp(),
+      };
+      await commandRef.set(update, { merge: true });
+      await appendDeviceEvent(
+        'COMMAND_RESULT',
+        { id: deviceId, ...device },
+        {
+          status,
+          commandId,
+          commandType: command.commandType || null,
+          message: update.resultMessage,
+        },
+      );
+
+      return res.status(200).send({
+        success: true,
+        commandId,
+        status,
+      });
+    } catch (error) {
+      return sendError(res, error.code || 500, error.message || 'Failed to record command result');
     }
   });
 };
@@ -765,6 +875,8 @@ module.exports = {
   kioskDeviceStatus,
   kioskDeviceHeartbeat,
   kioskApkDownload,
+  kioskDeviceCommands,
+  kioskDeviceCommandResult,
   adminCreateDeviceProfile,
   adminListManagedDevices,
   adminUpdateManagedDeviceMetadata,

--- a/backend/functions/handlers/managedDevices.test.js
+++ b/backend/functions/handlers/managedDevices.test.js
@@ -243,6 +243,33 @@ describe('managed device APIs', () => {
     ]);
   });
 
+  it('uses the assigned APK package as the kiosk and launch package in policy', async () => {
+    await seedKiosk('kiosk-1', { assignedKioskApkId: 'real-app-apk' });
+    await seedApk('real-app-apk', {
+      packageName: 'com.example.swiftcause',
+      downloadUrl: 'https://example.test/swiftcause-mobile-debug.apk',
+    });
+    const registered = await registerDevice();
+
+    const res = await invokeHandler(
+      kioskDevicePolicy,
+      withDeviceSecret(
+        request({ method: 'GET', query: { deviceId: registered.body.deviceId } }),
+        registered.body.deviceSecret,
+      ),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      kioskPackage: 'com.example.swiftcause',
+      launchPackage: 'com.example.swiftcause',
+      apk: {
+        apkId: 'real-app-apk',
+        packageName: 'com.example.swiftcause',
+      },
+    });
+  });
+
   it('rejects policy requests without the device secret', async () => {
     const registered = await registerDevice();
 
@@ -625,6 +652,44 @@ describe('managed device APIs', () => {
         }),
       }),
     ]);
+  });
+
+  it('rejects command result replay after a command has already completed', async () => {
+    const registered = await registerDevice();
+    await admin
+      .firestore()
+      .collection('deviceCommands')
+      .doc('command-1')
+      .set({
+        organizationId: 'org-1',
+        deviceId: registered.body.deviceId,
+        commandType: 'restart_kiosk',
+        status: 'succeeded',
+        resultMessage: 'Original result',
+        queuedAt: { __type: 'timestamp', ms: 1000 },
+      });
+
+    const res = await invokeHandler(
+      kioskDeviceCommandResult,
+      withDeviceSecret(
+        request({
+          body: {
+            deviceId: registered.body.deviceId,
+            commandId: 'command-1',
+            status: 'failed',
+            message: 'Replay overwrite',
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
+    );
+
+    expect(res.statusCode).toBe(409);
+    expect(admin.__getDoc('deviceCommands', 'command-1')).toMatchObject({
+      status: 'succeeded',
+      resultMessage: 'Original result',
+    });
+    expect(getDeviceEvents(registered.body.deviceId, 'COMMAND_RESULT')).toHaveLength(0);
   });
 
   it('rejects command results for commands assigned to another device or organization', async () => {

--- a/backend/functions/handlers/managedDevices.test.js
+++ b/backend/functions/handlers/managedDevices.test.js
@@ -8,6 +8,8 @@ const {
   kioskDeviceStatus,
   kioskDeviceHeartbeat,
   kioskApkDownload,
+  kioskDeviceCommands,
+  kioskDeviceCommandResult,
 } = require('./managedDevices');
 
 const createResponse = () => {
@@ -127,6 +129,11 @@ const registerDevice = async (overrides = {}) => {
   );
 };
 
+const getDeviceEvents = (deviceId, type) =>
+  admin
+    .__getCollection('deviceEvents')
+    .filter((event) => event.data.deviceId === deviceId && (!type || event.data.type === type));
+
 describe('managed device APIs', () => {
   beforeEach(() => {
     admin.__reset();
@@ -159,6 +166,7 @@ describe('managed device APIs', () => {
     });
     expect(device.deviceSecretHash).toEqual(expect.any(String));
     expect(device.deviceSecret).toBeUndefined();
+    expect(getDeviceEvents(res.body.deviceId, 'REGISTERED')).toHaveLength(1);
   });
 
   it('updates the same managed device when it registers again', async () => {
@@ -224,6 +232,15 @@ describe('managed device APIs', () => {
         versionCode: 7,
       },
     });
+    expect(getDeviceEvents(registered.body.deviceId, 'POLICY_FETCHED')).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          payload: expect.objectContaining({
+            apkId: 'apk-1',
+          }),
+        }),
+      }),
+    ]);
   });
 
   it('rejects policy requests without the device secret', async () => {
@@ -261,7 +278,7 @@ describe('managed device APIs', () => {
       installStatus: 'installed',
       deviceOwner: true,
     });
-    expect(admin.__getCollection('deviceEvents')).toEqual([
+    expect(getDeviceEvents(registered.body.deviceId, 'STATUS_UPDATED')).toEqual([
       expect.objectContaining({
         data: expect.objectContaining({
           type: 'STATUS_UPDATED',
@@ -399,7 +416,7 @@ describe('managed device APIs', () => {
       batteryLevel: 82,
       networkType: 'wifi',
     });
-    expect(admin.__getCollection('deviceEvents')[0].data).toMatchObject({
+    expect(getDeviceEvents(registered.body.deviceId, 'HEARTBEAT')[0].data).toMatchObject({
       type: 'HEARTBEAT',
       deviceId: registered.body.deviceId,
     });
@@ -438,6 +455,16 @@ describe('managed device APIs', () => {
       downloadUrl: 'https://example.test/swiftcause-kiosk.apk',
       checksumSha256: 'abc123',
     });
+    expect(getDeviceEvents(registered.body.deviceId, 'APK_DOWNLOAD_METADATA')).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          payload: expect.objectContaining({
+            apkId: 'apk-1',
+            packageName: 'com.swiftcause.kiosk',
+          }),
+        }),
+      }),
+    ]);
 
     await seedApk('other-apk', { organizationId: 'org-2' });
     const denied = await invokeHandler(
@@ -478,5 +505,171 @@ describe('managed device APIs', () => {
     );
 
     expect(denied.statusCode).toBe(403);
+  });
+
+  it('returns pending device commands for an authenticated device only', async () => {
+    const registered = await registerDevice();
+    await admin
+      .firestore()
+      .collection('deviceCommands')
+      .doc('command-1')
+      .set({
+        organizationId: 'org-1',
+        deviceId: registered.body.deviceId,
+        commandType: 'sync_policy',
+        status: 'pending',
+        queuedAt: { __type: 'timestamp', ms: 1000 },
+      });
+    await admin
+      .firestore()
+      .collection('deviceCommands')
+      .doc('command-2')
+      .set({
+        organizationId: 'org-1',
+        deviceId: registered.body.deviceId,
+        commandType: 'restart_kiosk',
+        status: 'succeeded',
+        queuedAt: { __type: 'timestamp', ms: 2000 },
+      });
+    await admin
+      .firestore()
+      .collection('deviceCommands')
+      .doc('command-3')
+      .set({
+        organizationId: 'org-2',
+        deviceId: registered.body.deviceId,
+        commandType: 'sync_policy',
+        status: 'pending',
+        queuedAt: { __type: 'timestamp', ms: 3000 },
+      });
+
+    const res = await invokeHandler(
+      kioskDeviceCommands,
+      withDeviceSecret(
+        request({ method: 'GET', query: { deviceId: registered.body.deviceId } }),
+        registered.body.deviceSecret,
+      ),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.commands).toEqual([
+      expect.objectContaining({
+        id: 'command-1',
+        commandType: 'sync_policy',
+        status: 'pending',
+      }),
+    ]);
+  });
+
+  it('rejects command pickup without a valid device secret', async () => {
+    const registered = await registerDevice();
+
+    const missing = await invokeHandler(
+      kioskDeviceCommands,
+      request({ method: 'GET', query: { deviceId: registered.body.deviceId } }),
+    );
+    const invalid = await invokeHandler(
+      kioskDeviceCommands,
+      withDeviceSecret(
+        request({ method: 'GET', query: { deviceId: registered.body.deviceId } }),
+        'wrong-secret',
+      ),
+    );
+
+    expect(missing.statusCode).toBe(401);
+    expect(invalid.statusCode).toBe(401);
+  });
+
+  it('records command results and appends a command result event', async () => {
+    const registered = await registerDevice();
+    await admin
+      .firestore()
+      .collection('deviceCommands')
+      .doc('command-1')
+      .set({
+        organizationId: 'org-1',
+        deviceId: registered.body.deviceId,
+        commandType: 'restart_kiosk',
+        status: 'pending',
+        queuedAt: { __type: 'timestamp', ms: 1000 },
+      });
+
+    const res = await invokeHandler(
+      kioskDeviceCommandResult,
+      withDeviceSecret(
+        request({
+          body: {
+            deviceId: registered.body.deviceId,
+            commandId: 'command-1',
+            status: 'succeeded',
+            message: 'Kiosk relaunched',
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(admin.__getDoc('deviceCommands', 'command-1')).toMatchObject({
+      status: 'succeeded',
+      resultMessage: 'Kiosk relaunched',
+    });
+    expect(getDeviceEvents(registered.body.deviceId, 'COMMAND_RESULT')).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          payload: expect.objectContaining({
+            commandId: 'command-1',
+            commandType: 'restart_kiosk',
+            status: 'succeeded',
+          }),
+        }),
+      }),
+    ]);
+  });
+
+  it('rejects command results for commands assigned to another device or organization', async () => {
+    const registered = await registerDevice();
+    await admin.firestore().collection('deviceCommands').doc('other-device-command').set({
+      organizationId: 'org-1',
+      deviceId: 'other-device',
+      commandType: 'sync_policy',
+      status: 'pending',
+    });
+    await admin.firestore().collection('deviceCommands').doc('other-org-command').set({
+      organizationId: 'org-2',
+      deviceId: registered.body.deviceId,
+      commandType: 'sync_policy',
+      status: 'pending',
+    });
+
+    const otherDevice = await invokeHandler(
+      kioskDeviceCommandResult,
+      withDeviceSecret(
+        request({
+          body: {
+            deviceId: registered.body.deviceId,
+            commandId: 'other-device-command',
+            status: 'failed',
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
+    );
+    const otherOrg = await invokeHandler(
+      kioskDeviceCommandResult,
+      withDeviceSecret(
+        request({
+          body: {
+            deviceId: registered.body.deviceId,
+            commandId: 'other-org-command',
+            status: 'failed',
+          },
+        }),
+        registered.body.deviceSecret,
+      ),
+    );
+
+    expect(otherDevice.statusCode).toBe(403);
+    expect(otherOrg.statusCode).toBe(403);
   });
 });

--- a/backend/functions/index.js
+++ b/backend/functions/index.js
@@ -62,6 +62,8 @@ const {
   kioskDeviceStatus,
   kioskDeviceHeartbeat,
   kioskApkDownload,
+  kioskDeviceCommands,
+  kioskDeviceCommandResult,
   adminCreateDeviceProfile,
   adminListManagedDevices,
   adminUpdateManagedDeviceMetadata,
@@ -215,6 +217,8 @@ exports.kioskDevicePolicy = functions.https.onRequest(kioskDevicePolicy);
 exports.kioskDeviceStatus = functions.https.onRequest(kioskDeviceStatus);
 exports.kioskDeviceHeartbeat = functions.https.onRequest(kioskDeviceHeartbeat);
 exports.kioskApkDownload = functions.https.onRequest(kioskApkDownload);
+exports.kioskDeviceCommands = functions.https.onRequest(kioskDeviceCommands);
+exports.kioskDeviceCommandResult = functions.https.onRequest(kioskDeviceCommandResult);
 exports.adminCreateDeviceProfile = functions.https.onRequest(adminCreateDeviceProfile);
 exports.adminListManagedDevices = functions.https.onRequest(adminListManagedDevices);
 exports.adminUpdateManagedDeviceMetadata = functions.https.onRequest(

--- a/docs/DEVICE_EMULATOR_E2E.md
+++ b/docs/DEVICE_EMULATOR_E2E.md
@@ -1,0 +1,149 @@
+# Device Controller Emulator E2E
+
+This runbook validates the local managed-device path inside `SwiftCause_Mono`.
+The detailed validation matrix and last local verification notes live in
+[`DEVICE_MANAGEMENT_TESTING.md`](./DEVICE_MANAGEMENT_TESTING.md).
+
+The flow is:
+
+```text
+Firestore emulator seed
+  -> SwiftCause Device Controller
+  -> Firebase Functions emulator
+  -> kiosk APK download
+  -> PackageInstaller / launch
+  -> status, heartbeat, events, command results
+```
+
+## Build
+
+```bash
+cd android
+./gradlew :device-controller:assembleDebug :test-kiosk:assembleDebug
+```
+
+Controller APK:
+
+```text
+android/device-controller/build/outputs/apk/debug/device-controller-debug.apk
+```
+
+Test kiosk APK:
+
+```text
+android/test-kiosk/build/outputs/apk/debug/test-kiosk-debug.apk
+```
+
+Real SwiftCause app APK:
+
+```text
+android/app/build/outputs/apk/debug/app-debug.apk
+```
+
+## Start Firebase Emulators
+
+In one terminal:
+
+```bash
+cd backend
+firebase emulators:start
+```
+
+The controller uses this emulator-visible functions base URL:
+
+```text
+http://10.0.2.2:5001/swiftcause-app/us-central1
+```
+
+## Seed E2E Data And Serve APK
+
+In another terminal:
+
+```bash
+npm run device:e2e:serve -- --build
+```
+
+This does four things:
+
+- builds the test kiosk APK when `--build` is passed
+- computes the APK SHA-256
+- seeds Firestore emulator documents for kiosk login, campaigns, enrollment, and APK metadata
+- serves the APK at `http://10.0.2.2:3005/swiftcause-test-kiosk.apk`
+
+The seed intentionally does not write an `organizations` document. The local Functions emulator runs Firestore triggers, and creating an organization document can execute production-adjacent organization provisioning side effects.
+
+It writes local state to:
+
+```text
+.e2e/device-e2e-state.json
+```
+
+The seeded kiosk login is:
+
+```text
+kioskId: kiosk-device-e2e
+accessCode: 123456
+```
+
+The seeded campaign data includes `Global Emergency Fund` and `Local Food Relief`.
+
+To ship the real Mono app instead of the small test kiosk APK, run:
+
+```bash
+DEVICE_E2E_KIOSK_APK=/absolute/path/to/SwiftCause_Mono/android/app/build/outputs/apk/debug/app-debug.apk \
+DEVICE_E2E_KIOSK_PACKAGE=com.example.swiftcause \
+DEVICE_E2E_BUILD_MODULE=:app:assembleDebug \
+DEVICE_E2E_APK_FILE_NAME=swiftcause-mobile-debug.apk \
+npm run device:e2e:serve -- --build
+```
+
+## Emulator
+
+Boot a clean emulator, preferably `Medium_Tablet`.
+
+Install the controller:
+
+```bash
+adb install -r android/device-controller/build/outputs/apk/debug/device-controller-debug.apk
+```
+
+If the emulator allows Device Owner setup, run this before opening the controller:
+
+```bash
+adb shell dpm set-device-owner com.swiftcause.devicecontroller/.DeviceAdminReceiver
+```
+
+Launch the E2E activity:
+
+```bash
+adb shell am start \
+  -n com.swiftcause.devicecontroller/.E2eActivity \
+  --es apiBaseUrl http://10.0.2.2:5001/swiftcause-app/us-central1 \
+  --es enrollmentToken enroll-device-e2e
+```
+
+Watch logs:
+
+```bash
+adb logcat -s SwiftCauseE2E
+```
+
+## Expected Result
+
+The E2E is successful when:
+
+- `managedDevices` has a device for `org-device-e2e`
+- the device stores `deviceSecretHash`, not plaintext `deviceSecret`
+- `deviceEvents` includes registration, policy fetch, APK download metadata, status, heartbeat, and command result events
+- the test kiosk package `com.swiftcause.kiosk` installs when Device Owner succeeds
+- the test kiosk launches and displays `SwiftCause Test Kiosk`
+- when using the real app package `com.example.swiftcause`, the app launches in lock task mode and can log in with `kiosk-device-e2e` / `123456`
+- if Device Owner setup fails, the controller reports a clear `install_failed` status instead of silently passing
+
+In development, it can still be possible to exit through ADB, emulator controls, removing Device Owner, or a stale/non-clean provisioning state. A normal Home press should not exit once Device Owner and lock task are active. Verify with:
+
+```bash
+adb shell dumpsys activity activities | grep -i locktask
+```
+
+To test command pickup, queue one safe command from the portal device dialog after the controller has registered, then relaunch the E2E activity. The controller polls pending commands once per E2E run and reports each result.

--- a/docs/DEVICE_MANAGEMENT_TESTING.md
+++ b/docs/DEVICE_MANAGEMENT_TESTING.md
@@ -37,6 +37,8 @@ Expected coverage:
 - server-pinned controller package identity
 - partial status updates preserving existing status fields
 - assigned APK enforcement, including same-org unassigned APK rejection
+- policy package fields resolving from the assigned APK package, including the real app package
+- command result idempotency so completed commands cannot be overwritten by replayed results
 - admin profile, list, metadata update, command queue, command list, and event list access control
 - E2E trace events for registration, policy fetch, APK metadata request, heartbeat, and command
   results

--- a/docs/DEVICE_MANAGEMENT_TESTING.md
+++ b/docs/DEVICE_MANAGEMENT_TESTING.md
@@ -1,0 +1,198 @@
+# Device Management Testing
+
+This document captures the automated and manual validation for the Mono-native device
+management E2E path.
+
+## Scope
+
+The tested flow is:
+
+```text
+Firestore emulator seed
+  -> SwiftCause Device Controller
+  -> Firebase Functions emulator
+  -> APK policy and download metadata
+  -> Android PackageInstaller
+  -> SwiftCause kiosk app launch
+  -> status, heartbeat, events, and command result reporting
+```
+
+The primary app package for the real kiosk run is `com.example.swiftcause`. The controller
+package is `com.swiftcause.devicecontroller`.
+
+## Automated Checks
+
+Run from the repository root unless noted:
+
+```bash
+cd backend/functions
+npm test -- managedDevice
+```
+
+Expected coverage:
+
+- device secret auth for policy, status, heartbeat, APK download, command polling, and command
+  results
+- registration returning plaintext `deviceSecret` only once and storing only `deviceSecretHash`
+- server-pinned controller package identity
+- partial status updates preserving existing status fields
+- assigned APK enforcement, including same-org unassigned APK rejection
+- admin profile, list, metadata update, command queue, command list, and event list access control
+- E2E trace events for registration, policy fetch, APK metadata request, heartbeat, and command
+  results
+
+```bash
+cd android
+./gradlew :app:assembleDebug :device-controller:assembleDebug :test-kiosk:assembleDebug
+```
+
+Expected coverage:
+
+- real SwiftCause app debug APK builds with Firebase emulator configuration
+- device controller debug APK builds
+- local test kiosk debug APK builds
+
+```bash
+cd android
+./gradlew :device-controller:testDebugUnitTest
+```
+
+Expected coverage:
+
+- controller endpoint URL construction
+- status and command mapping helpers
+
+```bash
+npm test -- --run src/entities/device
+npm test -- --run
+npx tsc --noEmit
+npm run build
+```
+
+Expected coverage:
+
+- device entity frontend API tests
+- full Vitest suite
+- TypeScript type checking
+- production Next.js build
+
+```bash
+git diff --check
+```
+
+Expected coverage:
+
+- no trailing whitespace or patch formatting issues
+
+## Local Firebase Seed
+
+Start Firebase emulators:
+
+```bash
+cd backend
+firebase emulators:start
+```
+
+Serve the real SwiftCause app as the kiosk APK:
+
+```bash
+DEVICE_E2E_KIOSK_APK=/absolute/path/to/SwiftCause_Mono/android/app/build/outputs/apk/debug/app-debug.apk \
+DEVICE_E2E_KIOSK_PACKAGE=com.example.swiftcause \
+DEVICE_E2E_BUILD_MODULE=:app:assembleDebug \
+DEVICE_E2E_APK_FILE_NAME=swiftcause-mobile-debug.apk \
+npm run device:e2e:serve -- --build
+```
+
+The seed writes `.e2e/device-e2e-state.json` and creates emulator-only kiosk/campaign/device
+records. It intentionally does not create an `organizations` document because the emulator runs
+Firestore triggers and organization creation can execute provisioning side effects.
+
+Seeded kiosk login:
+
+```text
+kioskId: kiosk-device-e2e
+accessCode: 123456
+```
+
+Seeded campaigns:
+
+- `Global Emergency Fund`
+- `Local Food Relief`
+
+## Manual Emulator Acceptance
+
+Use a clean `Medium_Tablet` emulator when possible.
+
+Build and install the controller:
+
+```bash
+cd android
+./gradlew :device-controller:assembleDebug
+adb install -r device-controller/build/outputs/apk/debug/device-controller-debug.apk
+```
+
+Set Device Owner before launching the controller:
+
+```bash
+adb shell dpm set-device-owner com.swiftcause.devicecontroller/.DeviceAdminReceiver
+```
+
+Launch the E2E controller flow:
+
+```bash
+adb shell am start \
+  -n com.swiftcause.devicecontroller/.E2eActivity \
+  --es apiBaseUrl http://10.0.2.2:5001/swiftcause-app/us-central1 \
+  --es enrollmentToken enroll-device-e2e
+```
+
+Verify:
+
+- `managedDevices` contains the registered device for `org-device-e2e`
+- the device stores `deviceSecretHash`, not plaintext `deviceSecret`
+- `deviceEvents` includes registration, policy fetch, APK metadata request, status, heartbeat,
+  and command result records
+- `com.example.swiftcause` installs and launches when Device Owner succeeds
+- the kiosk app logs in with `kiosk-device-e2e` / `123456`
+- the seeded campaigns render in the app
+- a normal Home press does not exit the kiosk app once lock task is active
+
+Lock task verification:
+
+```bash
+adb shell dumpsys activity activities | grep -i locktask
+```
+
+Expected output includes:
+
+```text
+mLockTaskModeState=LOCKED
+```
+
+Development caveat: ADB, emulator controls, Device Owner removal, or stale emulator state can still
+exit or disrupt kiosk mode. Normal user navigation should not exit when Device Owner and lock task
+are active.
+
+## Last Local Verification
+
+The current PR was locally verified with:
+
+```bash
+cd backend/functions && npm test -- managedDevice
+cd backend/functions && npm test
+cd android && ./gradlew :app:assembleDebug :device-controller:assembleDebug :test-kiosk:assembleDebug
+cd android && ./gradlew :device-controller:testDebugUnitTest
+npm test -- --run src/entities/device
+npm test -- --run
+npx tsc --noEmit
+npm run build
+git diff --check
+```
+
+Manual emulator verification confirmed:
+
+- controller registration succeeded
+- the real SwiftCause app package `com.example.swiftcause` installed and launched
+- local Firebase login succeeded with `kiosk-device-e2e` / `123456`
+- seeded campaigns rendered
+- Android reported lock task mode as `LOCKED` after pressing Home

--- a/docs/MANAGED_DEVICE_APIS.md
+++ b/docs/MANAGED_DEVICE_APIS.md
@@ -61,7 +61,9 @@ The first API slice uses these collections:
 - `managedDevices`: physical Android device records, linked to `organizationId` and
   optional `kioskId`.
 - `kioskApks`: uploaded or assigned kiosk APK metadata.
-- `deviceEvents`: append-only event records for status changes and heartbeats.
+- `deviceCommands`: queued safe remote commands for a registered device.
+- `deviceEvents`: append-only event records for registration, policy fetches, APK download
+  requests, status changes, heartbeats, and command results.
 
 Existing `kiosks` documents remain focused on fundraising configuration. A managed device
 links to a kiosk with `kioskId` when the tablet should run that kiosk.
@@ -182,6 +184,16 @@ Important behavior:
 - appends a `HEARTBEAT` event
 - returns the next heartbeat interval
 
+### `kioskDeviceCommands`
+
+Lists pending safe commands for a registered device. The endpoint requires a valid device
+secret and returns only commands assigned to that device.
+
+### `kioskDeviceCommandResult`
+
+Records the result of a queued device command. The endpoint requires a valid device secret,
+updates only that device's command record, and appends a `COMMAND_RESULT` event.
+
 ### `kioskApkDownload`
 
 Returns APK download metadata for a registered device.
@@ -218,13 +230,9 @@ for:
 - updating placement metadata without allowing protected policy fields
 - queueing only allowlisted remote commands
 
-React admin UI, Android controller wiring, QR provisioning, and Firebase Storage upload/signing
-are intentionally left for follow-up PRs.
+QR provisioning and Firebase Storage upload/signing are intentionally left for follow-up PRs.
 
 ## Next Integration Steps
 
-1. Add admin UI for provisioning profile creation, device listing, kiosk linking, placement
-   metadata, safe commands, and event history.
-2. Wire the Android controller to pick up queued commands and report command results.
-3. Add storage-backed APK download signing for SwiftCause-controlled rollout.
-4. Validate the full emulator path before physical QR/factory-reset provisioning.
+1. Add storage-backed APK download signing for SwiftCause-controlled rollout.
+2. Validate physical QR/factory-reset provisioning after the emulator path is stable.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test:functions": "npm --prefix backend/functions test",
     "test:watch": "vitest",
     "emulator": "cd backend && firebase emulators:start",
+    "device:e2e:seed": "node scripts/device-e2e/seed.js",
+    "device:e2e:serve": "node scripts/device-e2e/seed.js --serve",
     "deploy:functions": "cd backend && firebase deploy --only functions",
     "deploy:rules": "cd backend && firebase deploy --only firestore:rules",
     "deploy:all": "cd backend && firebase deploy",

--- a/scripts/device-e2e/seed.js
+++ b/scripts/device-e2e/seed.js
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+const { createHash } = require('crypto');
+const { createReadStream, existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs');
+const http = require('http');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const admin = require('../../backend/functions/node_modules/firebase-admin');
+
+const root = path.resolve(__dirname, '..', '..');
+const projectId = process.env.FIREBASE_PROJECT_ID || 'swiftcause-app';
+process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8081';
+const firestoreHost = process.env.FIRESTORE_EMULATOR_HOST;
+const apkServerPort = Number(process.env.DEVICE_E2E_APK_PORT || 3005);
+const apkServerHost = process.env.DEVICE_E2E_APK_HOST || '127.0.0.1';
+const emulatorApkHost = process.env.DEVICE_E2E_EMULATOR_APK_HOST || '10.0.2.2';
+const functionsBaseUrl =
+  process.env.DEVICE_E2E_FUNCTIONS_BASE_URL || `http://10.0.2.2:5001/${projectId}/us-central1`;
+const stateDir = path.join(root, '.e2e');
+const statePath = path.join(stateDir, 'device-e2e-state.json');
+const apkPath =
+  process.env.DEVICE_E2E_KIOSK_APK ||
+  path.join(
+    root,
+    'android',
+    'test-kiosk',
+    'build',
+    'outputs',
+    'apk',
+    'debug',
+    'test-kiosk-debug.apk',
+  );
+const apkPackageName = process.env.DEVICE_E2E_KIOSK_PACKAGE || 'com.swiftcause.kiosk';
+const apkServerFileName = process.env.DEVICE_E2E_APK_FILE_NAME || 'swiftcause-test-kiosk.apk';
+const apkVersionCode = Number(process.env.DEVICE_E2E_APK_VERSION_CODE || 1);
+const apkVersionName = process.env.DEVICE_E2E_APK_VERSION_NAME || '1.0.0';
+
+const shouldBuild = process.argv.includes('--build');
+const shouldServe = process.argv.includes('--serve');
+
+const ids = {
+  organizationId: 'org-device-e2e',
+  kioskId: 'kiosk-device-e2e',
+  campaignId: 'campaign-device-e2e',
+  globalCampaignId: 'campaign-device-e2e-global',
+  enrollmentToken: 'enroll-device-e2e',
+  apkId: 'apk-test-kiosk',
+};
+
+if (!admin.apps.length) {
+  admin.initializeApp({ projectId });
+}
+
+const writeDocument = async (collection, id, data) => {
+  await admin.firestore().collection(collection).doc(id).set(data, { merge: true });
+};
+
+const sha256 = (filePath) =>
+  new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    createReadStream(filePath)
+      .on('data', (chunk) => hash.update(chunk))
+      .on('error', reject)
+      .on('end', () => resolve(hash.digest('hex')));
+  });
+
+const buildTestKiosk = () => {
+  const moduleName = process.env.DEVICE_E2E_BUILD_MODULE || ':test-kiosk:assembleDebug';
+  const result = spawnSync('./gradlew', [moduleName], {
+    cwd: path.join(root, 'android'),
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    throw new Error(`Failed to build ${moduleName}`);
+  }
+};
+
+const startApkServer = () => {
+  const server = http.createServer((req, res) => {
+    if (req.url !== `/${apkServerFileName}`) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200, {
+      'Content-Type': 'application/vnd.android.package-archive',
+      'Content-Disposition': `attachment; filename="${apkServerFileName}"`,
+    });
+    createReadStream(apkPath).pipe(res);
+  });
+  server.listen(apkServerPort, apkServerHost, () => {
+    console.log(`APK server: http://${apkServerHost}:${apkServerPort}/${apkServerFileName}`);
+    console.log(
+      `Emulator APK URL: http://${emulatorApkHost}:${apkServerPort}/${apkServerFileName}`,
+    );
+  });
+};
+
+const main = async () => {
+  if (shouldBuild) {
+    buildTestKiosk();
+  }
+  if (!existsSync(apkPath)) {
+    throw new Error(
+      `Kiosk APK not found: ${apkPath}. Run with --build or set DEVICE_E2E_KIOSK_APK to an existing APK.`,
+    );
+  }
+
+  mkdirSync(stateDir, { recursive: true });
+  const apkHash = await sha256(apkPath);
+  const apkDownloadUrl = `http://${emulatorApkHost}:${apkServerPort}/${apkServerFileName}`;
+  const now = new Date();
+
+  await writeDocument('kiosks', ids.kioskId, {
+    organizationId: ids.organizationId,
+    name: 'Device E2E Kiosk',
+    location: 'Local emulator',
+    status: 'online',
+    accessCode: '123456',
+    assignedCampaigns: [ids.campaignId],
+    assignedKioskApkId: ids.apkId,
+    settings: {
+      displayMode: 'grid',
+      showAllCampaigns: false,
+      maxCampaignsDisplay: 6,
+      autoRotateCampaigns: false,
+    },
+    createdAt: now,
+    updatedAt: now,
+  });
+  await writeDocument('campaigns', ids.campaignId, {
+    organizationId: ids.organizationId,
+    title: 'Local Food Relief',
+    description: 'Help provide emergency meals through the local emulator campaign.',
+    longDescription:
+      'This campaign is seeded into the Firebase emulator so the Android kiosk can log in and render real campaign data without touching production.',
+    goal: 5000,
+    raised: 125000,
+    status: 'active',
+    isGlobal: false,
+    assignedKiosks: [ids.kioskId],
+    category: 'Community',
+    currency: 'GBP',
+    organizationInfo: {
+      name: 'SwiftCause Local Test Org',
+      currency: 'GBP',
+    },
+    configuration: {
+      predefinedAmounts: [5, 10, 25, 50],
+      allowCustomAmount: true,
+      minCustomAmount: 1,
+      maxCustomAmount: 1000,
+      enableRecurring: true,
+      recurringIntervals: ['monthly'],
+      showProgressBar: true,
+      showDonorCount: true,
+      primaryCTAText: 'Donate',
+      enableGiftAid: true,
+    },
+    createdAt: now,
+    updatedAt: now,
+  });
+  await writeDocument('campaigns', ids.globalCampaignId, {
+    organizationId: ids.organizationId,
+    title: 'Global Emergency Fund',
+    description: 'A global campaign that should appear for every kiosk in the test organization.',
+    longDescription:
+      'This confirms global campaign lookup from the Android app against the local Firestore emulator.',
+    goal: 10000,
+    raised: 275000,
+    status: 'active',
+    isGlobal: true,
+    assignedKiosks: [],
+    category: 'Emergency',
+    currency: 'GBP',
+    organizationInfo: {
+      name: 'SwiftCause Local Test Org',
+      currency: 'GBP',
+    },
+    configuration: {
+      predefinedAmounts: [10, 25, 50, 100],
+      allowCustomAmount: true,
+      minCustomAmount: 1,
+      maxCustomAmount: 2000,
+      enableRecurring: false,
+      showProgressBar: true,
+      showDonorCount: true,
+      primaryCTAText: 'Donate now',
+    },
+    createdAt: now,
+    updatedAt: now,
+  });
+  await writeDocument('deviceEnrollments', ids.enrollmentToken, {
+    organizationId: ids.organizationId,
+    kioskId: ids.kioskId,
+    label: 'Medium Tablet emulator',
+    status: 'active',
+    createdBy: 'device-e2e-seed',
+    createdAt: now,
+    updatedAt: now,
+  });
+  await writeDocument('kioskApks', ids.apkId, {
+    organizationId: ids.organizationId,
+    packageName: apkPackageName,
+    versionCode: apkVersionCode,
+    versionName: apkVersionName,
+    downloadUrl: apkDownloadUrl,
+    checksumSha256: apkHash,
+    active: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const state = {
+    ...ids,
+    projectId,
+    functionsBaseUrl,
+    firestoreHost,
+    apkPath,
+    apkDownloadUrl,
+    apkSha256: apkHash,
+    controllerPackage: 'com.swiftcause.devicecontroller',
+    controllerActivity: 'com.swiftcause.devicecontroller/.E2eActivity',
+    deviceAdminComponent: 'com.swiftcause.devicecontroller/.DeviceAdminReceiver',
+    kioskPackage: apkPackageName,
+    kioskLogin: {
+      kioskId: ids.kioskId,
+      accessCode: '123456',
+    },
+    seededCampaigns: [ids.globalCampaignId, ids.campaignId],
+    generatedAt: now.toISOString(),
+  };
+  writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`);
+  console.log(`Seeded device E2E data for project ${projectId}`);
+  console.log(`State file: ${statePath}`);
+  console.log(`Enrollment token: ${ids.enrollmentToken}`);
+  console.log(`Kiosk login: ${ids.kioskId} / 123456`);
+  console.log(`Functions base URL: ${functionsBaseUrl}`);
+  console.log(`APK SHA-256: ${apkHash}`);
+
+  if (shouldServe) {
+    startApkServer();
+  } else if (existsSync(statePath)) {
+    const writtenState = JSON.parse(readFileSync(statePath, 'utf8'));
+    console.log(`Run with --serve to keep APK server online: ${writtenState.apkDownloadUrl}`);
+  }
+};
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds the Mono-native Android device controller E2E path for managed kiosk devices.

- adds `android/device-controller` with Device Owner receiver, registration, policy fetch, APK download/install, kiosk launch, heartbeat/status reporting, and safe command result reporting
- adds `android/test-kiosk` as a minimal install target for emulator validation
- extends device-facing Functions with command pickup/result endpoints and E2E trace events
- wires the real SwiftCause Android debug app to local Firebase/Auth/Firestore emulators and local Functions for E2E login testing
- adds a local `scripts/device-e2e/seed.js` harness to seed kiosk/campaign/enrollment/APK metadata and serve an APK to the emulator
- documents the runbook and validation evidence in `docs/DEVICE_EMULATOR_E2E.md` and `docs/DEVICE_MANAGEMENT_TESTING.md`

## Why

The merged admin device-management APIs needed a concrete emulator path proving that a provisioned device can register, receive policy, install/launch the assigned kiosk app, report health, and process queued safe commands. This PR keeps the implementation inside `SwiftCause_Mono` instead of vendoring the Headwind fork, so the controller, backend contract, and real kiosk app can evolve together.

## Testing

Detailed testing notes and manual emulator acceptance criteria are in:

- `docs/DEVICE_MANAGEMENT_TESTING.md`
- `docs/DEVICE_EMULATOR_E2E.md`

Local checks run:

```bash
cd backend/functions && npm test -- managedDevice
cd backend/functions && npm test
cd android && ./gradlew :app:assembleDebug :device-controller:assembleDebug :test-kiosk:assembleDebug :device-controller:testDebugUnitTest
npm test -- --run src/entities/device
npm test -- --run
npx tsc --noEmit
npm run build
git diff --check
```

Manual emulator verification covered:

- controller registration with returned one-time `deviceSecret`
- policy fetch and APK download metadata event creation
- real app package `com.example.swiftcause` install and launch via Device Owner
- local Firebase kiosk login using `kiosk-device-e2e` / `123456`
- seeded campaigns rendering in the real app
- lock task mode reporting `LOCKED` after pressing Home

Notes:

- Gradle prints an existing local `sdk.dir` warning, but the Android builds pass.
- Next build prints existing framework/browser-data warnings, but the production build passes.
