### PR TITLE
ci: add Firebase Functions auto-deploy on merge to main

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -1,0 +1,77 @@
+name: Deploy Firebase Functions
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/functions/**'
+      - 'backend/firebase.json'
+      - 'backend/firestore.rules'
+      - 'backend/firestore.indexes.json'
+
+permissions:
+  contents: read
+  id-token: write # required for Workload Identity Federation
+
+jobs:
+  deploy-dev:
+    name: Deploy → swiftcause-app (Testing)
+    runs-on: ubuntu-latest
+    environment: Testing
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: backend/functions/package-lock.json
+
+      - name: Install function dependencies
+        working-directory: backend/functions
+        run: npm ci
+
+      - name: Deploy functions to swiftcause-app
+        working-directory: backend
+        run: npx firebase-tools deploy --only functions --project swiftcause-app --non-interactive
+
+  deploy-prod:
+    name: Deploy → swiftcause-prod (Production)
+    runs-on: ubuntu-latest
+    needs: deploy-dev
+    environment: Production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: backend/functions/package-lock.json
+
+      - name: Install function dependencies
+        working-directory: backend/functions
+        run: npm ci
+
+      - name: Deploy functions to swiftcause-prod
+        working-directory: backend
+        run: npx firebase-tools deploy --only functions --project swiftcause-prod --non-interactive


### PR DESCRIPTION
# ci: add Firebase Functions auto-deploy on merge to main
  
## Adds a GitHub Actions workflow that deploys Cloud Functions to both Firebase projects whenever backend code is merged to main.

## What it does:
  - Triggers only on changes to backend/functions/**, firebase.json, Firestore rules, or indexes — silent on frontend-only merges
  - Deploys to swiftcause-app (Testing) first; production deploy is blocked until Testing succeeds 
  - Authenticates via Workload Identity Federation — no long-lived credentials stored as secrets, tokens are short-lived and scoped to this repo only

## New secrets added:
  - WIF_PROVIDER
  - WIF_SERVICE_ACCOUNT

### The GCP-side setup (identity pool, OIDC provider, service account, IAM bindings on both projects) has already been applied.